### PR TITLE
chore: merge main into feat/crm-performance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,12 @@
 # LIFEOS_MCP_HTTP_HOST=127.0.0.1
 # LIFEOS_MCP_HTTP_PORT=8765
 
+# Bearer token required by POST /api/agents/cli-sessions/events — the
+# endpoint scripts/lifeos-agent-hook.sh posts to from every machine so a
+# Claude Code or Codex session anywhere on the tailnet shows up on /agents.
+# Empty disables the endpoint (503). Generate one with: openssl rand -hex 32
+# LIFEOS_AGENT_HOOK_TOKEN=
+
 # =============================================================================
 # AGENT WORKER (external worker that picks up #agent-tagged tasks)
 # =============================================================================
@@ -122,6 +128,9 @@
 
 # How often the worker polls for new #agent tasks (seconds).
 # LIFEOS_AGENT_WORKER_POLL_SECONDS=60
+
+# How often the worker checks Human-queue done_when conditions (seconds).
+# LIFEOS_HUMAN_QUEUE_POLL_SECONDS=300
 
 # Default per-task budget when the task title doesn't specify one. Haiku
 # preflight (Issue C) parses natural-language budget hints from titles like

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 > **Audience:** All AI coding agents (Claude Code, Cursor, Copilot, etc.)
 > **Status:** Complete
-> **Last Updated:** 2026-08-19
+> **Last Updated:** 2026-09-03
 
 LifeOS is a self-hosted personal AI assistant with two halves:
 
@@ -65,8 +65,11 @@ Runs on Linux or macOS. Optionally, a Mac can act as an Apple Data Agent for iMe
 | How is perf traced and monitored? | [specs/technical/observability.md](docs/specs/technical/observability.md) |
 | What does `#agent` do? | [specs/product/agent-worker.md](docs/specs/product/agent-worker.md) |
 | How does the agent worker work internally? | [specs/technical/agent-worker.md](docs/specs/technical/agent-worker.md) |
+| How does the task store work internally (id-addressed writes, notes body, conflict files)? | [specs/technical/task-management.md](docs/specs/technical/task-management.md) |
+| What can I do with tasks (statuses, API, chat)? | [specs/product/task-management.md](docs/specs/product/task-management.md) |
 | How do I set up the agent worker? | [guides/agent-worker-setup.md](docs/guides/agent-worker-setup.md) |
 | How does the doctor self-repair bot work? | [guides/doctor-bot.md](docs/guides/doctor-bot.md) |
+| How do agents hand work to the human? | [guides/human-queue.md](docs/guides/human-queue.md) |
 | How do schedules (triggers + actions) work? | [guides/scheduler.md](docs/guides/scheduler.md) |
 | How do I import Apple Health/Fitness data? | [guides/apple-health.md](docs/guides/apple-health.md) |
 | How do I configure a capture device (e.g. the Pebble Index ring) to feed the journal persona? | [guides/journal-ring-ingest.md](docs/guides/journal-ring-ingest.md) |
@@ -229,7 +232,7 @@ Quick-reference guardrails for all contributors. These complement the Developmen
 | `api/services/perf_trace.py` | Request-level performance tracing (spans, SQLite) |
 | `api/routes/perf.py` | Performance trace query API |
 | `api/services/agent_worker/` | Autonomous worker for `#agent`-tagged tasks (local Gemma or cloud Claude via Managed Agents) |
-| `mcp_server.py` | MCP server — stdio for Claude Code + HTTP transport for Managed Agents (64 tools: 56 from `CURATED_ENDPOINTS` plus 8 `lifeos_agent_*` tools registered separately by `_register_inter_agent_tools()` from `INTER_AGENT_TOOL_SCHEMAS`) |
+| `mcp_server.py` | MCP server — stdio for Claude Code + HTTP transport for Managed Agents (67 tools: 59 from `CURATED_ENDPOINTS` plus 8 `lifeos_agent_*` tools registered separately by `_register_inter_agent_tools()` from `INTER_AGENT_TOOL_SCHEMAS`) |
 | `tests/test_perf_benchmark.py` | Benchmark suite for query performance and quality |
 
 | Script | Purpose |

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ LifeOS includes an external **agent worker** that picks up tasks you've tagged `
 - **Spawns its own teammates.** Agents can spawn child sessions, message them, and yield until they finish — good for fan-out research and parallel pipelines.
 - **Fully audited and restart-safe.** Every tool call, model turn, and cost delta is captured; a crash mid-task rolls back to `#agent` for retry (or resumes a still-running cloud session).
 
-You can also run terminal, filesystem, and code tasks through **Claude Code** or **Codex** — via `/claude` / `/codex` on Telegram, "use claude code" in chat, or the `/chat` model picker (see [Claude Code / Codex orchestration](docs/specs/product/claude-code-orchestration.md)). Watch every running session — local, cloud, and CLI — on the live [`/agents`](docs/specs/product/agent-viz.md) page.
+You can also run terminal, filesystem, and code tasks through **Claude Code** or **Codex** — via `/claude` / `/codex` on Telegram, "use claude code" in chat, or the `/chat` model picker (see [Claude Code / Codex orchestration](docs/specs/product/claude-code-orchestration.md)). Watch every running session — local, cloud, and CLI — on the live [`/agents`](docs/specs/product/agent-viz.md) page, whose primary view is a Kanban board of the work queue with the session graph as a secondary tab.
 
 Set up: [Agent Worker Setup](docs/guides/agent-worker-setup.md). Full reference: [Product](docs/specs/product/agent-worker.md) · [Technical](docs/specs/technical/agent-worker.md).
 

--- a/api/main.py
+++ b/api/main.py
@@ -49,7 +49,7 @@ from fastapi.exceptions import RequestValidationError
 
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
-from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, scheduler, tasks, monarch, investments, jobs, perf, agents, vault, fitness, voice, agent_proxy, hermes_proxy, journal, journal_trends, journal_ingest
+from api.routes import search, ask, calendar, gmail, drive, people, chat, briefings, admin, conversations, memories, imessage, crm, slack, photos, reminders, scheduler, tasks, monarch, investments, jobs, perf, agents, agent_assignment, vault, fitness, voice, agent_proxy, hermes_proxy, journal, journal_trends, journal_ingest
 from api.services.log_redaction import configure_telegram_log_redaction
 from config.settings import settings
 
@@ -315,6 +315,7 @@ app.include_router(investments.router)
 app.include_router(jobs.router)
 app.include_router(perf.router)
 app.include_router(agents.router)
+app.include_router(agent_assignment.router)
 app.include_router(vault.router)
 app.include_router(fitness.router)
 app.include_router(voice.router)

--- a/api/routes/agent_assignment.py
+++ b/api/routes/agent_assignment.py
@@ -1,0 +1,272 @@
+"""New card-assignment endpoints (#851): the model catalog and the
+Assigned-card "open" action.
+
+Kept in its OWN router module rather than appended to `api/routes/agents.py`
+— that file is being extended concurrently (and independently) by the
+Kanban board UI issue with a *different* set of endpoints (`/board`,
+`/board/cards/{id}/lane`, `/accept`, `/pending-questions...`); putting this
+issue's two new paths here means the two branches touch different files and
+merge without conflict. Both routers share the `/api/agents` prefix —
+FastAPI accepts two routers on one prefix as long as the paths differ,
+which they do here.
+"""
+from __future__ import annotations
+
+import logging
+import shlex
+import subprocess
+import threading
+import time
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+from api.services.agent_worker.model_catalog import get_model_catalog
+from api.services.agent_worker.session_store import (
+    CLI_STATUS_ENDED,
+    TERMINAL_STATUSES,
+    SessionStore,
+)
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/agents", tags=["agents"])
+
+# Recognized assignee tags, in the order checked. Mirrors preflight.py's
+# `_apply_tag_overrides` tag set for the CLI-spawning engines — "local" is
+# excluded here because Local Gemma runs headless (no interactive
+# terminal to open).
+_ASSIGNEE_TAGS = ("claude", "codex", "hermes")
+
+# (round 1, finding #6) Serializes the todo/running-session checks and the
+# actual spawn in `open_board_card` — without it, two concurrent requests
+# (a double-click) can both pass the checks before either has spawned,
+# opening two terminals onto the same card. A single process-wide lock is
+# enough: this is a single API process (see module docstring), and the
+# critical section is a few dict/DB reads plus a subprocess spawn, never
+# a network call.
+#
+# The lock alone isn't sufficient by itself, though: neither `task.status`
+# (the vault task doesn't flip to `in_progress` until the spawned CLI
+# registers itself over its OWN lifecycle hook, seconds later — not
+# synchronously within this request) nor `session_store` (nothing here
+# writes to it; that also only happens on registration) changes as a
+# result of a spawn, so a call that lands right after another one's spawn
+# would see the exact same "nothing running yet" state and spawn again —
+# lock-serialized, but still two spawns. `_opening_card_ids` closes that
+# gap: a card_id already claimed by an in-flight-or-completed spawn this
+# process has made stays 409'd regardless of what the vault/session_store
+# say, until an actual registered session (or a failed spawn, which frees
+# the card_id again) supersedes it.
+#
+# (round 2, finding #1) That gap is only ever a few seconds wide — the CLI
+# registers its own lifecycle event shortly after it starts. So the claim
+# doesn't need to live forever: `_opening_card_ids` maps card_id ->
+# `time.monotonic()` at claim time, and the membership check below only
+# honors it while younger than `_OPENING_GRACE_SECONDS`. Once expired, the
+# card is eligible to be claimed again — closing the gap without
+# permanently 409ing a card for the life of the process after a
+# successful open (a fresh claim overwrites the stale timestamp, which is
+# how an expired entry gets dropped — no separate removal pass needed).
+_open_lock = threading.Lock()
+_opening_card_ids: dict[str, float] = {}
+_OPENING_GRACE_SECONDS = 30
+
+_session_store: SessionStore | None = None
+
+
+def _get_session_store() -> SessionStore:
+    global _session_store
+    if _session_store is None:
+        _session_store = SessionStore()
+    return _session_store
+
+
+@router.get("/models")
+async def get_models() -> dict[str, Any]:
+    """Per-engine model catalog for the board's assignment pickers.
+
+    `{engines: {claude: [...], codex: [...], local: [...], hermes: [...]},
+    refreshed_at, stale}` — see `model_catalog.py` for how each engine's
+    list is sourced and cached.
+    """
+    return await get_model_catalog().get()
+
+
+def _card_assignee(tags: list[str]) -> str | None:
+    normalized = {t.strip().lower().lstrip("#") for t in (tags or [])}
+    for candidate in _ASSIGNEE_TAGS:
+        if candidate in normalized:
+            return candidate
+    return None
+
+
+def _has_running_cli_session(card_id: str) -> bool:
+    store = _get_session_store()
+    for cli in store.list_cli_sessions():
+        if cli.task_id == card_id and cli.status != CLI_STATUS_ENDED:
+            return True
+    return False
+
+
+@router.post("/board/cards/{card_id}/open")
+async def open_board_card(card_id: str) -> dict[str, Any]:
+    """Open an Assigned card: spawn the interactive CLI in a terminal with
+    the card's prompt, or deep-link to its Hermes conversation.
+
+    A card is "Assigned" for this endpoint's purposes when its status is
+    still `todo` (the worker hasn't claimed it — `#agent-running` swaps
+    status away from `todo`), it carries a recognized assignee tag
+    (`claude`/`codex`/`hermes`), and no session — worker-dispatched or a
+    prior interactive open — is already running against it. 409 on any of
+    those failing, so the board never opens a second terminal onto the
+    same card.
+
+    `claude`/`codex`: spawns the CLI locally (or over ssh when the card
+    names a registered `host` field) with `LIFEOS_TASK_ID=<card_id>` set —
+    `scripts/lifeos-agent-hook.sh` already forwards that as `task_id` on
+    every lifecycle event it posts (#849), and `POST /cli-sessions/events`
+    now moves the card to `in_progress` the moment that session registers
+    (see `cli_session_event` in `api/routes/agents.py`).
+
+    `hermes`: no terminal to spawn — returns `open_url` pointing at the
+    card's Hermes conversation in `/chat` once one exists (set by
+    `HermesExecutor` on the session row), else 409.
+    """
+    from api.services.task_manager import get_task_manager
+
+    manager = get_task_manager()
+    task = manager.get(card_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail=f"card {card_id} not found")
+
+    assignee = _card_assignee(task.tags)
+    if assignee is None:
+        raise HTTPException(
+            status_code=409,
+            detail="card has no recognized assignee tag (#claude, #codex, or #hermes)",
+        )
+
+    session_store = _get_session_store()
+
+    if assignee == "hermes":
+        session = session_store.get(card_id)
+        if session is None or not session.conversation_id:
+            raise HTTPException(status_code=409, detail="no Hermes conversation yet for this card")
+        return {"open_url": f"/chat?conversation={session.conversation_id}"}
+
+    # (round 1, finding #6) Hold the lock across the checks AND the spawn —
+    # not just the spawn — so a double-click can't have both requests pass
+    # the checks before either has actually spawned anything.
+    with _open_lock:
+        if task.status != "todo":
+            raise HTTPException(
+                status_code=409,
+                detail=f"card is not in Assigned state (status={task.status!r})",
+            )
+        existing = session_store.get(card_id)
+        if existing is not None and existing.status not in TERMINAL_STATUSES:
+            raise HTTPException(status_code=409, detail="card already has a running session")
+        if _has_running_cli_session(card_id):
+            raise HTTPException(status_code=409, detail="card already has a running interactive session")
+        claimed_at = _opening_card_ids.get(card_id)
+        if claimed_at is not None and time.monotonic() - claimed_at < _OPENING_GRACE_SECONDS:
+            raise HTTPException(status_code=409, detail="card open is already in progress")
+        _opening_card_ids[card_id] = time.monotonic()
+        try:
+            return _spawn_interactive_cli(card_id, task, assignee)
+        except Exception:
+            # Spawn failed (bad launcher config, missing binary, ...) — free
+            # the card_id so a retry isn't permanently locked out.
+            _opening_card_ids.pop(card_id, None)
+            raise
+
+
+def _spawn_interactive_cli(card_id: str, task, assignee: str) -> dict[str, Any]:
+    """Launch `claude`/`codex` in a terminal (local, or over ssh for a
+    registered `host` field) seeded with the card's prompt. Reuses the
+    same `cc_resume_cmd`/`codex_resume_cmd` WezTerm launcher templates
+    `/resume` uses — only `{inner_command}` differs (a fresh interactive
+    invocation with `LIFEOS_TASK_ID` set, not a `--resume <id>`)."""
+    from api.routes.agents import _inject_wezterm_pane, _resume_env, api_host_name
+    from api.services.agent_worker.assignment import extract_assignment
+    from api.services.directory_resolver import resolve_working_directory
+    from config.settings import settings
+
+    prompt = (task.description or "").strip()
+    if task.notes:
+        prompt = f"{prompt}\n\n{task.notes}".strip()
+    if not prompt:
+        raise HTTPException(status_code=400, detail="card has no title to seed the session with")
+
+    if assignee == "claude":
+        if not getattr(settings, "cc_resume_enabled", False):
+            raise HTTPException(status_code=400, detail="cc resume disabled — set LIFEOS_CC_RESUME_ENABLED=true")
+        template = (settings.cc_resume_cmd or "").strip()
+        binary = "claude"
+    else:
+        if not getattr(settings, "codex_resume_enabled", False):
+            raise HTTPException(status_code=400, detail="codex resume disabled — set LIFEOS_CODEX_RESUME_ENABLED=true")
+        template = (settings.codex_resume_cmd or "").strip()
+        binary = "codex"
+    if not template:
+        raise HTTPException(status_code=400, detail="no launcher command configured for this engine")
+
+    assignment = extract_assignment(task.fields)
+    host = assignment.host or ""
+    remote_target: str | None = None
+    if host and host != api_host_name():
+        remote_target = settings.agent_hosts.get(host)
+        if not remote_target:
+            raise HTTPException(
+                status_code=409,
+                detail=f"host {host!r} is not configured in LIFEOS_AGENT_HOSTS",
+            )
+
+    cwd = resolve_working_directory(task.description or "")
+    # `env NAME=value cmd...` — sets LIFEOS_TASK_ID for the spawned CLI so
+    # the hook script (already reading it — see this function's docstring)
+    # links the registered session back to this card. Works identically
+    # whether the whole thing runs locally or is later ssh-wrapped, since
+    # `env` runs as part of the command itself either way.
+    inner_command = f"env LIFEOS_TASK_ID={shlex.quote(card_id)} {binary} {shlex.quote(prompt)}"
+    rendered = template.replace("{cwd}", cwd).replace("{inner_command}", inner_command)
+    try:
+        argv = shlex.split(rendered)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"launcher command parse failed: {exc}") from exc
+    if not argv:
+        raise HTTPException(status_code=400, detail="launcher command resolved to an empty argv")
+
+    env = _resume_env()
+    popen_argv = argv
+    popen_cwd: str | None = cwd
+    if remote_target:
+        from api.services.agent_worker.remote_spawn import build_remote_launcher_argv
+        popen_argv = build_remote_launcher_argv(argv, target=remote_target)
+        popen_cwd = None
+    elif "wezterm" in argv[0]:
+        _inject_wezterm_pane(env)
+
+    try:
+        proc = subprocess.Popen(  # noqa: S603 — argv only, no shell=True (explicit shlex.split above)
+            popen_argv,
+            cwd=popen_cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=500, detail=f"launcher binary not found: {exc}") from exc
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"launcher spawn failed: {exc}") from exc
+
+    return {
+        "opened": True,
+        "pid": proc.pid,
+        "host": host or None,
+        "cwd": cwd,
+        "command": argv,
+    }

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -7,17 +7,23 @@ agent worker sessions, plus per-session transcript tailing. See
 from __future__ import annotations
 
 import asyncio
+import hmac
 import json
 import logging
+import socket
 import time
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from api.services.agent_worker.session_store import (
+    CLI_ENGINE_PREFIXES,
+    CLI_SESSION_EVENTS,
     TERMINAL_STATUSES,
+    CliSession,
     Session,
     SessionStore,
 )
@@ -35,6 +41,12 @@ router = APIRouter(prefix="/api/agents", tags=["agents"])
 # directory.
 _session_store: SessionStore | None = None
 _transcript_store: TranscriptStore | None = None
+
+# (#851) Injectable remote-kill runner, forwarded to `teardown_session` for a
+# session whose `host` names a machine other than this API host. None (the
+# default) uses `remote_spawn.kill_remote_process_group`'s real `subprocess.run`
+# over ssh; tests monkeypatch this to a fake that records the argv.
+_remote_kill_runner = None
 
 # Labels are stable once derived from a non-fallback source, so cache to avoid
 # re-deriving on every snapshot tick. Capped to bound memory if the process
@@ -74,6 +86,21 @@ def _get_transcript_store() -> TranscriptStore:
     if _transcript_store is None:
         _transcript_store = TranscriptStore()
     return _transcript_store
+
+
+def api_host_name() -> str:
+    """Short hostname of the machine running this API process (#849).
+
+    Used to label every snapshot row with `host` — worker sessions and
+    local-transcript CLI sessions always ran here, so they get this value
+    directly; remote `cli_sessions` rows carry whatever host their own
+    hook posted. Strips any domain suffix the same way the hook script
+    does, so a row's `host` reads identically whether it came from this
+    function or from a remote hook post. A single function (rather than
+    inlining `socket.gethostname()` at each call site) so tests can
+    monkeypatch one target.
+    """
+    return socket.gethostname().split(".")[0]
 
 
 def _is_error_kind(kind: str) -> bool:
@@ -164,6 +191,9 @@ def _session_to_dict(s: Session, transcript: TranscriptStore) -> dict[str, Any]:
         "session_id": s.session_id,
         "task_id": s.task_id,
         "status": s.status,
+        # Worker sessions only ever run on the machine hosting the API
+        # (#849) — no cross-host worker dispatch exists.
+        "host": api_host_name(),
         "routing": s.routing,
         "parent_session_id": s.parent_session_id,
         "root_session_id": s.root_session_id,
@@ -252,6 +282,69 @@ def _codex_snapshot() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         return [], []
 
 
+def _apply_cli_session_to_dict(sd: dict[str, Any], cli: CliSession) -> None:
+    """Merge an event-driven `cli_sessions` row onto a transcript-derived
+    snapshot dict for the same session (#849). Event status wins over the
+    transcript scan's file-age guess; token/cost fields stay
+    transcript-derived — the hook posts no usage data.
+    """
+    sd["status"] = cli.status
+    sd["status_inferred"] = False
+    sd["host"] = cli.host
+    sd["branch"] = cli.branch
+    sd["prompt_preview"] = cli.prompt_preview
+    if cli.task_id:
+        sd["task_id"] = cli.task_id
+
+
+def _cli_session_to_dict(cli: CliSession) -> dict[str, Any]:
+    """Synthetic snapshot row for a `cli_sessions` row with no matching
+    local transcript — a session running on a different machine (#849).
+    No token or dollar detail (the hook posts none); `status_inferred` is
+    always False because the status here is event-driven by definition.
+    """
+    if cli.engine == "claude_code":
+        from api.services.claude_code import session_ingest as cc
+        model_lbl = cc.model_label(cli.model or "")
+    elif cli.engine == "codex":
+        from api.services.codex import session_ingest as cx
+        model_lbl = cx.model_label(cli.model or "")
+    else:
+        model_lbl = "Claude"
+    return {
+        "session_id": cli.session_id,
+        "task_id": cli.task_id,
+        "status": cli.status,
+        "routing": cli.engine,
+        "parent_session_id": None,
+        "root_session_id": cli.session_id,
+        "spawn_depth": 0,
+        "yield_waiting_for": [],
+        "managed_agent_session_id": None,
+        "started_at": cli.started_at,
+        "last_activity_at": cli.last_event_at,
+        "total_input_tokens": 0,
+        "total_output_tokens": 0,
+        "total_cache_creation_tokens": 0,
+        "total_cache_read_tokens": 0,
+        "total_dollars": 0.0,
+        "total_active_seconds": 0.0,
+        "expected_output": None,
+        "label": cli.session_id,
+        "model_label": model_lbl,
+        "last_event_kind": "",
+        "tool_call_count": 0,
+        "error_count": 0,
+        "source": cli.engine,
+        "status_inferred": False,
+        "project_key": "",
+        "decoded_cwd": cli.cwd or "",
+        "host": cli.host,
+        "branch": cli.branch,
+        "prompt_preview": cli.prompt_preview,
+    }
+
+
 def _build_snapshot() -> dict[str, Any]:
     session_store = _get_session_store()
     transcript_store = _get_transcript_store()
@@ -268,6 +361,22 @@ def _build_snapshot() -> dict[str, Any]:
         if s.parent_session_id
     ]
 
+    # Cross-machine CLI sessions (#849): registered via the hook script's
+    # POST /api/agents/cli-sessions/events, keyed the same way
+    # transcript-derived rows are (cc:<uuid> / cx:<uuid>). Ids that also
+    # have a local transcript merge below (event status wins, tokens stay
+    # transcript-derived); whatever's left after both scans ran had no
+    # local transcript match — those become synthetic remote rows further
+    # down. Popped from this dict as each cc/cx row consumes its match, so
+    # what remains at the end is exactly the unmatched set.
+    try:
+        cli_by_id: dict[str, CliSession] = {
+            c.session_id: c for c in session_store.list_cli_sessions()
+        }
+    except Exception as exc:  # noqa: BLE001 — never break the snapshot on a store error
+        logger.warning("cli_sessions read failed: %s", exc)
+        cli_by_id = {}
+
     cc_sessions, cc_edges = _claude_code_snapshot()
     # CC session dicts come from claude_code/session_ingest.py and don't carry
     # the short_label field — attach it the same way (cached-only, no LLM in
@@ -283,6 +392,11 @@ def _build_snapshot() -> dict[str, Any]:
             ),
         )
         sd["custom_label"] = agent_viz_label_override.get_override(sid)
+        cli = cli_by_id.pop(sid, None)
+        if cli is not None:
+            _apply_cli_session_to_dict(sd, cli)
+        else:
+            sd["host"] = api_host_name()
     session_dicts.extend(cc_sessions)
     edges.extend(cc_edges)
 
@@ -298,8 +412,40 @@ def _build_snapshot() -> dict[str, Any]:
             ),
         )
         sd["custom_label"] = agent_viz_label_override.get_override(sid)
+        cli = cli_by_id.pop(sid, None)
+        if cli is not None:
+            _apply_cli_session_to_dict(sd, cli)
+        else:
+            sd["host"] = api_host_name()
     session_dicts.extend(cx_sessions)
     edges.extend(cx_edges)
+
+    # Whatever's left in cli_by_id had no local transcript — a remote host,
+    # or (rarely) a local hook post that raced ahead of the transcript
+    # scan's cache. Bound to the same recency window the transcript scan
+    # already applies per engine so a stale registration doesn't linger.
+    now = time.time()
+    try:
+        from config.settings import settings
+        cc_cutoff = now - int(getattr(settings, "claude_code_lookback_days", 7)) * 86400
+        cx_cutoff = now - int(getattr(settings, "codex_lookback_days", 7)) * 86400
+    except Exception:  # noqa: BLE001 — degrade to "no cutoff" if settings fail to load
+        cc_cutoff = cx_cutoff = 0.0
+    for cli in cli_by_id.values():
+        cutoff = cc_cutoff if cli.engine == "claude_code" else cx_cutoff
+        if cli.last_event_at < cutoff:
+            continue
+        sd = _cli_session_to_dict(cli)
+        sd.setdefault(
+            "short_label",
+            _short_label_for_snapshot(
+                cli.session_id,
+                sd.get("last_activity_at") or 0.0,
+                sd.get("status") or "",
+            ),
+        )
+        sd["custom_label"] = agent_viz_label_override.get_override(cli.session_id)
+        session_dicts.append(sd)
 
     return {
         "sessions": session_dicts,
@@ -316,6 +462,12 @@ def _model_label_for_routing(routing: str | None) -> str:
         # not an Anthropic model, so it must not fall into the Claude-model-
         # name guessing below.
         return "Remote"
+    from api.services.agent_worker.hermes_session import HERMES_ROUTING
+    if routing == HERMES_ROUTING:
+        # (#850) Hermes sessions used to fall through to the Claude-model-name
+        # guess below and get mislabeled "Claude" — Hermes runs its own
+        # DeepSeek-backed engine, not an Anthropic model.
+        return "Hermes"
     try:
         from config.settings import settings
         m = (settings.agent_managed_model or "").lower()
@@ -510,6 +662,314 @@ async def stream_snapshots() -> StreamingResponse:
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
     )
+
+
+# ---------------------------------------------------------------------------
+# Kanban board (#850) — vault-task-backed view of /agents. Lane derivation
+# lives in api/services/agent_board.py; this section only reads the task,
+# scheduler, and session stores, calls into that pure module for the
+# decision, and performs the write. See docs/specs/technical/agent-viz.md.
+# ---------------------------------------------------------------------------
+
+# Board SSE tick interval. The task watcher's own debounce is 2.0s (see
+# api/services/task_watcher.py); ticking the board every 0.5s on top of that
+# (plus the shared cache's 0.25s TTL, see _BOARD_CACHE_TTL below) keeps
+# "reflects an external vault edit" comfortably under the 3s budget without a
+# heavier cross-thread push mechanism — both TaskManager and SchedulerStore
+# serve from in-memory indexes, so rebuilding the board is cheap. A tick only
+# emits when the board actually changed (compared by a cheap signature), so
+# an idle board doesn't spam the client. See docs/specs/technical/agent-viz.md
+# for the full worst-case arithmetic.
+_BOARD_STREAM_INTERVAL = 0.5
+
+
+def _task_card(task, sessions_by_task: dict[str, list[dict[str, Any]]],
+                open_question_by_task: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    from api.services import agent_board
+
+    candidates = sessions_by_task.get(task.id) or []
+    session = max(candidates, key=lambda s: s.get("last_activity_at") or 0) if candidates else None
+    pq = open_question_by_task.get(task.id)
+    return {
+        "kind": "task",
+        "id": task.id,
+        "title": task.description,
+        "notes": task.notes,
+        "status": task.status,
+        "tags": list(task.tags),
+        "assignee": agent_board.derive_assignee(task.tags),
+        "fields": dict(task.fields),
+        "context": task.context,
+        "updated_at": task.updated_at,
+        "session": session,
+        "pending_question": (
+            {
+                "id": pq["id"],
+                "session_id": pq["session_id"],
+                "question": pq["question"],
+                "asked_at": pq["sent_at"],
+                "bot": pq.get("bot"),
+            }
+            if pq else None
+        ),
+    }
+
+
+def _schedule_card(entry) -> dict[str, Any]:
+    last_run = None
+    if entry.last_triggered_at:
+        last_run = {
+            "at": entry.last_triggered_at,
+            "outcome": entry.last_status or "",
+            "snippet": entry.last_result or "",
+        }
+    return {
+        "kind": "schedule",
+        "id": entry.id,
+        "name": entry.name,
+        "message_content": entry.message_content,
+        "enabled": entry.enabled,
+        "next_fire_at": entry.next_trigger_at,
+        "recurring": entry.schedule_type == "cron",
+        "last_run": last_run,
+    }
+
+
+def _build_board() -> dict[str, Any]:
+    from api.services import agent_board
+    from api.services.task_manager import get_task_manager
+    from api.services.scheduler_store import get_scheduler_store
+
+    task_manager = get_task_manager()
+    scheduler_store = get_scheduler_store()
+    session_store = _get_session_store()
+
+    tasks = task_manager.list_tasks()
+
+    sessions_by_task: dict[str, list[dict[str, Any]]] = {}
+    for sd in _build_snapshot()["sessions"]:
+        tid = sd.get("task_id")
+        if tid:
+            sessions_by_task.setdefault(tid, []).append(sd)
+
+    open_question_by_task: dict[str, dict[str, Any]] = {}
+    for q in session_store.list_open_questions():
+        open_question_by_task[q["task_id"]] = q
+
+    lanes: dict[str, list[dict[str, Any]]] = {lane: [] for lane in agent_board.LANES}
+    for task in tasks:
+        lane = agent_board.derive_lane(task.status, task.tags)
+        lanes[lane].append(_task_card(task, sessions_by_task, open_question_by_task))
+
+    for entry in scheduler_store.list_all():
+        bucket = "scheduled" if agent_board.is_schedule_active(entry.enabled, entry.next_trigger_at) else "done"
+        lanes[bucket].append(_schedule_card(entry))
+
+    return {"lanes": lanes, "generated_at": int(time.time())}
+
+
+# Module-level (built_at, board) cache used ONLY by the stream's own tick —
+# NOT by GET /board (round-2 finding 6). `_build_board` reads every task,
+# every schedule entry, and up to 200 session transcript files — cheap once,
+# but every open board tab's stream connection rebuilding independently on
+# every tick would multiply that cost by the number of open tabs. Sharing
+# one build per short window keeps concurrent stream connections reading
+# identical data without adding this TTL's staleness to a direct GET.
+# TTL is intentionally much shorter than the tick interval — it only exists
+# to de-duplicate simultaneous stream connections within the same instant,
+# not to skip rebuilds between ticks.
+_BOARD_CACHE_TTL = 0.25
+_board_cache: tuple[float, dict[str, Any]] | None = None
+
+
+async def _get_board_cached() -> dict[str, Any]:
+    global _board_cache
+    now = time.monotonic()
+    if _board_cache is not None and now - _board_cache[0] < _BOARD_CACHE_TTL:
+        return _board_cache[1]
+    board = await run_in_threadpool(_build_board)
+    _board_cache = (now, board)
+    return board
+
+
+def _invalidate_board_cache() -> None:
+    """Drop the cached board so the next stream tick rebuilds it immediately
+    instead of possibly serving a pre-write board for up to `_BOARD_CACHE_TTL`
+    more seconds. Called after every board write (lane-move, accept, answer).
+    """
+    global _board_cache
+    _board_cache = None
+
+
+@router.get("/board")
+async def get_board() -> dict[str, Any]:
+    """Full current board view model — see `_build_board`.
+
+    Always built fresh, never served from `_board_cache` — an explicit GET
+    is a direct client request (e.g. the drawer's own `await putTask();
+    await fetchBoard()` after a save) and must reflect the write that just
+    happened, not a cache built before it (round-2 finding 6).
+    """
+    return await run_in_threadpool(_build_board)
+
+
+@router.get("/board/stream")
+async def stream_board() -> StreamingResponse:
+    """SSE stream emitting the board whenever it changes.
+
+    Ticks every `_BOARD_STREAM_INTERVAL` seconds but only sends when the
+    lanes actually differ from the last-sent snapshot, so a page left open
+    doesn't re-render on every tick.
+    """
+
+    async def generate():
+        yield ": ok\n\n"
+        last_signature: str | None = None
+        while True:
+            try:
+                board = await _get_board_cached()
+                signature = json.dumps(board["lanes"], sort_keys=True, default=str)
+                if signature != last_signature:
+                    last_signature = signature
+                    yield f"event: board\ndata: {json.dumps(board, default=str)}\n\n"
+            except Exception as exc:  # noqa: BLE001 — keep the stream alive on errors
+                logger.warning("board stream tick failed: %s", exc)
+                yield f"event: error\ndata: {json.dumps({'error': str(exc)})}\n\n"
+            await asyncio.sleep(_BOARD_STREAM_INTERVAL)
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )
+
+
+class LaneMoveRequest(BaseModel):
+    """Body for PUT /api/agents/board/cards/{id}/lane."""
+    lane: str
+    assignee: str | None = None
+
+
+@router.put("/board/cards/{card_id}/lane")
+async def move_board_card(card_id: str, body: LaneMoveRequest) -> dict[str, Any]:
+    """Move a task card to `lane`, writing the corresponding status/tag at
+    once. See `api.services.agent_board.plan_lane_move` for the rules.
+    """
+    from api.services import agent_board
+    from api.services.task_manager import get_task_manager, TaskConflictError
+
+    task_manager = get_task_manager()
+    task = task_manager.get(card_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="card not found")
+
+    plan = agent_board.plan_lane_move(task.status, task.tags, body.lane, body.assignee)
+    if plan.error is not None:
+        status_code, detail = plan.error
+        raise HTTPException(status_code=status_code, detail=detail)
+
+    write_kwargs: dict[str, Any] = {}
+    if plan.status is not None:
+        write_kwargs["status"] = plan.status
+    if plan.tags is not None:
+        write_kwargs["tags"] = plan.tags
+
+    if write_kwargs:
+        try:
+            task = task_manager.update(card_id, **write_kwargs)
+        except TaskConflictError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        if task is None:
+            raise HTTPException(status_code=404, detail="card not found")
+        _invalidate_board_cache()
+
+    lane = agent_board.derive_lane(task.status, task.tags)
+    return {"id": task.id, "lane": lane, "status": task.status, "tags": list(task.tags)}
+
+
+@router.post("/board/cards/{card_id}/accept")
+async def accept_board_card(card_id: str) -> dict[str, Any]:
+    """Move a Review card to Done by adding the `accepted` tag. Idempotent —
+    calling this on an already-accepted, already-done card is a no-op.
+    """
+    from api.services import agent_board
+    from api.services.task_manager import get_task_manager, TaskConflictError
+
+    task_manager = get_task_manager()
+    task = task_manager.get(card_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="card not found")
+
+    tags_norm = {t.lstrip("#").lower() for t in task.tags}
+    already_accepted = agent_board.ACCEPTED_TAG in tags_norm
+    if agent_board.derive_lane(task.status, task.tags) != "review" and not already_accepted:
+        raise HTTPException(status_code=409, detail="card is not in the Review lane")
+
+    needs_tag = not already_accepted
+    needs_status = task.status != "done"
+    if needs_tag or needs_status:
+        new_tags = list(task.tags) + ([agent_board.ACCEPTED_TAG] if needs_tag else [])
+        try:
+            task = task_manager.update(card_id, status="done", tags=new_tags)
+        except TaskConflictError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        if task is None:
+            raise HTTPException(status_code=404, detail="card not found")
+        _invalidate_board_cache()
+
+    lane = agent_board.derive_lane(task.status, task.tags)
+    return {"id": task.id, "lane": lane, "status": task.status, "tags": list(task.tags)}
+
+
+@router.get("/pending-questions")
+async def list_pending_questions() -> dict[str, Any]:
+    """Unanswered agent questions across all sessions — the board's "waiting
+    on an answer" list. Same rows `worker.py::_process_clarification_answers`
+    will eventually drain, just read before they're answered.
+    """
+    session_store = _get_session_store()
+    rows = session_store.list_open_questions()
+    return {
+        "questions": [
+            {
+                "id": r["id"],
+                "task_id": r["task_id"],
+                "session_id": r["session_id"],
+                "question": r["question"],
+                "asked_at": r["sent_at"],
+                "bot": r.get("bot"),
+            }
+            for r in rows
+        ],
+    }
+
+
+class PendingQuestionAnswerRequest(BaseModel):
+    """Body for POST /api/agents/pending-questions/{id}/answer."""
+    # 4096 mirrors Telegram's message cap — the answer becomes the agent's
+    # next turn via the same path a Telegram reply takes (see the handler).
+    answer: str = Field(..., min_length=1, max_length=4096)
+
+
+@router.post("/pending-questions/{question_id}/answer")
+async def answer_pending_question(question_id: int, body: PendingQuestionAnswerRequest) -> dict[str, Any]:
+    """Answer a pending question from the board drawer.
+
+    Writes the same `answer`/`answered_at` columns a Telegram reply would via
+    `SessionStore.deposit_answer` — `worker.py::_process_clarification_answers`
+    picks the row up and resumes the session on its next tick, unchanged.
+    """
+    answer = (body.answer or "").strip()
+    if not answer:
+        raise HTTPException(status_code=400, detail="answer is required")
+    session_store = _get_session_store()
+    ok = session_store.deposit_answer_by_id(question_id, answer)
+    if not ok:
+        raise HTTPException(status_code=404, detail="question not found, already answered, or timed out")
+    _invalidate_board_cache()
+    return {"ok": True, "id": question_id}
 
 
 # ---------------------------------------------------------------------------
@@ -892,6 +1352,7 @@ async def operator_kill_session(session_id: str, body: KillRequest | None = None
                     transcript_kind=kind,
                     transcript_payload=payload,
                     managed_driver=driver,
+                    remote_kill_runner=_remote_kill_runner,
                 )
                 killed.append(s.session_id)
                 if result.get("managed_failure"):
@@ -925,6 +1386,141 @@ class CCPaneBindRequest(BaseModel):
     session_id: str = Field(..., min_length=1, max_length=128)
     pane_id: int = Field(..., ge=0)
     cwd: str = Field(default="", max_length=4096)
+
+
+class CliSessionEventRequest(BaseModel):
+    """Body for POST /api/agents/cli-sessions/events — posted by
+    `scripts/lifeos-agent-hook.sh` from any machine, on Claude Code /
+    Codex SessionStart, UserPromptSubmit, Stop, and SessionEnd (#849).
+
+    Unlike /cc-pane-bind and /cx-pane-bind, this endpoint is reachable over
+    the tailnet (bearer-token gated, not localhost-only) — it's what lets a
+    session on a laptop or another box register itself with /agents.
+    """
+    engine: str = Field(..., min_length=1, max_length=32)
+    event: str = Field(..., min_length=1, max_length=32)
+    session_id: str = Field(..., min_length=1, max_length=128)
+    host: str = Field(..., min_length=1, max_length=255)
+    cwd: str = Field(default="", max_length=4096)
+    transcript_path: str = Field(default="", max_length=4096)
+    branch: str = Field(default="", max_length=255)
+    model: str = Field(default="", max_length=128)
+    prompt_preview: str = Field(default="", max_length=4096)
+    task_id: str = Field(default="", max_length=128)
+    pane_id: int | None = Field(default=None, ge=0)
+    wezterm_pid: int | None = Field(default=None, ge=0)
+
+
+def _check_agent_hook_auth(request: Request) -> None:
+    """Bearer-token gate for POST /api/agents/cli-sessions/events (#849).
+
+    Mirrors `api/routes/hermes_proxy.py`'s `_check_hermes_inbound_auth`:
+    disabled (503) until an operator sets `LIFEOS_AGENT_HOOK_TOKEN`, since
+    an empty token here would mean "accept unauthenticated session data
+    from the tailnet" rather than "send no auth" (which is what an empty
+    *outbound* token means elsewhere in this codebase).
+    """
+    from config.settings import settings
+
+    expected = settings.agent_hook_token
+    if not expected:
+        raise HTTPException(
+            status_code=503,
+            detail="CLI session registration disabled: set LIFEOS_AGENT_HOOK_TOKEN to enable.",
+        )
+    header = request.headers.get("authorization", "")
+    scheme, _, token = header.partition(" ")
+    token = token.strip()
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(status_code=401, detail="missing bearer token")
+    if not hmac.compare_digest(token, expected):
+        raise HTTPException(status_code=401, detail="invalid bearer token")
+
+
+@router.post("/cli-sessions/events")
+async def cli_session_event(request: Request, body: CliSessionEventRequest) -> dict[str, Any]:
+    """Register one Claude Code / Codex CLI lifecycle event (#849).
+
+    Posted by `scripts/lifeos-agent-hook.sh` on SessionStart,
+    UserPromptSubmit, Stop, and SessionEnd, from any machine. Applies the
+    event to the `cli_sessions` table (see
+    `SessionStore.record_cli_session_event` for the status machine) so
+    `/agents` shows sessions from every machine, not just the one hosting
+    the API.
+
+    When the event carries `pane_id` AND its `host` matches this API's own
+    host AND the request itself arrived from loopback, the pane mapping is
+    also written into `cc_wezterm_store` — the same store `/cc-pane-bind`
+    and `/cx-pane-bind` write to — so Focus keeps working for local
+    sessions registered this way. The loopback check matters because
+    `host` is client-supplied and this endpoint is reachable off-host: a
+    remote, bearer-authenticated caller naming this API's hostname could
+    otherwise redirect Go To for a real local session by supplying an
+    arbitrary `pane_id`. Requests that aren't from loopback (or don't name
+    this host) still record the event and pane id on the `cli_sessions`
+    row — they just don't touch the shared pane store.
+    """
+    _check_agent_hook_auth(request)
+
+    if body.engine not in CLI_ENGINE_PREFIXES:
+        raise HTTPException(status_code=422, detail=f"unknown engine: {body.engine!r}")
+    if body.event not in CLI_SESSION_EVENTS:
+        raise HTTPException(status_code=422, detail=f"unknown event: {body.event!r}")
+
+    store = _get_session_store()
+    cli = store.record_cli_session_event(
+        engine=body.engine,
+        event=body.event,
+        session_id=body.session_id,
+        host=body.host,
+        cwd=body.cwd or None,
+        transcript_path=body.transcript_path or None,
+        branch=body.branch or None,
+        model=body.model or None,
+        prompt=body.prompt_preview or None,
+        task_id=body.task_id or None,
+        pane_id=body.pane_id,
+        wezterm_pid=body.wezterm_pid,
+    )
+
+    client_host = request.client.host if request.client else ""
+    if (
+        body.pane_id is not None
+        and body.host == api_host_name()
+        and client_host in ("127.0.0.1", "::1")
+    ):
+        try:
+            from api.services.cc_wezterm_store import get_default_store
+            get_default_store().upsert(
+                cli.session_id, int(body.pane_id), body.cwd or "",
+                wezterm_pid=body.wezterm_pid or 0,
+            )
+        except Exception as exc:  # noqa: BLE001 — pane mapping is a nice-to-have, never fail the event
+            logger.warning("cc_wezterm_store upsert failed for %s: %s", cli.session_id, exc)
+
+    # (#851) A `session_start` naming a task links this CLI session to its
+    # board card and moves the card to In progress — the interactive
+    # terminal `POST /board/cards/{id}/open` (api/routes/agent_assignment.py)
+    # spawns sets `LIFEOS_TASK_ID`, the hook script already forwards it as
+    # `task_id` on every event (scripts/lifeos-agent-hook.sh), so this is
+    # the one piece #849 didn't need: turning a task_id-bearing session_start
+    # into a lane move. Best-effort — a task lookup/update failure must
+    # never break the registration event itself.
+    if body.event == "session_start" and body.task_id:
+        try:
+            from api.services.task_manager import get_task_manager
+            manager = get_task_manager()
+            task = manager.get(body.task_id)
+            if task is not None and task.status == "todo":
+                manager.update(body.task_id, status="in_progress")
+        except Exception as exc:  # noqa: BLE001 — never fail the registration event
+            logger.warning("task status update for %s failed: %s", body.task_id, exc)
+
+    return {
+        "registered": True,
+        "session_id": cli.session_id,
+        "status": cli.status,
+    }
 
 
 def _copy_to_clipboard(text: str, env: dict[str, str]) -> bool:
@@ -1235,14 +1831,50 @@ def _resume_env() -> dict[str, str]:
     return env
 
 
+def _check_session_host_or_409(session_id: str) -> str | None:
+    """Resolve /focus and /resume's target host for `session_id` (#849, #851).
+
+    Returns `None` when the session ran on THIS API host (or has no
+    `cli_sessions` row at all — never registered via the hook, or
+    registered before this feature existed — which falls through
+    unchanged to the existing local-only resolution: cache / FD-probe).
+    Returns the ssh target string when the session's host is a DIFFERENT,
+    but registered (`settings.agent_hosts`), machine — the caller then
+    runs the launcher over ssh instead of spawning it locally. Raises
+    `HTTPException(409)` when the session's host is neither this API host
+    nor a registered one.
+    """
+    try:
+        store = _get_session_store()
+        cli = store.get_cli_session(session_id)
+    except Exception as exc:  # noqa: BLE001 — never block a local resume/focus on a store error
+        logger.warning("cli_sessions lookup failed for %s: %s", session_id, exc)
+        return None
+    if cli is None or cli.host == api_host_name():
+        return None
+    from config.settings import settings
+    target = settings.agent_hosts.get(cli.host)
+    if not target:
+        raise HTTPException(
+            status_code=409,
+            detail=f"session {session_id} is running on host {cli.host!r}, which is "
+                    f"not this API host and not in LIFEOS_AGENT_HOSTS",
+        )
+    return target
+
+
 async def _resume_codex_session(
     session_id: str,
     body: "CCResumeRequest | None",
+    remote_ssh_target: str | None = None,
 ) -> dict[str, Any]:
     """Codex sibling of resume_claude_code_session.
 
     Reuses the same env / wezterm pane injection / clipboard / dock
     machinery; only the lookup, settings, and inner command differ.
+    `remote_ssh_target` (#851): the ssh target to run the launcher on when
+    the session's host isn't this API host, resolved by the caller via
+    `_check_session_host_or_409`.
     """
     import shlex
     import subprocess
@@ -1266,21 +1898,31 @@ async def _resume_codex_session(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    # Widen lookback for resume so older sessions are still resolvable.
-    metas = cx.discover_sessions(
-        sessions_dir=settings.codex_sessions_dir,
-        lookback_days=max(int(settings.codex_lookback_days), 365),
-    )
-    target = next((m for m in metas if m.raw_session_id == bare), None)
-    if target is None:
-        raise HTTPException(status_code=404, detail=f"session {session_id} not found")
-    # Codex stores cwd inside session_meta, populated by parse_session. The
-    # snapshot prepopulates it but on a fresh resume call we may need to
-    # re-parse to recover it (cheap — one jsonl read).
-    if not target.decoded_cwd:
-        target, _ = cx.parse_session(target)
-    if not target.decoded_cwd:
-        raise HTTPException(status_code=404, detail=f"session {session_id} has no cwd")
+    if remote_ssh_target:
+        # (#851) See the identical branch in resume_claude_code_session —
+        # a remote session's rollout file isn't under this API's local
+        # `codex_sessions_dir`; its cwd comes from the `cli_sessions` row.
+        cli = _get_session_store().get_cli_session(session_id)
+        if cli is None or not cli.cwd:
+            raise HTTPException(status_code=404, detail=f"session {session_id} not found or has no cwd")
+        from types import SimpleNamespace
+        target = SimpleNamespace(decoded_cwd=cli.cwd)
+    else:
+        # Widen lookback for resume so older sessions are still resolvable.
+        metas = cx.discover_sessions(
+            sessions_dir=settings.codex_sessions_dir,
+            lookback_days=max(int(settings.codex_lookback_days), 365),
+        )
+        target = next((m for m in metas if m.raw_session_id == bare), None)
+        if target is None:
+            raise HTTPException(status_code=404, detail=f"session {session_id} not found")
+        # Codex stores cwd inside session_meta, populated by parse_session. The
+        # snapshot prepopulates it but on a fresh resume call we may need to
+        # re-parse to recover it (cheap — one jsonl read).
+        if not target.decoded_cwd:
+            target, _ = cx.parse_session(target)
+        if not target.decoded_cwd:
+            raise HTTPException(status_code=404, detail=f"session {session_id} has no cwd")
 
     inner_template = (settings.codex_resume_inner_cmd or "").strip()
     inner_rendered = (
@@ -1308,13 +1950,20 @@ async def _resume_codex_session(
     if body and body.extra_env:
         env.update(body.extra_env)
 
-    if "wezterm" in argv[0]:
+    if "wezterm" in argv[0] and not remote_ssh_target:
         _inject_wezterm_pane(env)
+
+    popen_argv = argv
+    popen_cwd = target.decoded_cwd
+    if remote_ssh_target:
+        from api.services.agent_worker.remote_spawn import build_remote_launcher_argv
+        popen_argv = build_remote_launcher_argv(argv, target=remote_ssh_target)
+        popen_cwd = None
 
     try:
         proc = subprocess.Popen(  # noqa: S603 — argv only, no shell=True
-            argv,
-            cwd=target.decoded_cwd,
+            popen_argv,
+            cwd=popen_cwd,
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -1327,9 +1976,13 @@ async def _resume_codex_session(
 
     clipboard_text = ""
     if inner_rendered:
-        clipboard_text = (
+        local_form = (
             f"cd {shlex.quote(target.decoded_cwd)} && {inner_rendered}"
             if target.decoded_cwd else inner_rendered
+        )
+        clipboard_text = (
+            f"ssh {shlex.quote(remote_ssh_target)} -- {shlex.quote(local_form)}"
+            if remote_ssh_target else local_form
         )
     clipboard_copied = False
     if clipboard_text:
@@ -1338,8 +1991,15 @@ async def _resume_codex_session(
     pane_id: int | None = None
     stdout_bytes = b""
     stderr_bytes = b""
+    # (round 1, finding #7) An ssh round trip routinely exceeds the local
+    # 1.5s budget — use the connect-timeout-derived value on the remote
+    # branch so a remote launcher doesn't spuriously degrade to
+    # `pane_id: None` before the real ssh response even arrives.
+    communicate_timeout = 1.5
+    if remote_ssh_target:
+        communicate_timeout = settings.agent_ssh_connect_timeout + 1.5
     try:
-        stdout_bytes, stderr_bytes = proc.communicate(timeout=1.5)
+        stdout_bytes, stderr_bytes = proc.communicate(timeout=communicate_timeout)
     except subprocess.TimeoutExpired:
         return {
             "spawned": True,
@@ -1364,7 +2024,11 @@ async def _resume_codex_session(
         except ValueError:
             pane_id = None
 
-    if pane_id is not None:
+    # (round 1, finding #10) `wezterm_pid` comes from THIS host's own
+    # `_current_wezterm_pid` — on a remote resume the pane and its wezterm
+    # process live on `remote_ssh_target`, not here, so upserting would
+    # record a host-mismatched pid/pane into the LOCAL store.
+    if pane_id is not None and not remote_ssh_target:
         try:
             from api.services.cc_wezterm_store import get_default_store
             wezterm_pid = _current_wezterm_pid(env.get("XDG_RUNTIME_DIR"))
@@ -1405,13 +2069,30 @@ async def resume_claude_code_session(
     Local-network only — do not expose via Tailscale Funnel or the
     public MCP HTTP transport.
     """
-    import shlex
-    import subprocess
+    if not session_id.startswith("cx:") and not session_id.startswith("cc:"):
+        raise HTTPException(status_code=400, detail="resume is only available for Claude Code or Codex sessions")
+
+    # (#849/#851) A session registered on a different, but REGISTERED
+    # (settings.agent_hosts), host resumes over ssh; an unregistered host
+    # still 409s rather than silently no-op'ing.
+    remote_ssh_target = _check_session_host_or_409(session_id)
 
     if session_id.startswith("cx:"):
-        return await _resume_codex_session(session_id, body)
-    if not session_id.startswith("cc:"):
-        raise HTTPException(status_code=400, detail="resume is only available for Claude Code or Codex sessions")
+        return await _resume_codex_session(session_id, body, remote_ssh_target=remote_ssh_target)
+    return await _resume_claude_code_launcher(session_id, body, remote_ssh_target=remote_ssh_target)
+
+
+async def _resume_claude_code_launcher(
+    session_id: str,
+    body: "CCResumeRequest | None",
+    remote_ssh_target: str | None = None,
+) -> dict[str, Any]:
+    """The `cc:`-prefixed half of `resume_claude_code_session`, factored out
+    (#851) so `/focus`'s remote fallback (no cross-host pane registry — see
+    that function) can reuse it exactly like it already reuses
+    `_resume_codex_session` for `cx:` sessions."""
+    import shlex
+    import subprocess
 
     try:
         from config.settings import settings
@@ -1435,14 +2116,26 @@ async def resume_claude_code_session(
     if ":agent:" in bare:
         bare = bare.split(":agent:", 1)[0]
 
-    # Find the matching jsonl to recover the working directory.
-    metas = cc.discover_sessions(
-        projects_dir=settings.claude_code_projects_dir,
-        lookback_days=max(int(settings.claude_code_lookback_days), 365),  # widen lookback for resume
-    )
-    target = next((m for m in metas if m.raw_session_id == bare), None)
-    if target is None or not target.decoded_cwd:
-        raise HTTPException(status_code=404, detail=f"session {session_id} not found or has no cwd")
+    if remote_ssh_target:
+        # (#851) A remote session's transcript lives on the REMOTE host, not
+        # under this API's local `claude_code_projects_dir` — the local
+        # `discover_sessions` scan below would always 404 it. Its cwd comes
+        # from the `cli_sessions` row instead (populated by the remote
+        # host's own hook script over HTTP, host-agnostic by design — #849).
+        cli = _get_session_store().get_cli_session(session_id)
+        if cli is None or not cli.cwd:
+            raise HTTPException(status_code=404, detail=f"session {session_id} not found or has no cwd")
+        from types import SimpleNamespace
+        target = SimpleNamespace(decoded_cwd=cli.cwd)
+    else:
+        # Find the matching jsonl to recover the working directory.
+        metas = cc.discover_sessions(
+            projects_dir=settings.claude_code_projects_dir,
+            lookback_days=max(int(settings.claude_code_lookback_days), 365),  # widen lookback for resume
+        )
+        target = next((m for m in metas if m.raw_session_id == bare), None)
+        if target is None or not target.decoded_cwd:
+            raise HTTPException(status_code=404, detail=f"session {session_id} not found or has no cwd")
 
     # Render the inner command first so the outer template can substitute
     # `{inner_command}` (wezterm path) AND so we can copy it to the clipboard
@@ -1488,14 +2181,27 @@ async def resume_claude_code_session(
     # no $WEZTERM_PANE and wezterm can't probe focus, so it errors out
     # ("--pane-id was not specified and $WEZTERM_PANE is not set"). Probe
     # `wezterm cli list` for an existing pane and pin its id into the env
-    # — wezterm then spawns into that pane's window.
-    if "wezterm" in argv[0]:
+    # — wezterm then spawns into that pane's window. Only meaningful for a
+    # LOCAL spawn — a remote target's own wezterm window state isn't
+    # something this process's env can probe.
+    if "wezterm" in argv[0] and not remote_ssh_target:
         _inject_wezterm_pane(env)
+
+    popen_argv = argv
+    popen_cwd = target.decoded_cwd
+    if remote_ssh_target:
+        # (#851) The rendered argv already carries `--cwd <remote path>` (or
+        # equivalent) baked in by the template above — that path is on the
+        # REMOTE filesystem, so the LOCAL ssh client must not `cwd=` into
+        # it (it likely doesn't exist locally at all).
+        from api.services.agent_worker.remote_spawn import build_remote_launcher_argv
+        popen_argv = build_remote_launcher_argv(argv, target=remote_ssh_target)
+        popen_cwd = None
 
     try:
         proc = subprocess.Popen(  # noqa: S603 — argv only, no shell=True (explicit shlex.split above)
-            argv,
-            cwd=target.decoded_cwd,
+            popen_argv,
+            cwd=popen_cwd,
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -1514,12 +2220,19 @@ async def resume_claude_code_session(
     # already runs with `--cwd target.decoded_cwd`), but the clipboard
     # is a backup for operator-overridden non-wezterm launchers AND
     # for the case where the wezterm tab opened off-screen and the
-    # operator just wants to run the command somewhere visible.
+    # operator just wants to run the command somewhere visible. For a
+    # remote target (#851), wrap it as a runnable ssh command instead of a
+    # bare `cd && ...` — the local clipboard's contents must be paste-able
+    # into a LOCAL terminal to be useful.
     clipboard_text = ""
     if inner_rendered:
-        clipboard_text = (
+        local_form = (
             f"cd {shlex.quote(target.decoded_cwd)} && {inner_rendered}"
             if target.decoded_cwd else inner_rendered
+        )
+        clipboard_text = (
+            f"ssh {shlex.quote(remote_ssh_target)} -- {shlex.quote(local_form)}"
+            if remote_ssh_target else local_form
         )
     clipboard_copied = False
     if clipboard_text:
@@ -1531,12 +2244,17 @@ async def resume_claude_code_session(
     #   (b) The launcher BECOMES the terminal (rare; not the default) —
     #       communicate() times out, no pane id available, return spawned=True.
     # A 1.5s timeout is plenty for (a) and short enough that the API stays
-    # snappy for (b).
+    # snappy for (b) — LOCALLY. (round 1, finding #7) An ssh round trip
+    # routinely exceeds 1.5s, so the remote branch uses the connect-
+    # timeout-derived value instead, leaving the local value untouched.
     pane_id: int | None = None
     stdout_bytes = b""
     stderr_bytes = b""
+    communicate_timeout = 1.5
+    if remote_ssh_target:
+        communicate_timeout = settings.agent_ssh_connect_timeout + 1.5
     try:
-        stdout_bytes, stderr_bytes = proc.communicate(timeout=1.5)
+        stdout_bytes, stderr_bytes = proc.communicate(timeout=communicate_timeout)
     except subprocess.TimeoutExpired:
         # Long-running launcher — no pane id this turn, but the spawn is
         # in progress; surface what we have.
@@ -1567,7 +2285,9 @@ async def resume_claude_code_session(
         except ValueError:
             pane_id = None
 
-    if pane_id is not None:
+    # (round 1, finding #10) See the codex sibling above — a remote resume's
+    # pane and wezterm process live on `remote_ssh_target`, not here.
+    if pane_id is not None and not remote_ssh_target:
         try:
             from api.services.cc_wezterm_store import get_default_store
             wezterm_pid = _current_wezterm_pid(env.get("XDG_RUNTIME_DIR"))
@@ -1826,6 +2546,10 @@ async def focus_claude_code_session(session_id: str) -> dict[str, Any]:
     if not session_id.startswith("cc:") and not is_cx:
         raise HTTPException(status_code=400, detail="focus is only available for Claude Code or Codex sessions")
 
+    # (#849/#851) A session registered on a different, but REGISTERED host
+    # resumes over ssh; an unregistered host still 409s.
+    remote_ssh_target = _check_session_host_or_409(session_id)
+
     try:
         from config.settings import settings
     except Exception as exc:  # noqa: BLE001
@@ -1839,6 +2563,27 @@ async def focus_claude_code_session(session_id: str) -> dict[str, Any]:
     else:
         if not getattr(settings, "cc_resume_enabled", False):
             raise HTTPException(status_code=400, detail="cc resume disabled — set LIFEOS_CC_RESUME_ENABLED=true")
+
+    if remote_ssh_target:
+        # (#851) There is no cross-host pane registry: the local
+        # `cc_wezterm_store` mapping is only ever written for a session
+        # that ran ON this API host (`cli_session_event`'s upsert guard),
+        # and the FD-probe fallback below reads a local transcript file a
+        # remote session's never has. Rather than invent a remote pane
+        # registry, "focus" a remote session by running the same launcher
+        # `/resume` does (over ssh) — same operator outcome (a terminal
+        # showing the session), degraded from "reuse the existing pane"
+        # to "open a new one", which the local path only reaches anyway
+        # once its own cache/probe both miss.
+        if is_cx:
+            result = await _resume_codex_session(session_id, None, remote_ssh_target=remote_ssh_target)
+        else:
+            result = await _resume_claude_code_launcher(session_id, None, remote_ssh_target=remote_ssh_target)
+        return {
+            "focused": True,
+            "pane_id": result.get("pane_id"),
+            "cwd": result.get("cwd"),
+        }
 
     from api.services.cc_wezterm_store import get_default_store
     from api.services import cc_pane_locate
@@ -1976,6 +2721,54 @@ async def _stream_claude_code_session(session_id: str, backfill: int):
             return
 
 
+async def _stream_codex_session(session_id: str, backfill: int):
+    """Per-session SSE generator for Codex (cx:-prefixed) sessions.
+
+    Mirrors `_stream_claude_code_session` — Codex has no DB status either, so
+    it uses the same idle-close-after-5-minutes heuristic. (#850: previously
+    `/sessions/{id}/stream` only dispatched `cc:` here, so opening a Codex
+    session's panel fell through to the LifeOS transcript store and 400'd.)
+    """
+    from config.settings import settings
+    from api.services.codex import session_ingest as cx
+
+    yield ": ok\n\n"
+    try:
+        events = cx.read_normalized_events(session_id, settings.codex_sessions_dir)
+    except Exception as exc:  # noqa: BLE001
+        yield f"event: error\ndata: {json.dumps({'error': str(exc)})}\n\n"
+        return
+    tail = events[-backfill:] if backfill and len(events) > backfill else events
+    for ev in tail:
+        yield f"event: transcript_event\ndata: {json.dumps(ev)}\n\n"
+
+    line_count = len(events)
+    now0 = time.time()
+    last_new_event_at = now0
+    last_heartbeat_at = now0
+    while True:
+        await asyncio.sleep(1.0)
+        try:
+            events = cx.read_normalized_events(session_id, settings.codex_sessions_dir)
+        except Exception:
+            events = []
+        if len(events) > line_count:
+            for ev in events[line_count:]:
+                yield f"event: transcript_event\ndata: {json.dumps(ev)}\n\n"
+            line_count = len(events)
+            last_new_event_at = time.time()
+            last_heartbeat_at = last_new_event_at
+        elif time.time() - last_heartbeat_at >= 15.0:
+            yield ": heartbeat\n\n"
+            last_heartbeat_at = time.time()
+        if time.time() - last_new_event_at > 300.0:
+            yield (
+                "event: closed\n"
+                f"data: {json.dumps({'session_id': session_id, 'status': 'idle'})}\n\n"
+            )
+            return
+
+
 @router.get("/sessions/{session_id}/stream")
 async def stream_session_transcript(
     session_id: str,
@@ -1984,7 +2777,8 @@ async def stream_session_transcript(
     """Per-session SSE: backfill last N events, then live-tail the JSONL file.
 
     Closes cleanly when the session reaches a terminal status.
-    Dispatches by `cc:` prefix to the Claude Code ingest path.
+    Dispatches by `cc:` prefix to the Claude Code ingest path, `cx:` to the
+    Codex ingest path (#850).
     """
     if session_id.startswith("cc:"):
         if not _claude_code_enabled():
@@ -1996,6 +2790,20 @@ async def stream_session_transcript(
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         return StreamingResponse(
             _stream_claude_code_session(session_id, backfill),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+        )
+
+    if session_id.startswith("cx:"):
+        if not _codex_enabled():
+            raise HTTPException(status_code=404, detail="codex viz disabled")
+        try:
+            from api.services.codex.session_ingest import validate_session_id as cx_validate
+            cx_validate(session_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return StreamingResponse(
+            _stream_codex_session(session_id, backfill),
             media_type="text/event-stream",
             headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
         )

--- a/api/routes/hermes_proxy.py
+++ b/api/routes/hermes_proxy.py
@@ -428,6 +428,30 @@ class _HermesTurnPersister:
         # instead of a locally-created row.
         self._turn = None
 
+    @property
+    def conversation_id(self) -> Optional[str]:
+        """The conversation id observed on this turn, or None if the
+        `conversation_id` event never arrived (or arrived over-length —
+        see `_handle_event`). Read by `HermesExecutor` (#851) after
+        `finalize()` so it can record the same id LifeOS's own store
+        persisted the turn under."""
+        return self._conversation_id
+
+    @property
+    def content_text(self) -> str:
+        """The assistant reply text accumulated from `content` events,
+        joined in arrival order. Read by `HermesExecutor` (#851) as the
+        session's `final_text` — the same text `finalize()` persists to
+        the conversation store, so the two never diverge."""
+        return "".join(self._content_parts)
+
+    @property
+    def done_seen(self) -> bool:
+        """Whether a `done` event was observed before the stream ended —
+        see the class docstring's #611 paragraph. Read by `HermesExecutor`
+        (#851) to tell a normal completion apart from a truncated one."""
+        return self._done_seen
+
     def bind_turn(self, turn) -> None:
         """Hook `_proxy.py`'s detached pump calls once it creates this
         turn's `ChatTurn` — see the class docstring. If a `conversation_id`

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -9,11 +9,28 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from api.services.task_manager import get_task_manager, Task
+from api.services import human_queue
+from api.services.task_manager import get_task_manager, Task, TaskConflictError, VALID_STATUSES
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/tasks", tags=["tasks"])
+
+
+def _require_valid_status(status: Optional[str]) -> None:
+    """Raise 422 for an unrecognized status.
+
+    Deliberately a manual check + HTTPException rather than a pydantic
+    `field_validator` — the app's global `RequestValidationError` handler
+    (api/main.py) converts every pydantic validation failure to 400, and (as
+    a separate, pre-existing bug) can't JSON-serialize a validator's raised
+    exception object at all. Matches the pattern already used for schedules'
+    bot-name validation (api/routes/scheduler.py `_require_known_bot`)."""
+    if status is not None and status not in VALID_STATUSES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid status '{status}'. Must be one of: {', '.join(sorted(VALID_STATUSES))}",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -22,6 +39,14 @@ router = APIRouter(prefix="/api/tasks", tags=["tasks"])
 
 class CreateTaskRequest(BaseModel):
     description: str = Field(..., min_length=1, description="Task description")
+    context: Optional[str] = Field(default=None, description="Context/category; defaults to 'Inbox'.")
+    status: Optional[str] = Field(
+        default=None,
+        description=(
+            "Initial status; defaults to 'todo'. One of: todo, done, in_progress, "
+            "cancelled, deferred, blocked, urgent."
+        ),
+    )
     priority: Optional[str] = Field(default="", description="Priority: high, medium, low, or empty")
     due_date: Optional[str] = Field(default=None, description="Due date (YYYY-MM-DD)")
     tags: Optional[list[str]] = Field(
@@ -35,6 +60,16 @@ class CreateTaskRequest(BaseModel):
                     "precedence slot.",
     )
     reminder_id: Optional[str] = Field(default=None, description="Associated reminder ID")
+    notes: Optional[str] = Field(
+        default=None,
+        description="Multi-line notes body, stored as indented '> ' lines beneath the task line.",
+    )
+    fields: Optional[dict[str, Optional[str]]] = Field(
+        default=None,
+        description="Operator-editable inline fields (e.g. host, effort, model, "
+                    "key) plus any custom [key:: value] field. Round-trips "
+                    "untouched through any later rewrite of the task.",
+    )
     dry_run: Optional[bool] = Field(
         default=False,
         description="When true and the task carries the #agent tag, run the "
@@ -80,6 +115,16 @@ class UpdateTaskRequest(BaseModel):
                     "explicitly named that engine — these tags are operator-"
                     "authority and outrank every routing safeguard.",
     )
+    notes: Optional[str] = Field(
+        default=None,
+        description="Replaces the task's notes body (indented '> ' lines beneath the task line).",
+    )
+    fields: Optional[dict[str, Optional[str]]] = Field(
+        default=None,
+        description="Merged into the task's operator/unknown fields, not replaced: "
+                    "a string value sets that field, a null value removes it. "
+                    "Fields not mentioned are left alone.",
+    )
 
 
 class TaskResponse(BaseModel):
@@ -92,8 +137,11 @@ class TaskResponse(BaseModel):
     created_date: str
     done_date: Optional[str]
     cancelled_date: Optional[str]
+    updated_at: Optional[str]
     tags: list[str]
     reminder_id: Optional[str]
+    notes: Optional[str]
+    fields: dict[str, str]
     source_file: str
     line_number: int
 
@@ -109,8 +157,11 @@ class TaskResponse(BaseModel):
             created_date=t.created_date,
             done_date=t.done_date,
             cancelled_date=t.cancelled_date,
+            updated_at=t.updated_at,
             tags=t.tags,
             reminder_id=t.reminder_id,
+            notes=t.notes,
+            fields=t.fields,
             source_file=t.source_file,
             line_number=t.line_number,
         )
@@ -119,6 +170,15 @@ class TaskResponse(BaseModel):
 class TaskListResponse(BaseModel):
     tasks: list[TaskResponse]
     total: int
+
+
+class ConflictFile(BaseModel):
+    name: str
+    mtime: str
+
+
+class ConflictListResponse(BaseModel):
+    conflicts: list[ConflictFile]
 
 
 # ---------------------------------------------------------------------------
@@ -139,14 +199,25 @@ async def create_task(request: CreateTaskRequest):
     """
     if request.dry_run and _has_agent_tag(request.tags):
         return _build_preflight_preview(request)
+    _require_valid_status(request.status)
     manager = get_task_manager()
-    task = manager.create(
-        description=request.description,
-        priority=request.priority or "",
-        due_date=request.due_date,
-        tags=request.tags,
-        reminder_id=request.reminder_id,
-    )
+    fields = {k: v for k, v in (request.fields or {}).items() if v is not None}
+    try:
+        task = manager.create(
+            description=request.description,
+            context=request.context or "Inbox",
+            status=request.status or "todo",
+            priority=request.priority or "",
+            due_date=request.due_date,
+            tags=request.tags,
+            reminder_id=request.reminder_id,
+            notes=request.notes,
+            fields=fields,
+        )
+    except TaskConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
     return TaskResponse.from_task(task)
 
 
@@ -292,6 +363,119 @@ async def list_tags():
     return TagListResponse(tags=[TagUsage(**t) for t in manager.list_tags()])
 
 
+@router.get("/conflicts", response_model=ConflictListResponse)
+async def list_conflicts():
+    """List Syncthing conflict copies / in-progress temp files sitting in the
+    tasks folder. These are never indexed as tasks and never reindexed —
+    surfaced here so a client (the board) can warn the operator to resolve
+    them by hand in Obsidian/Syncthing.
+
+    Registered before `/{task_id}` so FastAPI doesn't treat "conflicts" as
+    a task id.
+    """
+    manager = get_task_manager()
+    return ConflictListResponse(conflicts=[ConflictFile(**c) for c in manager.list_conflicts()])
+
+
+# ---------------------------------------------------------------------------
+# Human queue (#852) — fire-and-forget cards any agent can file/resolve for
+# the operator. Business logic (dedupe, done_when validation, card shape)
+# lives in api/services/human_queue.py, shared with the native chat tool and
+# the briefing line. Registered before /{task_id} — see the module comment
+# above "Routes (static paths MUST come before {id})".
+# ---------------------------------------------------------------------------
+
+class HumanQueueAddRequest(BaseModel):
+    title: str = Field(..., min_length=1, description="Card title.")
+    notes: Optional[str] = Field(default=None, description="Notes body.")
+    key: Optional[str] = Field(
+        default=None,
+        description="Dedupe key. Filing with an existing OPEN card's key updates "
+                    "its notes instead of creating a duplicate.",
+    )
+    done_when: Optional[dict] = Field(
+        default=None,
+        description="Auto-resolve check: {type: 'endpoint', path, pointer, equals} "
+                    "or {type: 'file_exists', path}.",
+    )
+    source_host: Optional[str] = Field(default=None, description="Filing session's hostname.")
+    source_cwd: Optional[str] = Field(default=None, description="Filing session's working directory.")
+    source_session: Optional[str] = Field(default=None, description="Filing session's id, if any.")
+
+
+class HumanQueueAddResponse(BaseModel):
+    id: str
+
+
+class HumanQueueCard(BaseModel):
+    id: str
+    title: str
+    key: Optional[str] = None
+    notes: Optional[str] = None
+    age_hours: Optional[float] = None
+    source_host: Optional[str] = None
+    source_cwd: Optional[str] = None
+    source_session: Optional[str] = None
+    done_when: Optional[dict] = None
+
+
+class HumanQueueListResponse(BaseModel):
+    cards: list[HumanQueueCard]
+    total: int
+
+
+class HumanQueueResolveRequest(BaseModel):
+    note: Optional[str] = Field(default=None, description="Resolution note, appended to the card's notes.")
+
+
+class HumanQueueResolveResponse(BaseModel):
+    id: str
+    status: str = "done"
+
+
+@router.post("/human-queue", response_model=HumanQueueAddResponse)
+async def add_human_queue_card(request: HumanQueueAddRequest):
+    """File a human-queue card (status blocked, tag human). Filing with an
+    existing open `key` updates that card's notes instead of duplicating it.
+    """
+    try:
+        task = human_queue.add_card(
+            title=request.title,
+            notes=request.notes,
+            key=request.key,
+            done_when=request.done_when,
+            source_host=request.source_host,
+            source_cwd=request.source_cwd,
+            source_session=request.source_session,
+        )
+    except TaskConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except (human_queue.DoneWhenError, ValueError) as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    return HumanQueueAddResponse(id=task.id)
+
+
+@router.get("/human-queue", response_model=HumanQueueListResponse)
+async def list_human_queue_cards():
+    """List open human-queue cards (status blocked, tag human)."""
+    cards = [HumanQueueCard(**c) for c in human_queue.list_open_cards()]
+    return HumanQueueListResponse(cards=cards, total=len(cards))
+
+
+@router.put("/human-queue/{id_or_key}/resolve", response_model=HumanQueueResolveResponse)
+async def resolve_human_queue_card(id_or_key: str, request: HumanQueueResolveRequest):
+    """Mark an open human-queue card done, by task id or dedupe key."""
+    try:
+        task = human_queue.resolve_card(id_or_key, note=request.note)
+    except TaskConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    if task is None:
+        raise HTTPException(status_code=404, detail="Human-queue card not found")
+    return HumanQueueResolveResponse(id=task.id)
+
+
 class SwapTagResponse(BaseModel):
     swapped: bool
     reason: Optional[str] = None
@@ -313,7 +497,10 @@ async def swap_tag(
     manager = get_task_manager()
     if manager.get(task_id) is None:
         return SwapTagResponse(swapped=False, reason="task not found")
-    ok = manager.swap_tag(task_id, from_tag, to_tag)
+    try:
+        ok = manager.swap_tag(task_id, from_tag, to_tag)
+    except TaskConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     return SwapTagResponse(swapped=ok, reason=None if ok else f"tag '{from_tag}' not present")
 
 
@@ -330,9 +517,15 @@ async def get_task(task_id: str):
 @router.put("/{task_id}", response_model=TaskResponse)
 async def update_task(task_id: str, request: UpdateTaskRequest):
     """Update an existing task."""
+    _require_valid_status(request.status)
     manager = get_task_manager()
     updates = {k: v for k, v in request.model_dump().items() if v is not None}
-    task = manager.update(task_id, **updates)
+    try:
+        task = manager.update(task_id, **updates)
+    except TaskConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     return TaskResponse.from_task(task)
@@ -342,7 +535,10 @@ async def update_task(task_id: str, request: UpdateTaskRequest):
 async def complete_task(task_id: str):
     """Mark a task as done (shortcut endpoint)."""
     manager = get_task_manager()
-    task = manager.complete(task_id)
+    try:
+        task = manager.complete(task_id)
+    except TaskConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     return TaskResponse.from_task(task)
@@ -352,7 +548,10 @@ async def complete_task(task_id: str):
 async def delete_task(task_id: str):
     """Delete a task."""
     manager = get_task_manager()
-    deleted = manager.delete(task_id)
+    try:
+        deleted = manager.delete(task_id)
+    except TaskConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     if not deleted:
         raise HTTPException(status_code=404, detail="Task not found")
     return {"status": "deleted", "id": task_id}

--- a/api/services/agent_board.py
+++ b/api/services/agent_board.py
@@ -1,0 +1,236 @@
+"""Kanban board view-model helpers for `/agents` (#850).
+
+Pure functions only — no I/O, no vault or scheduler access — so lane
+derivation and lane-move planning can be unit-tested exhaustively against the
+lane table in issue #850 without a TaskManager or SchedulerStore fixture.
+`api/routes/agents.py` wires these against the real stores and stays thin:
+it reads a task/schedule entry, calls into this module for the *decision*,
+then performs the write. See docs/specs/technical/agent-viz.md.
+
+Lanes are derived from task status + tags on every read — there is no stored
+lane field anywhere in the vault or the task index.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+# Tags the agent worker itself writes as it drives a task through its
+# lifecycle — see AGENT_TAG / RUNNING_TAG / COMPLETED_TAG / BLOCKED_TAG in
+# api/services/agent_worker/worker.py. Mirrored here (not imported) so this
+# module stays import-light — the board treats them as opaque strings, not
+# worker internals.
+AGENT_TAG = "agent"
+RUNNING_TAG = "agent-running"
+COMPLETED_TAG = "agent-completed"
+BLOCKED_TAG = "agent-blocked"
+
+# A `#human` card is filed for the operator directly (not by the worker).
+HUMAN_TAG = "human"
+
+# The accepted marker for Review -> Done (#850) — a tag, not a new status
+# symbol, per the issue's constraints.
+ACCEPTED_TAG = "accepted"
+
+# Assignee is exactly one tag from this set. "me" is the operator; the rest
+# are agent engines. This is a labeling convention only at this stage —
+# actually dispatching to an engine from an assignee tag is issue #851
+# (assignment and execution), out of scope here.
+ASSIGNEE_TAGS: tuple[str, ...] = ("me", "claude", "codex", "hermes", "local")
+AGENT_ASSIGNEES: tuple[str, ...] = ("claude", "codex", "hermes", "local")
+
+LANES: tuple[str, ...] = (
+    "unassigned",
+    "assigned",
+    "in_progress",
+    "human_queue",
+    "scheduled",
+    "review",
+    "done",
+)
+
+# Lanes a task can derive into (excludes "scheduled", which only ever holds
+# scheduler entries).
+TASK_LANES: tuple[str, ...] = tuple(lane for lane in LANES if lane != "scheduled")
+
+
+def _norm_tags(tags: Iterable[str]) -> set[str]:
+    return {str(t).lstrip("#").lower() for t in (tags or [])}
+
+
+def derive_assignee(tags: Iterable[str]) -> Optional[str]:
+    """Return the single assignee tag on `tags`, or None.
+
+    First match (in `ASSIGNEE_TAGS` order) wins if a task somehow carries
+    more than one — the lane-move endpoint always replaces, never adds, an
+    assignee tag, so this should not happen in practice.
+    """
+    tset = _norm_tags(tags)
+    for a in ASSIGNEE_TAGS:
+        if a in tset:
+            return a
+    return None
+
+
+def derive_lane(status: str, tags: Iterable[str]) -> str:
+    """Derive a task's board lane from its status + tags.
+
+    See the lane table in issue #850. Never stored — recomputed on every
+    read from the task's current status/tags.
+
+    Priority (highest first), and why:
+      1. Review — an `agent-completed` tag without `accepted` wins over
+         everything else, INCLUDING a terminal status, so a task the worker
+         marked done still surfaces for the operator's accept/reject instead
+         of silently landing in Done.
+      2. Human queue — an agent question (`agent-blocked`), an operator-filed
+         `#human` card, or a manually-blocked status all mean "needs a human
+         right now"; this must win over In progress / Done so a blocked task
+         is never hidden behind a stale status.
+      3. In progress — status `in_progress`, or the worker's `agent-running`
+         tag.
+      4. Done — status `done` or `cancelled`.
+      5. Assigned — an assignee tag is present but the task isn't yet in any
+         of the working lanes above.
+      6. Unassigned — the default: an open task with no assignee tag.
+    """
+    tset = _norm_tags(tags)
+    status_norm = (status or "todo").lower()
+
+    if COMPLETED_TAG in tset and ACCEPTED_TAG not in tset:
+        return "review"
+    if BLOCKED_TAG in tset or HUMAN_TAG in tset or status_norm == "blocked":
+        return "human_queue"
+    if status_norm == "in_progress" or RUNNING_TAG in tset:
+        return "in_progress"
+    if status_norm in ("done", "cancelled"):
+        return "done"
+    if derive_assignee(tset) is not None:
+        return "assigned"
+    return "unassigned"
+
+
+@dataclass
+class LaneMovePlan:
+    """What a `PUT /board/cards/{id}/lane` request should write, or why not.
+
+    `status` / `tags` are `None` when that field shouldn't change. `error`
+    is `(http_status, detail)` when the move is invalid or forbidden — the
+    caller should raise an `HTTPException` and perform no write.
+    """
+    status: Optional[str] = None
+    tags: Optional[list[str]] = None
+    error: Optional[tuple[int, str]] = None
+
+
+def plan_lane_move(
+    current_status: str,
+    current_tags: Iterable[str],
+    target_lane: str,
+    assignee: Optional[str] = None,
+) -> LaneMovePlan:
+    """Compute the status/tags write for a card dropped into `target_lane`.
+
+    Pure — the caller reads the current task, applies this plan via
+    `TaskManager.update`, and (optionally) re-derives the lane from the
+    written task to confirm it landed where expected. Never touches the
+    vault or scheduler directly.
+    """
+    tags_list = [str(t) for t in (current_tags or [])]
+    tset_lower = {t.lstrip("#").lower() for t in tags_list}
+    current_assignee = derive_assignee(tags_list)
+    # The worker owns this card while it's actively running or waiting on an
+    # answer — dropping it on In progress or Done would desync the tag from
+    # the worker's own claim state (round-2 finding 1: the round-1 strip of
+    # these tags let a card silently detach from a live worker task).
+    worker_owned = bool(tset_lower & {RUNNING_TAG, BLOCKED_TAG})
+    worker_owned_error = (
+        409,
+        "the worker owns this task while it is running or waiting on an "
+        "answer — answer or kill the session first",
+    )
+    # A pending review (agent-completed, not yet accepted) must be accepted
+    # or rejected before it can be reassigned to work or handed to a human —
+    # only Done (the accept path) may act on it directly (round-2 finding 2a).
+    is_review = COMPLETED_TAG in tset_lower and ACCEPTED_TAG not in tset_lower
+    review_error = (409, "accept the review first")
+
+    if target_lane not in LANES:
+        return LaneMovePlan(error=(400, f"unknown lane '{target_lane}'"))
+
+    if target_lane == "unassigned":
+        # Dropping into Unassigned clears the assignee tag.
+        new_tags = [t for t in tags_list if t.lstrip("#").lower() not in ASSIGNEE_TAGS]
+        return LaneMovePlan(tags=new_tags)
+
+    if target_lane == "assigned":
+        assignee_norm = (assignee or "").lstrip("#").lower()
+        if assignee_norm not in ASSIGNEE_TAGS:
+            return LaneMovePlan(error=(
+                400,
+                "assignee is required and must be one of: " + ", ".join(ASSIGNEE_TAGS),
+            ))
+        new_tags = [t for t in tags_list if t.lstrip("#").lower() not in ASSIGNEE_TAGS]
+        new_tags.append(assignee_norm)
+        return LaneMovePlan(tags=new_tags)
+
+    if target_lane == "in_progress":
+        if worker_owned:
+            return LaneMovePlan(error=worker_owned_error)
+        # Only the worker claims agent-assigned tasks (swaps #agent ->
+        # #agent-running itself); a human dragging such a card to In
+        # progress would desync the tag from the actual claim state.
+        if current_assignee in AGENT_ASSIGNEES:
+            return LaneMovePlan(error=(409, "only the worker claims agent-assigned tasks"))
+        if is_review:
+            return LaneMovePlan(error=review_error)
+        # A card can arrive here from Human queue (#human) — strip it so it
+        # actually leaves Human queue instead of derive_lane immediately
+        # pulling it back (Human queue outranks In progress).
+        strip = {HUMAN_TAG}
+        if tset_lower & strip:
+            new_tags = [t for t in tags_list if t.lstrip("#").lower() not in strip]
+            return LaneMovePlan(status="in_progress", tags=new_tags)
+        return LaneMovePlan(status="in_progress")
+
+    if target_lane == "human_queue":
+        if is_review:
+            return LaneMovePlan(error=review_error)
+        return LaneMovePlan(status="blocked")
+
+    if target_lane == "done":
+        if worker_owned:
+            return LaneMovePlan(error=worker_owned_error)
+        # A card can arrive here from Human queue — strip `human` so it
+        # actually leaves that lane (it outranks Done in derive_lane). A
+        # pending agent-completed review also needs the `accepted` tag or
+        # Review would keep claiming it (Review outranks Done too) — this is
+        # the one case dragging to Done still doubles as an accept.
+        strip = {HUMAN_TAG}
+        needs_strip = bool(tset_lower & strip)
+        needs_accept = is_review
+        if needs_strip or needs_accept:
+            new_tags = [t for t in tags_list if t.lstrip("#").lower() not in strip]
+            if needs_accept:
+                new_tags.append(ACCEPTED_TAG)
+            return LaneMovePlan(status="done", tags=new_tags)
+        return LaneMovePlan(status="done")
+
+    # Review and Scheduled are derived — Review from the worker's
+    # agent-completed/accepted tags (use POST .../accept instead), Scheduled
+    # from the scheduler store. Neither is directly settable by dragging a
+    # card there.
+    return LaneMovePlan(error=(400, f"lane '{target_lane}' cannot be set directly"))
+
+
+def is_schedule_active(enabled: bool, next_trigger_at: Optional[str]) -> bool:
+    """True -> Scheduled lane; False -> Done lane.
+
+    A schedule entry is Scheduled while it's enabled and has a future fire.
+    `SchedulerStore` already clears `next_trigger_at` when a recurring entry
+    is disabled and when a one-off fires (see `update()` / trigger recording
+    in `scheduler_store.py`), so `enabled and next_trigger_at is not None` is
+    sufficient — it covers "fired one-off" and "disabled recurring" the same
+    way, matching the issue's rule that both show in Done.
+    """
+    return bool(enabled) and next_trigger_at is not None

--- a/api/services/agent_system_prompt.py
+++ b/api/services/agent_system_prompt.py
@@ -62,6 +62,9 @@ Create, list, or complete Obsidian tasks. When tagging a task and an existing-ta
 **manage_reminders (action: create/list):**
 Create or list timed Telegram notification reminders.
 
+**manage_human_queue (action: add/list/resolve):**
+The Human queue is a shared list of things only {name} can do — an expired login, an approval, a decision the conversation can't finish on its own. 'add' files a card (title, notes on what's needed, an optional dedupe `key`) without blocking the conversation — never file work you could do yourself. 'list' returns open cards; use it for "what's waiting on me" or "what's in my Human queue". 'resolve' marks a card done once you've observed the thing is actually done. See docs/guides/human-queue.md for the full contract.
+
 **search_finances (action: accounts/transactions/cashflow/budgets/investments):**
 Live financial data from Monarch Money. Use 'accounts' for current balances, 'transactions' to search recent spending (filterable by date, category, merchant), 'cashflow' for income/expense/savings summary, 'budgets' for budget vs actual, 'investments' for the full portfolio snapshot (Schwab + Guideline 401(k) + TSP — total value, tax buckets, holdings with cost basis). Prefer 'investments' over 'accounts' for portfolio / net-worth / holdings questions — it is deeper than Monarch's investment balances. Defaults: transactions=last 30 days, cashflow/budgets=current month. Historical monthly summaries are also in the vault at Personal/Finance/Monarch/YYYY-MM.md — use search_vault for past months.
 

--- a/api/services/agent_tools.py
+++ b/api/services/agent_tools.py
@@ -358,9 +358,10 @@ TOOL_DEFINITIONS = [
         "name": "manage_tasks",
         "description": (
             "Manage Obsidian tasks. Actions: 'create' (new task — always lands in "
-            "Inbox; do not pass a context), 'list' (filter tasks; supports the "
-            "context filter for already-categorized tasks), 'complete' (mark task "
-            "done), 'update' (edit any field on an existing task, including tags or "
+            "Inbox; do not pass a context — status/notes/fields are accepted), "
+            "'list' (filter tasks; supports the context filter for already-"
+            "categorized tasks), 'complete' (mark task done), 'update' (edit any "
+            "field on an existing task, including tags, notes, operator fields, or "
             "moving the task to a different context), 'tags' (list every distinct "
             "tag across all tasks with usage counts — the same list is already in "
             "the system prompt; call this action only if the user explicitly asks "
@@ -429,14 +430,69 @@ TOOL_DEFINITIONS = [
                         "'urgent'. Omitting it returns tasks of EVERY status, and in an "
                         "established vault most tasks are done or cancelled — so pass "
                         "'todo' for open/outstanding work rather than listing unfiltered "
-                        "and sorting it out afterwards. Also accepted on update to change "
-                        "status."
+                        "and sorting it out afterwards. Also accepted on create (initial "
+                        "status; defaults to 'todo') and update (to change status)."
                     ),
                 },
                 "query": {
                     "type": "string",
                     "description": "Search within task descriptions (for list).",
                 },
+                "notes": {
+                    "type": "string",
+                    "description": (
+                        "Multi-line notes body for the task (create or update). "
+                        "Stored beneath the task line; replaces the existing body on update."
+                    ),
+                },
+                "fields": {
+                    "type": "object",
+                    "additionalProperties": {"type": ["string", "null"]},
+                    "description": (
+                        "Operator-editable fields (e.g. host, effort, model, key) to set on "
+                        "the task (create or update). On update, a null value removes that "
+                        "field; other fields not mentioned are left alone."
+                    ),
+                },
+            },
+            "required": ["action"],
+        },
+    },
+    {
+        "name": "manage_human_queue",
+        "description": (
+            "File, list, or resolve Human-queue cards — things only the operator "
+            "can do (e.g. re-authenticate an expired login), which the conversation "
+            "itself can't finish. Actions: 'add' (file a card; never file work you "
+            "can do yourself), 'list' (open cards — use for 'what's waiting on "
+            "me'), 'resolve' (mark a card done once you've observed the thing is "
+            "actually done)."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["add", "list", "resolve"],
+                    "description": "Action to perform.",
+                },
+                "title": {"type": "string", "description": "Card title (for add)."},
+                "notes": {"type": "string", "description": "What needs doing and why (for add)."},
+                "key": {
+                    "type": "string",
+                    "description": "Dedupe key (for add). Letters, digits, '.', ':', '-', '_' "
+                                   "only. Filing again with an already-open key updates that "
+                                   "card's notes instead of duplicating it.",
+                },
+                "done_when": {
+                    "type": "object",
+                    "description": "Optional auto-resolve check (for add): "
+                                   "{type: 'endpoint', path, pointer, equals} or "
+                                   "{type: 'file_exists', path}. For 'endpoint', path must "
+                                   "start with '/' (not '//').",
+                },
+                "id_or_key": {"type": "string", "description": "Card id or dedupe key (for resolve)."},
+                "note": {"type": "string", "description": "Resolution note (for resolve)."},
             },
             "required": ["action"],
         },
@@ -900,7 +956,7 @@ async def execute_tool(name: str, tool_input: dict) -> str:
 
 
 # Sync handlers to wrap in to_thread for parallel execution
-_SYNC_HANDLERS = {"search_vault", "read_vault_file", "search_slack", "get_message_history", "person_info", "manage_tasks", "manage_reminders", "manage_schedules", "create_calendar_event", "update_calendar_event", "delete_calendar_event", "search_memories"}
+_SYNC_HANDLERS = {"search_vault", "read_vault_file", "search_slack", "get_message_history", "person_info", "manage_tasks", "manage_human_queue", "manage_reminders", "manage_schedules", "create_calendar_event", "update_calendar_event", "delete_calendar_event", "search_memories"}
 
 
 async def execute_tool_parallel(name: str, tool_input: dict) -> str:
@@ -2133,11 +2189,15 @@ def _tool_person_info(inp: dict):
 def _task_create(inp: dict) -> str:
     from api.services.task_manager import get_task_manager
     tm = get_task_manager()
+    fields = {k: v for k, v in (inp.get("fields") or {}).items() if v is not None}
     task = tm.create(
         description=inp["description"],
+        status=inp.get("status") or "todo",
         priority=inp.get("priority", ""),
         due_date=inp.get("due_date"),
         tags=inp.get("tags"),
+        notes=inp.get("notes"),
+        fields=fields,
     )
     due = f", due {task.due_date}" if task.due_date else ""
     return f"Task created: \"{task.description}\" (id: {task.id}{due})"
@@ -2184,7 +2244,7 @@ def _task_complete(inp: dict) -> str:
     return f"Task completed: \"{task.description}\""
 
 
-_UPDATABLE_FIELDS = ("description", "status", "context", "priority", "due_date", "tags")
+_UPDATABLE_FIELDS = ("description", "status", "context", "priority", "due_date", "tags", "notes", "fields")
 
 
 def _task_update(inp: dict) -> str:
@@ -2195,7 +2255,10 @@ def _task_update(inp: dict) -> str:
     tm = get_task_manager()
     updates = {k: inp[k] for k in _UPDATABLE_FIELDS if k in inp and inp[k] is not None}
     if not updates:
-        return "Error: no updatable fields provided (description, status, context, priority, due_date, tags)."
+        return (
+            "Error: no updatable fields provided (description, status, context, "
+            "priority, due_date, tags, notes, fields)."
+        )
     task = tm.update(task_id, **updates)
     if not task:
         return f"Error: Task '{task_id}' not found."
@@ -2224,6 +2287,61 @@ def _tool_manage_tasks(inp: dict):
     elif action == "tags":
         return _task_tags(inp)
     return f"Error: Unknown manage_tasks action '{action}'"
+
+
+# -- Human queue helpers (#852) --
+
+def _human_queue_add(inp: dict) -> str:
+    from api.services import human_queue
+    title = inp.get("title")
+    if not title:
+        return "Error: 'title' is required for add."
+    try:
+        task = human_queue.add_card(
+            title=title,
+            notes=inp.get("notes"),
+            key=inp.get("key"),
+            done_when=inp.get("done_when"),
+        )
+    except (human_queue.DoneWhenError, ValueError) as e:
+        return f"Error: {e}"
+    return f"Human-queue card filed: \"{task.description}\" (id: {task.id})"
+
+
+def _human_queue_list(_inp: dict) -> str:
+    from api.services import human_queue
+    cards = human_queue.list_open_cards()
+    if not cards:
+        return "No open Human-queue cards."
+    lines = []
+    for c in cards:
+        age = c.get("age_hours")
+        age_str = f"{age:.1f}h old" if age is not None else "age unknown"
+        key = f" key:{c['key']}" if c.get("key") else ""
+        lines.append(f"- {c['title']} ({age_str}) [id:{c['id']}]{key}")
+    return "\n".join(lines)
+
+
+def _human_queue_resolve(inp: dict) -> str:
+    from api.services import human_queue
+    id_or_key = inp.get("id_or_key")
+    if not id_or_key:
+        return "Error: 'id_or_key' is required for resolve."
+    task = human_queue.resolve_card(id_or_key, note=inp.get("note"))
+    if not task:
+        return f"Error: no open Human-queue card matching '{id_or_key}'."
+    return f"Human-queue card resolved: \"{task.description}\" (id: {task.id})"
+
+
+def _tool_manage_human_queue(inp: dict) -> str:
+    action = inp["action"]
+    if action == "add":
+        return _human_queue_add(inp)
+    elif action == "list":
+        return _human_queue_list(inp)
+    elif action == "resolve":
+        return _human_queue_resolve(inp)
+    return f"Error: Unknown manage_human_queue action '{action}'"
 
 
 # -- Reminder helpers --
@@ -3468,6 +3586,7 @@ _TOOL_HANDLERS = {
     "get_message_history": _tool_get_message_history,
     "person_info": _tool_person_info,
     "manage_tasks": _tool_manage_tasks,
+    "manage_human_queue": _tool_manage_human_queue,
     "manage_reminders": _tool_manage_reminders,
     "manage_schedules": _tool_manage_schedules,
     "manage_workouts": _tool_manage_workouts,
@@ -3500,6 +3619,10 @@ TOOL_STATUS_MESSAGES = {
     "manage_tasks.complete": "Completing task...",
     "manage_tasks.update": "Updating task...",
     "manage_tasks.tags": "Loading tag list...",
+    "manage_human_queue": "Managing Human queue...",
+    "manage_human_queue.add": "Filing Human-queue card...",
+    "manage_human_queue.list": "Loading Human queue...",
+    "manage_human_queue.resolve": "Resolving Human-queue card...",
     "manage_reminders": "Managing reminders...",
     "manage_reminders.create": "Setting reminder...",
     "manage_reminders.list": "Loading reminders...",

--- a/api/services/agent_worker/assignment.py
+++ b/api/services/agent_worker/assignment.py
@@ -1,0 +1,129 @@
+"""Card-assignment plumbing shared by the executors and the worker (#851).
+
+The Kanban board assigns a card to an engine (`claude`/`codex`/`local`/
+`hermes` tags), a model, an effort level, and a host — written onto the
+task as `[key:: value]` inline fields (round-tripped verbatim by
+`TaskManager`/`Task.fields`, see docs/specs/technical/task-management.md).
+This module has two small, independent jobs:
+
+1. `extract_assignment()` — pull `model`/`effort`/`host`/`assigned_by` off
+   `task["fields"]` into one typed shape, so `worker.py` doesn't repeat the
+   same four `.get()` calls at every dispatch site.
+2. Per-engine effort mapping — the board's effort vocabulary is exactly
+   `low|medium|high|max`; each engine speaks a different vocabulary (or
+   none at all), so `map_effort_for_engine()` translates once, in one
+   place, instead of scattering the mapping across three executors.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+# The board's own effort vocabulary — the only values a card's `effort`
+# field should ever carry. Anything else is treated as absent (no override)
+# rather than raising, since a stray/legacy value must not crash dispatch.
+BOARD_EFFORT_LEVELS = ("low", "medium", "high", "max")
+
+# Claude Code CLI: `claude --effort <level>` accepts exactly these five
+# (verified via `claude --help` on the operator's host). The board has no
+# "xhigh" tier, so the mapping is 1:1 for the four it does have.
+CLAUDE_CODE_EFFORT_MAP: dict[str, str] = {
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+    "max": "max",
+}
+
+# Codex CLI: `-c model_reasoning_effort=<level>` accepts
+# minimal|low|medium|high|xhigh. The board's "max" maps to Codex's ceiling,
+# "xhigh" — there is no board tier above it to lose.
+CODEX_EFFORT_MAP: dict[str, str] = {
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+    "max": "xhigh",
+}
+
+ENGINE_CLAUDE_CODE = "claude_code"
+ENGINE_CODEX = "codex"
+ENGINE_LOCAL = "local"
+ENGINE_HERMES = "hermes"
+
+_EFFORT_MAPS: dict[str, dict[str, str]] = {
+    ENGINE_CLAUDE_CODE: CLAUDE_CODE_EFFORT_MAP,
+    ENGINE_CODEX: CODEX_EFFORT_MAP,
+}
+
+
+def map_effort_for_engine(engine: str, effort: str | None) -> str | None:
+    """Translate a board effort level to the engine's own flag value.
+
+    Returns `None` when there's nothing to pass: `effort` unset/unrecognized,
+    or `engine` doesn't take an effort flag at all (`local`, `hermes` — see
+    `local_thinking_for_effort()` and the Hermes executor, which handle
+    their own engines' effort semantics separately since neither is a CLI
+    flag).
+    """
+    if not effort:
+        return None
+    mapping = _EFFORT_MAPS.get(engine)
+    if mapping is None:
+        return None
+    return mapping.get(effort)
+
+
+def local_thinking_for_effort(effort: str | None) -> bool | None:
+    """Whether the local Gemma executor should turn thinking on for this
+    session's effort level.
+
+    `high`/`max` → True (thinking on). `low`/`medium` → False (thinking
+    off). Anything else (unset, unrecognized) → `None`, meaning "no
+    per-session override — fall back to `settings.local_agent_enable_thinking`".
+    """
+    if effort in ("high", "max"):
+        return True
+    if effort in ("low", "medium"):
+        return False
+    return None
+
+
+@dataclass(frozen=True)
+class Assignment:
+    """The board-assignment fields extracted from one task, typed and
+    defaulted so every caller reads the same shape."""
+
+    model: str | None = None
+    effort: str | None = None
+    host: str | None = None
+    assigned_by: str | None = None
+
+    @property
+    def is_board_assigned(self) -> bool:
+        return (self.assigned_by or "").strip().lower() == "board"
+
+
+def extract_assignment(fields: dict | None) -> Assignment:
+    """Pull `model`/`effort`/`host`/`assigned_by` off a task's `fields` dict
+    (`Task.fields`, round-tripped `[key:: value]` inline fields — see
+    `docs/specs/technical/task-management.md`). Blank/whitespace-only values
+    normalize to `None` so callers never have to special-case `""`.
+    """
+    fields = fields or {}
+
+    def _clean(key: str) -> str | None:
+        value = fields.get(key)
+        if not isinstance(value, str):
+            return None
+        value = value.strip()
+        return value or None
+
+    effort = _clean("effort")
+    if effort not in BOARD_EFFORT_LEVELS:
+        effort = None
+
+    return Assignment(
+        model=_clean("model"),
+        effort=effort,
+        host=_clean("host"),
+        assigned_by=_clean("assigned_by"),
+    )

--- a/api/services/agent_worker/claude_code_executor.py
+++ b/api/services/agent_worker/claude_code_executor.py
@@ -20,8 +20,19 @@ import time
 from dataclasses import dataclass, field
 from typing import Callable, NamedTuple, Optional
 
+from api.services.agent_worker.assignment import ENGINE_CLAUDE_CODE, map_effort_for_engine
 from api.services.agent_worker.delegation import delegation_preamble
 from api.services.agent_worker.local_executor import ExecutorOutcome
+from api.services.agent_worker.remote_spawn import (
+    HostResolutionError,
+    build_remote_argv,
+    env_names_matching_prefixes,
+    last_nonempty_line,
+    read_line_with_deadline,
+    read_remote_pgid_line,
+    resolve_host_target,
+)
+from api.services.agent_worker.remote_spawn import api_host_name as _api_host_name
 from api.services.agent_worker.session_store import (
     STATUS_BLOCKED,
     STATUS_COMPLETED,
@@ -416,6 +427,7 @@ class ClaudeCodeExecutor:
         session_id: str = "",
         model: str = "opus",
         is_child: bool = False,
+        effort: Optional[str] = None,
     ) -> list[str]:
         platform_desc = (
             "Linux server running Ubuntu"
@@ -451,6 +463,12 @@ class ClaudeCodeExecutor:
         ]
         if resume_session_id:
             cmd.extend(["-r", resume_session_id])
+        # (#851) Board-assigned effort, mapped to the CLI's own vocabulary.
+        # None (no assignment, or an engine that ignores effort) omits the
+        # flag entirely — the CLI keeps its own default.
+        claude_effort = map_effort_for_engine(ENGINE_CLAUDE_CODE, effort)
+        if claude_effort:
+            cmd.extend(["--effort", claude_effort])
         return cmd
 
     @staticmethod
@@ -475,6 +493,14 @@ class ClaudeCodeExecutor:
             k: v for k, v in os.environ.items()
             if not k.startswith(_ALTERNATE_AUTH_ENV_PREFIXES)
         }
+
+    @staticmethod
+    def _remote_unset_env_names() -> list[str]:
+        """(#851) Env var names to `env -u` on a remote-spawned subprocess —
+        mirrors `_clean_env`'s own prefix strip, applied to the remote
+        command instead of the local one (the local ssh client's own env is
+        already cleaned via `_clean_env` at the Popen call site)."""
+        return env_names_matching_prefixes(_ALTERNATE_AUTH_ENV_PREFIXES)
 
     @staticmethod
     def _effective_final_text(state: _RunState) -> str:
@@ -506,14 +532,40 @@ class ClaudeCodeExecutor:
         sid = session.session_id
         cmd = self._build_command(
             prompt, resume_session_id, session_id=sid,
-            model=session.claude_code_model or "opus",
+            # (round 1, finding #1) `session.model` is the board-assignment
+            # field (`SessionStore.set_assignment`, written by
+            # `worker._dispatch`) — it must win over `claude_code_model`,
+            # which only exists for the child-spawn escalation tier
+            # (#349/#578) and was never populated by a board assignment.
+            model=getattr(session, "model", None) or session.claude_code_model or "opus",
             is_child=bool(session.parent_session_id),
+            effort=getattr(session, "effort", None),
         )
+
+        # (#851) Board-assigned host: resolve BEFORE any spawn call. An
+        # unknown host name fails the task closed with no ssh invocation —
+        # never a fallback to local.
+        host = getattr(session, "host", None)
+        is_remote = False
+        try:
+            target = resolve_host_target(host, _api_host_name())
+        except HostResolutionError as exc:
+            self.transcript_store.append(sid, "claude_code_unknown_host", {"host": host})
+            return ExecutorOutcome(status=STATUS_FAILED, reason=str(exc))
+        if target is not None:
+            is_remote = True
+            cmd = build_remote_argv(
+                cmd,
+                target=target,
+                unset_env_names=self._remote_unset_env_names(),
+            )
 
         self.transcript_store.append(sid, "claude_code_spawn", {
             "resume": bool(resume_session_id),
             "plan_mode": plan_mode,
             "working_dir": working_dir,
+            "host": host,
+            "remote": is_remote,
         })
 
         try:
@@ -527,6 +579,9 @@ class ClaudeCodeExecutor:
                 # #379: own session/process-group leader so the operator kill can
                 # `os.killpg(pgid, ...)` the CLI + every child it spawns WITHOUT
                 # touching this worker process (which shares the worker's group).
+                # For a remote spawn this is the local `ssh` client's own group —
+                # harmless (nothing kills it via killpg) since the remote kill
+                # path (#851) reaches the actual CLI process over ssh instead.
                 start_new_session=True,
             )
         except FileNotFoundError as exc:
@@ -541,16 +596,64 @@ class ClaudeCodeExecutor:
         # observer sees the correct status.
         self.session_store.update_status(session.task_id, STATUS_RUNNING)
 
-        # #379: record the subprocess PID + process-group id so the operator
-        # kill endpoint (a separate process) can signal it. `start_new_session`
-        # makes pid==pgid, but resolve the pgid explicitly so the teardown can
-        # `killpg` the whole group. Separate from the `claude_code_spawn` marker
-        # above, which is the #400 crash-guard written *before* the Popen.
-        try:
-            pgid = os.getpgid(proc.pid)
-        except Exception:  # pragma: no cover — defensive; fall back to the pid
-            pgid = proc.pid
-        self.transcript_store.append(sid, "claude_code_pid", {"pid": proc.pid, "pgid": pgid})
+        if is_remote:
+            # (#851) The remote wrapper echoes `PGID:<n>` as its very first
+            # stdout line before the CLI's own output begins — strip it here
+            # rather than in `_consume_stream` (which would just silently
+            # discard it as unparseable JSON) so the pgid is actually
+            # captured for the remote kill path.
+            #
+            # (round 1, finding #3) Bounded wait: this read runs BEFORE the
+            # wall-clock watchdog below even exists, and `ssh -o
+            # ConnectTimeout` bounds only the TCP handshake — a stall during
+            # auth, or a host that accepts the connection but never
+            # answers, would otherwise hang this thread (and the worker's
+            # `_cli_pool`) forever with no watchdog to rescue it.
+            #
+            # (round 2, finding #2) Record the pid event immediately after
+            # Popen — BEFORE this deadline-bounded read, not after — so the
+            # operator-kill fallback (`inter_agent._kill_local_subprocess`)
+            # can reach a stalled local ssh client during the read's own
+            # deadline window instead of finding no pid event and silently
+            # no-op'ing until the wall-clock watchdog eventually fires. A
+            # second event follows with the real pgid once (if) the line
+            # arrives; `_kill_local_subprocess` scans for the LATEST
+            # `claude_code_pid` event, so it picks up the real pgid once
+            # it's recorded and falls back to this one until then.
+            self.transcript_store.append(sid, "claude_code_pid", {
+                "pid": proc.pid, "pgid": None, "remote": True, "host": host,
+            })
+            pgid = None
+            if proc.stdout is not None:
+                deadline = settings.agent_ssh_connect_timeout + 5
+                first_line, timed_out_reading_pgid = read_line_with_deadline(proc.stdout, deadline)
+                if timed_out_reading_pgid:
+                    self._terminate_unresponsive(proc)
+                    self.transcript_store.append(sid, "claude_code_remote_unresponsive", {
+                        "host": host, "deadline_seconds": deadline,
+                    })
+                    self.session_store.update_status(session.task_id, STATUS_FAILED)
+                    return ExecutorOutcome(
+                        status=STATUS_FAILED,
+                        reason=f"host {host} did not answer within {deadline}s",
+                    )
+                pgid = read_remote_pgid_line(first_line)
+            if pgid is not None:
+                self.session_store.set_remote_pgid(session.task_id, pgid)
+                self.transcript_store.append(sid, "claude_code_pid", {
+                    "pid": proc.pid, "pgid": pgid, "remote": True, "host": host,
+                })
+        else:
+            # #379: record the subprocess PID + process-group id so the operator
+            # kill endpoint (a separate process) can signal it. `start_new_session`
+            # makes pid==pgid, but resolve the pgid explicitly so the teardown can
+            # `killpg` the whole group. Separate from the `claude_code_spawn` marker
+            # above, which is the #400 crash-guard written *before* the Popen.
+            try:
+                pgid = os.getpgid(proc.pid)
+            except Exception:  # pragma: no cover — defensive; fall back to the pid
+                pgid = proc.pid
+            self.transcript_store.append(sid, "claude_code_pid", {"pid": proc.pid, "pgid": pgid})
 
         state = _RunState(plan_mode=plan_mode, is_child=bool(session.parent_session_id))
         timed_out = threading.Event()
@@ -678,9 +781,20 @@ class ClaudeCodeExecutor:
             "returncode": proc.returncode,
             "stderr_tail": stderr_tail[-500:],
         })
+        # (round 1, finding #4) On the remote path, fold the ssh failure's
+        # stderr into the reason itself — `worker.py` uses `outcome.reason`
+        # verbatim for the #agent-failed card/notice, so without this an
+        # unreachable-host failure (`Connection refused`, `Permission
+        # denied (publickey)`) only ever surfaced in the transcript's
+        # `stderr_tail`, never where the operator actually looks.
+        reason = f"claude exited with code {proc.returncode}"
+        if is_remote:
+            last_line = last_nonempty_line(stderr_tail)
+            if last_line:
+                reason = f"ssh to {host} failed (exit {proc.returncode}): {last_line}"
         return ExecutorOutcome(
             status=STATUS_FAILED,
-            reason=f"claude exited with code {proc.returncode}",
+            reason=reason,
         )
 
     # ------------------------------------------------------------------
@@ -911,6 +1025,23 @@ class ClaudeCodeExecutor:
         if rc is not None and rc < 0:
             meta["signal"] = -rc
         return meta
+
+    @staticmethod
+    def _terminate_unresponsive(proc) -> None:
+        """Best-effort terminate an ssh client that never answered the
+        `PGID:` read within its deadline (round 1, finding #3). Mirrors
+        `_on_timeout`'s terminate/wait/kill sequence minus the timed_out
+        flag (there is no watchdog running yet at this point — this read
+        happens BEFORE it starts)."""
+        if proc.poll() is None:
+            try:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.warning("remote pgid-wait terminate failed: %s", exc)
 
     @staticmethod
     def _on_timeout(proc, timed_out: threading.Event) -> None:

--- a/api/services/agent_worker/codex_executor.py
+++ b/api/services/agent_worker/codex_executor.py
@@ -31,12 +31,23 @@ import time
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
+from api.services.agent_worker.assignment import ENGINE_CODEX, map_effort_for_engine
 from api.services.agent_worker.capabilities_preamble import CAPABILITIES_PREAMBLE
 from api.services.agent_worker.claude_code_executor import (
     _ALTERNATE_AUTH_ENV_PREFIXES,
 )
 from api.services.agent_worker.delegation import delegation_preamble
 from api.services.agent_worker.local_executor import ExecutorOutcome
+from api.services.agent_worker.remote_spawn import (
+    HostResolutionError,
+    build_remote_argv,
+    env_names_matching_prefixes,
+    last_nonempty_line,
+    read_line_with_deadline,
+    read_remote_pgid_line,
+    resolve_host_target,
+)
+from api.services.agent_worker.remote_spawn import api_host_name as _api_host_name
 from api.services.agent_worker.session_store import (
     STATUS_COMPLETED,
     STATUS_FAILED,
@@ -111,6 +122,10 @@ REASON_BINARY_NOT_FOUND = "binary_not_found"
 # FAILED and signals this subprocess; we exit silently under this reason so the
 # worker skips the spurious "session failed" notice.
 REASON_KILLED = "killed"
+
+# CODEX_* env vars kept when stripping the subprocess env (see `_clean_env`
+# and `_remote_unset_env_names`) — CODEX_HOME carries `~/.codex/auth.json`.
+_CODEX_ENV_KEEP = {"CODEX_HOME"}
 
 
 @dataclass
@@ -231,6 +246,8 @@ class CodexExecutor:
         working_dir: str,
         resume_session_id: Optional[str],
         last_message_file: str,
+        model: Optional[str] = None,
+        effort: Optional[str] = None,
     ) -> list[str]:
         binary = self._binary_resolver()
         # `workspace-write` lets codex edit files inside the working dir
@@ -245,6 +262,16 @@ class CodexExecutor:
             "-C", working_dir,
             "-o", last_message_file,
         ]
+        # (#851) Board-assigned model/effort. Neither flag was previously
+        # passed at all — codex took whatever `~/.codex/config.toml` said.
+        # `--model` only when set (an unset board model keeps that
+        # behavior); effort is mapped to Codex's own
+        # minimal|low|medium|high|xhigh vocabulary via the config override.
+        if model:
+            common = ["--model", model, *common]
+        codex_effort = map_effort_for_engine(ENGINE_CODEX, effort)
+        if codex_effort:
+            common = ["-c", f"model_reasoning_effort={codex_effort}", *common]
         if resume_session_id:
             return [binary, "exec", "resume", resume_session_id, *common, prompt]
         return [binary, "exec", *common, prompt]
@@ -291,12 +318,22 @@ class CodexExecutor:
         Code session, which — like codex itself — is exempt from the per-task
         dollar cap for being subscription-billed.
         """
-        keep = {"CODEX_HOME"}
+        keep = _CODEX_ENV_KEEP
         return {
             k: v for k, v in os.environ.items()
             if (not k.startswith("CODEX_") or k in keep)
             and not k.startswith(_ALTERNATE_AUTH_ENV_PREFIXES)
         }
+
+    @staticmethod
+    def _remote_unset_env_names() -> list[str]:
+        """(#851) Env var names to `env -u` on a remote-spawned subprocess —
+        mirrors `_clean_env`'s own strip (CODEX_* except CODEX_HOME, plus
+        the alternate-auth prefixes), applied to the remote command instead
+        of the local one."""
+        names = env_names_matching_prefixes(("CODEX_",), keep=_CODEX_ENV_KEEP)
+        names += env_names_matching_prefixes(_ALTERNATE_AUTH_ENV_PREFIXES)
+        return sorted(set(names))
 
     def _run(
         self,
@@ -312,11 +349,40 @@ class CodexExecutor:
         last_msg_fd, last_msg_path = tempfile.mkstemp(prefix="codex_last_", suffix=".txt")
         os.close(last_msg_fd)
 
-        cmd = self._build_command(prompt, working_dir, resume_session_id, last_msg_path)
+        cmd = self._build_command(
+            prompt, working_dir, resume_session_id, last_msg_path,
+            model=getattr(session, "model", None),
+            effort=getattr(session, "effort", None),
+        )
+
+        # (#851) Board-assigned host: resolve BEFORE any spawn call. An
+        # unknown host name fails the task closed with no ssh invocation.
+        # NOTE: the `-o last_msg_path` fallback (below) reads a LOCAL temp
+        # file, which a remote CLI never writes to — remote sessions rely
+        # entirely on the `--json` stream's `agent_message` events for
+        # final_text (the normal, primary path); see
+        # docs/specs/technical/agent-worker.md's host registry section.
+        host = getattr(session, "host", None)
+        is_remote = False
+        try:
+            target = resolve_host_target(host, _api_host_name())
+        except HostResolutionError as exc:
+            self.transcript_store.append(sid, "codex_unknown_host", {"host": host})
+            self._cleanup_tempfile(last_msg_path)
+            return ExecutorOutcome(status=STATUS_FAILED, reason=str(exc))
+        if target is not None:
+            is_remote = True
+            cmd = build_remote_argv(
+                cmd,
+                target=target,
+                unset_env_names=self._remote_unset_env_names(),
+            )
 
         self.transcript_store.append(sid, "codex_spawn", {
             "resume": bool(resume_session_id),
             "working_dir": working_dir,
+            "host": host,
+            "remote": is_remote,
         })
 
         try:
@@ -329,7 +395,9 @@ class CodexExecutor:
                 env=self._clean_env(),
                 # #379: own process-group leader so the operator kill can
                 # `os.killpg(pgid, ...)` codex + its children without touching
-                # the worker process. Mirrors ClaudeCodeExecutor.
+                # the worker process. Mirrors ClaudeCodeExecutor. For a remote
+                # spawn this is the local `ssh` client's own group — the
+                # remote kill path (#851) reaches the real CLI over ssh.
                 start_new_session=True,
             )
         except FileNotFoundError as exc:
@@ -339,14 +407,52 @@ class CodexExecutor:
 
         self.session_store.update_status(session.task_id, STATUS_RUNNING)
 
-        # #379: record the subprocess pid + pgid so the operator kill endpoint
-        # (a separate process) can signal it via the transcript. Mirrors the
-        # claude_code path; teardown scans for `codex_pid` too.
-        try:
-            pgid = os.getpgid(proc.pid)
-        except Exception:  # pragma: no cover — defensive; fall back to the pid
-            pgid = proc.pid
-        self.transcript_store.append(sid, "codex_pid", {"pid": proc.pid, "pgid": pgid})
+        if is_remote:
+            # (#851) Strip the remote wrapper's `PGID:<n>` first stdout line
+            # — see ClaudeCodeExecutor._run for the identical mechanism.
+            #
+            # (round 1, finding #3) Bounded wait: see ClaudeCodeExecutor._run
+            # for why this read needs a deadline of its own, ahead of the
+            # wall-clock watchdog below.
+            #
+            # (round 2, finding #2) Record the pid event immediately after
+            # Popen — BEFORE this deadline-bounded read — see
+            # ClaudeCodeExecutor._run for why: it's what lets the operator-
+            # kill fallback reach a stalled local ssh client during the
+            # read's own deadline window rather than finding no pid event.
+            self.transcript_store.append(sid, "codex_pid", {
+                "pid": proc.pid, "pgid": None, "remote": True, "host": host,
+            })
+            pgid = None
+            if proc.stdout is not None:
+                deadline = settings.agent_ssh_connect_timeout + 5
+                first_line, timed_out_reading_pgid = read_line_with_deadline(proc.stdout, deadline)
+                if timed_out_reading_pgid:
+                    self._terminate_unresponsive(proc)
+                    self.transcript_store.append(sid, "codex_remote_unresponsive", {
+                        "host": host, "deadline_seconds": deadline,
+                    })
+                    self.session_store.update_status(session.task_id, STATUS_FAILED)
+                    self._cleanup_tempfile(last_msg_path)
+                    return ExecutorOutcome(
+                        status=STATUS_FAILED,
+                        reason=f"host {host} did not answer within {deadline}s",
+                    )
+                pgid = read_remote_pgid_line(first_line)
+            if pgid is not None:
+                self.session_store.set_remote_pgid(session.task_id, pgid)
+                self.transcript_store.append(sid, "codex_pid", {
+                    "pid": proc.pid, "pgid": pgid, "remote": True, "host": host,
+                })
+        else:
+            # #379: record the subprocess pid + pgid so the operator kill endpoint
+            # (a separate process) can signal it via the transcript. Mirrors the
+            # claude_code path; teardown scans for `codex_pid` too.
+            try:
+                pgid = os.getpgid(proc.pid)
+            except Exception:  # pragma: no cover — defensive; fall back to the pid
+                pgid = proc.pid
+            self.transcript_store.append(sid, "codex_pid", {"pid": proc.pid, "pgid": pgid})
 
         state = _RunState()
         timed_out = threading.Event()
@@ -449,9 +555,16 @@ class CodexExecutor:
             "returncode": proc.returncode,
             "stderr_tail": stderr_tail[-500:],
         })
+        # (round 1, finding #4) Fold the ssh failure's stderr into the
+        # reason on the remote path — see ClaudeCodeExecutor._run for why.
+        reason = f"codex exited with code {proc.returncode}"
+        if is_remote:
+            last_line = last_nonempty_line(stderr_tail)
+            if last_line:
+                reason = f"ssh to {host} failed (exit {proc.returncode}): {last_line}"
         return ExecutorOutcome(
             status=STATUS_FAILED,
-            reason=f"codex exited with code {proc.returncode}",
+            reason=reason,
         )
 
     @staticmethod
@@ -571,6 +684,24 @@ class CodexExecutor:
     # ------------------------------------------------------------------
     # Watchdog + heartbeat
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _terminate_unresponsive(proc) -> None:
+        """Best-effort terminate an ssh client that never answered the
+        `PGID:` read within its deadline (round 1, finding #3). Mirrors
+        `_on_timeout`'s terminate/wait/kill sequence minus the timed_out
+        flag (there is no watchdog running yet at this point — this read
+        happens BEFORE it starts). Mirrors ClaudeCodeExecutor's identical
+        helper."""
+        if proc.poll() is None:
+            try:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.warning("remote pgid-wait terminate failed: %s", exc)
 
     @staticmethod
     def _on_timeout(proc, timed_out: threading.Event) -> None:

--- a/api/services/agent_worker/hermes_executor.py
+++ b/api/services/agent_worker/hermes_executor.py
@@ -1,0 +1,156 @@
+"""Drives one Hermes turn from inside the agent worker (#851).
+
+Mirrors the executor surface used by `ClaudeCodeExecutor`/`CodexExecutor`/
+`LocalExecutor` — one `execute(session, task)` call, one `ExecutorOutcome`
+— but the "subprocess" is a single synchronous HTTP round trip to the
+configured Hermes backend, using the SAME request-building
+(`_build_envelope`) and persistence (`_HermesTurnPersister`) the `/chat`
+Hermes proxy uses, so a board-assigned Hermes turn's conversation and usage
+rows are indistinguishable from one that came through `/chat`.
+
+Runs synchronously on the worker's tick thread (unlike the CLI routes,
+which run off-tick through the CLI dispatch pool) because a Hermes turn is
+one bounded HTTP request/response, not a long-lived subprocess.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Callable, Optional
+
+import httpx
+
+from api.routes.hermes_proxy import _HermesTurnPersister, _build_envelope
+from api.services.agent_worker.local_executor import ExecutorOutcome
+from api.services.agent_worker.session_store import (
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_RUNNING,
+    SessionStore,
+)
+from api.services.agent_worker.transcript_store import TranscriptStore
+from config.settings import settings
+
+
+logger = logging.getLogger(__name__)
+
+# Same read timeout the browser-facing proxy gives a Hermes turn
+# (api/routes/_proxy.py's TIMEOUT) — a board-assigned turn deserves the
+# same patience as one typed into /chat.
+_TIMEOUT = httpx.Timeout(connect=5.0, read=300.0, write=300.0, pool=5.0)
+
+HttpClientFactory = Callable[[], httpx.Client]
+
+
+def _default_client_factory() -> httpx.Client:
+    return httpx.Client(timeout=_TIMEOUT)
+
+
+class HermesExecutor:
+    """Run one Hermes turn synchronously and persist its state.
+
+    Constructor injection points (test seams):
+      - `http_client_factory` — override to return a fake/mocked sync
+        `httpx.Client` whose `.stream()` yields a scripted SSE response,
+        so tests never touch the network.
+      - `persona_id` — which Hermes persona a board-assigned card opens a
+        conversation as. Defaults to "primary"; a future card field could
+        override this, but the issue doesn't ask for one.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_store: SessionStore,
+        transcript_store: TranscriptStore,
+        http_client_factory: Optional[HttpClientFactory] = None,
+        persona_id: str = "primary",
+    ) -> None:
+        self.session_store = session_store
+        self.transcript_store = transcript_store
+        self._client_factory = http_client_factory or _default_client_factory
+        self._persona_id = persona_id
+
+    def execute(self, session, task: dict) -> ExecutorOutcome:
+        sid = session.session_id
+        prompt = self._build_prompt(task)
+        if not prompt:
+            self.transcript_store.append(sid, "hermes_no_prompt", {})
+            return ExecutorOutcome(status=STATUS_FAILED, reason="empty prompt")
+
+        if not settings.hermes_backend_url:
+            self.transcript_store.append(sid, "hermes_not_configured", {})
+            return ExecutorOutcome(
+                status=STATUS_FAILED,
+                reason="Hermes backend not configured (LIFEOS_HERMES_BACKEND_URL)",
+            )
+
+        raw_body = json.dumps({"question": prompt, "persona_id": self._persona_id}).encode("utf-8")
+        try:
+            envelope_body = _build_envelope(raw_body)
+        except Exception as exc:  # noqa: BLE001 — _build_envelope raises HTTPException
+            self.transcript_store.append(sid, "hermes_envelope_failed", {"error": str(exc)})
+            return ExecutorOutcome(status=STATUS_FAILED, reason=f"envelope build failed: {exc}")
+
+        self.session_store.update_status(session.task_id, STATUS_RUNNING)
+        self.transcript_store.append(sid, "hermes_spawn", {"question_chars": len(prompt)})
+
+        persister = _HermesTurnPersister(question=prompt, persona_id=self._persona_id)
+        url = f"{settings.hermes_backend_url.rstrip('/')}/api/ask/stream"
+        headers = {"Content-Type": "application/json"}
+        if settings.hermes_backend_token:
+            headers["Authorization"] = f"Bearer {settings.hermes_backend_token}"
+
+        try:
+            client = self._client_factory()
+            try:
+                with client.stream("POST", url, content=envelope_body, headers=headers) as resp:
+                    resp.raise_for_status()
+                    for chunk in resp.iter_bytes():
+                        persister.observe(chunk)
+            finally:
+                # A factory-provided client (real or fake) may or may not
+                # support context-manager close; best-effort only.
+                close = getattr(client, "close", None)
+                if callable(close):
+                    close()
+        except Exception as exc:  # noqa: BLE001 — network/HTTP errors of every shape
+            persister.finalize()
+            self.transcript_store.append(sid, "hermes_request_failed", {"error": str(exc)})
+            return ExecutorOutcome(status=STATUS_FAILED, reason=f"hermes request failed: {exc}")
+
+        persister.finalize()
+
+        conversation_id = persister.conversation_id
+        final_text = persister.content_text.strip()
+
+        if conversation_id:
+            self.session_store.set_conversation_id(session.task_id, conversation_id)
+        self.transcript_store.append(sid, "hermes_completed", {
+            "conversation_id": conversation_id,
+            "final_chars": len(final_text),
+            "done_seen": persister.done_seen,
+        })
+
+        if not final_text:
+            return ExecutorOutcome(
+                status=STATUS_FAILED,
+                reason="hermes turn produced no content" + (
+                    "" if persister.done_seen else " (stream truncated before completion)"
+                ),
+            )
+
+        return ExecutorOutcome(status=STATUS_COMPLETED, final_text=final_text)
+
+    @staticmethod
+    def _build_prompt(task: dict) -> str:
+        """The card's title (`task["description"]`) plus its notes, if any
+        — mirrors the CLI routes' `task["description"]`-as-prompt
+        convention, extended with notes since a Hermes conversation has no
+        separate "system prompt" slot for extra context the way a CLI
+        invocation's `--append-system-prompt` does."""
+        title = (task.get("description") or "").strip()
+        notes = (task.get("notes") or "").strip()
+        if title and notes:
+            return f"{title}\n\n{notes}"
+        return title or notes

--- a/api/services/agent_worker/inter_agent.py
+++ b/api/services/agent_worker/inter_agent.py
@@ -554,10 +554,47 @@ _LOCAL_KILL_GRACE_S = 2.0
 _LOCAL_KILL_POLL_S = 0.1
 
 
-def _kill_local_subprocess(
-    transcript_store: TranscriptStore, target: Session,
+def _kill_remote_subprocess(
+    transcript_store: TranscriptStore, target: Session, *, remote_kill_runner=None,
 ) -> None:
-    """Best-effort terminate the local CLI subprocess owned by a LOCAL session.
+    """(#851) Best-effort terminate a CLI subprocess a `claude_code`/`codex`
+    executor spawned on a board-assigned HOST other than the API host.
+
+    Signalling a local pid/pgid (as `_kill_local_subprocess` does) can't
+    reach a remote process — the executor recorded the REMOTE process
+    group id instead (`session.remote_pgid`, echoed by the ssh wrapper's
+    first stdout line; see `remote_spawn.build_remote_argv`). This runs
+    `ssh <target> kill -- -<pgid>` through an injectable runner (production
+    default: a real `subprocess.run`; tests inject a fake) — see
+    `remote_spawn.kill_remote_process_group`.
+
+    Best-effort by contract, same as `_kill_local_subprocess`: a missing
+    pgid, an unregistered host, or an ssh failure must never break teardown.
+    """
+    from api.services.agent_worker.remote_spawn import kill_remote_process_group
+    from config.settings import settings
+
+    pgid = getattr(target, "remote_pgid", None)
+    if pgid is None:
+        return  # no remote_pgid recorded yet (subprocess never spawned, or crashed pre-spawn)
+    ssh_target = settings.agent_hosts.get(target.host or "")
+    if not ssh_target:
+        logger.warning(
+            "remote kill: host %r for session %s is not in agent_hosts — nothing to signal",
+            target.host, target.session_id,
+        )
+        return
+    ok = kill_remote_process_group(target=ssh_target, pgid=pgid, runner=remote_kill_runner)
+    transcript_store.append(target.session_id, "remote_subprocess_kill_attempted", {
+        "host": target.host, "pgid": pgid, "ok": ok,
+    })
+
+
+def _kill_local_subprocess(
+    transcript_store: TranscriptStore, target: Session, *, remote_kill_runner=None,
+) -> None:
+    """Best-effort terminate the CLI subprocess owned by a LOCAL or
+    (#851) REMOTE session.
 
     The `claude_code` / `codex` executors run a `subprocess.Popen` in the
     *worker* process and record its pid/process-group id via a `claude_code_pid`
@@ -566,12 +603,37 @@ def _kill_local_subprocess(
     can only reach that subprocess by signalling the recorded pgid. Same-user
     `killpg` is permitted; the worker's `proc.wait()` reaps the dead child.
 
+    A session whose `host` names a machine other than the API host never
+    ran a local subprocess at all — its argv was wrapped in `ssh` instead
+    (see `remote_spawn.build_remote_argv`), so it's dispatched to
+    `_kill_remote_subprocess` instead of the local killpg path below —
+    UNLESS no `remote_pgid` was ever recorded (round 1, finding #3): the
+    executor's pgid read can itself hang (a stalled ssh client that
+    connected but never answered), in which case there's no remote process
+    to signal yet and the only thing this operator kill CAN reach is the
+    hung LOCAL `ssh` client process — the same `claude_code_pid`/`codex_pid`
+    transcript event below already recorded its pid (see
+    `ClaudeCodeExecutor._run`/`CodexExecutor._run`, the "remote": True
+    branch, which appends that event with the local ssh client's own
+    `proc.pid` regardless of whether the pgid line ever arrived). Falling
+    through to the local pid path is what makes that hang killable.
+
     Best-effort by contract: a missing pid event, a stale pid (process already
     gone), or a signalling error must NOT break teardown — the managed kill, DB
     flip, and transcript event have already run by the time this is called.
     """
     if target.routing not in CLI_ROUTINGS:
         return  # pure managed/cloud sessions own no local subprocess
+
+    host = (getattr(target, "host", None) or "").strip()
+    if host:
+        from api.services.agent_worker.remote_spawn import api_host_name as _api_host_name
+        if host != _api_host_name():
+            if getattr(target, "remote_pgid", None) is not None:
+                _kill_remote_subprocess(transcript_store, target, remote_kill_runner=remote_kill_runner)
+                return
+            # No remote_pgid recorded — fall through to the local pid path
+            # below, which can still reach the hung local ssh client.
 
     # Find the most recent pid event in the transcript. Codex records `codex_pid`;
     # claude_code records `claude_code_pid`. The latest wins (a resumed session
@@ -647,14 +709,21 @@ def teardown_session(
     transcript_kind: str,
     transcript_payload: dict,
     managed_driver: Any | None = None,
+    remote_kill_runner=None,
 ) -> dict[str, Any]:
     """Tear down a single session: kill the managed remote (best-effort),
     flip the local DB status to FAILED, append a transcript event, and
-    (for local CLI sessions) terminate the worker-owned subprocess.
+    (for local or #851 remote-host CLI sessions) terminate the worker-owned
+    subprocess.
 
     Shared between agent-initiated `kill()` (this module) and the operator
     HTTP kill endpoint (`api/routes/agents.py`). Authorization is the
     caller's responsibility — this helper just runs the mechanics.
+
+    `remote_kill_runner` (#851) is a test seam forwarded to
+    `_kill_remote_subprocess`/`remote_spawn.kill_remote_process_group` for a
+    session whose `host` names a machine other than the API host — None
+    (the default) uses a real `subprocess.run` over ssh.
 
     Returns `{"managed_failure": <reason or None>}` so the caller can
     surface partial-success in its response.
@@ -679,7 +748,7 @@ def teardown_session(
     # alone doesn't stop the OS process (the worker's `claude -p` keeps running
     # until the next poll) — this reaps it promptly so an operator kill actually
     # stops compute within seconds.
-    _kill_local_subprocess(transcript_store, target)
+    _kill_local_subprocess(transcript_store, target, remote_kill_runner=remote_kill_runner)
     return {"managed_failure": managed_failure}
 
 

--- a/api/services/agent_worker/local_executor.py
+++ b/api/services/agent_worker/local_executor.py
@@ -518,7 +518,7 @@ class LocalExecutor:
 
             turn_start = time.time()
             try:
-                response = self._call_llm(sid)
+                response = self._call_llm(sid, effort=session.effort)
             except Exception as exc:
                 logger.exception("local executor LLM call failed: %s", exc)
                 # Charge the time we spent trying so the budget reflects real
@@ -633,7 +633,7 @@ class LocalExecutor:
         self.session_store.append_message(sid, "user", _user_message_for(task))
         self.transcript_store.append(sid, "seed", {"task_id": session.task_id})
 
-    def _call_llm(self, session_id: str):
+    def _call_llm(self, session_id: str, effort: str | None = None):
         history = self.session_store.get_messages(session_id)
         # Separate the system message from the user/assistant/tool history.
         system_text = ""
@@ -644,6 +644,37 @@ class LocalExecutor:
                 system_text = content if isinstance(content, str) else json.dumps(content)
             else:
                 messages_for_llm.append(entry)
+
+        # (#851) Per-session thinking override. `effort` is the board's
+        # assignment field (`low|medium|high|max`); `high`/`max` turns
+        # thinking on, `low`/`medium` turns it off, and unset/unrecognized
+        # falls back to `settings.local_agent_enable_thinking` — same
+        # mapping `agent_loop.run_agent_loop` uses for the chat surface,
+        # applied here per-SESSION instead of via the global setting so
+        # concurrent agent-worker sessions with different assigned efforts
+        # don't race each other over one process-wide flag.
+        #
+        # Gated on `isinstance(self.llm, LocalLLMClient)` — the exact same
+        # check `run_agent_loop` uses — for two independent reasons: (1) the
+        # #809 remote-forced route (`self.is_remote`) is ALSO a LocalLLMClient
+        # instance (same OpenAI-compatible plumbing) but isn't llama-server —
+        # it doesn't understand llama-server's `chat_template_kwargs` switch,
+        # so `enable_thinking` must never reach it (mirrors `run_agent_loop`'s
+        # `not force_remote` gate); an isinstance check alone wouldn't exclude
+        # it, so `self.is_remote` is checked too. (2) a test-injected fake LLM
+        # client's `create()` may not accept `enable_thinking` at all — gating
+        # on the concrete class keeps every existing fake-client test
+        # byte-identical.
+        create_kwargs: dict = {}
+        from api.services.llm_client import LocalLLMClient
+        if isinstance(self.llm, LocalLLMClient) and not self.is_remote:
+            from api.services.agent_worker.assignment import local_thinking_for_effort
+            from config.settings import settings as _settings
+            override = local_thinking_for_effort(effort)
+            enable_thinking = override if override is not None else (
+                None if _settings.local_agent_enable_thinking else False
+            )
+            create_kwargs["enable_thinking"] = enable_thinking
 
         # Retry transient connection drops. llama-server occasionally
         # disconnects mid-request under memory pressure ("Server
@@ -659,6 +690,7 @@ class LocalExecutor:
                     system=system_text or None,
                     max_tokens=PER_TURN_MAX_TOKENS,
                     tools=self.tools.definitions(),
+                    **create_kwargs,
                 )
             except Exception as exc:
                 if not _is_transient_llm_error(exc) or attempt == LLM_RETRY_ATTEMPTS - 1:

--- a/api/services/agent_worker/model_catalog.py
+++ b/api/services/agent_worker/model_catalog.py
@@ -1,0 +1,209 @@
+"""Model catalog for the board's assignment pickers (#851).
+
+`GET /api/agents/models` (`api/routes/agent_assignment.py`) needs "what
+models can each engine actually run right now" — the same "observed, not
+declared" discipline `model_readout.py` already established for the /chat
+surfaces, extended here to the four engines a card can be assigned to.
+Never hardcodes a model list beyond `pricing.PRICING`'s rates, which are
+merged into whichever entries they cover as a `pricing` hint.
+
+Sources, one per engine:
+  - **claude**: the Anthropic SDK's own `models.list()` — never a
+    hand-maintained table (that's exactly what went stale in pricing.py
+    before #655/#656). Skipped (empty list, not an error) when no API key
+    is configured.
+  - **codex**: the Codex CLI's own `~/.codex/models_cache.json`
+    (`settings.codex_models_cache_path`), falling back to a live OpenAI
+    models list call when the file is missing/unreadable/empty AND
+    `settings.openai_api_key` is set; otherwise empty (not an error).
+  - **local**: the running llama-server's `/v1/models`, via
+    `model_readout._probe_live_model` — the same live probe /chat's local
+    picker already trusts over a declared setting.
+  - **hermes**: `model_readout.get_hermes_models()`'s `hermes_chat` entry —
+    observed from the last real turn, never probed (see that module's
+    docstring for why Hermes can't be probed for "what it would run").
+
+Cached for `settings.agent_model_catalog_ttl_seconds` (default 24h) so a
+picker open doesn't cost a provider round trip every time. A refresh
+failure (any engine's fetch raising) falls back to the last successful
+catalog with `stale: true` rather than 500ing the picker or discarding
+what's cached — the same "observed beats nothing" instinct as everywhere
+else in this module, applied to failure instead of absence.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+import httpx
+
+from api.services.agent_worker.pricing import PRICING, _DATED_SNAPSHOT_SUFFIX
+from config.settings import settings
+
+
+logger = logging.getLogger(__name__)
+
+ENGINES = ("claude", "codex", "local", "hermes")
+
+_OPENAI_MODELS_URL = "https://api.openai.com/v1/models"
+_OPENAI_TIMEOUT = httpx.Timeout(10.0)
+
+
+def _pricing_for(model_id: str) -> Optional[dict]:
+    rates = PRICING.get(model_id) or PRICING.get(_DATED_SNAPSHOT_SUFFIX.sub("", model_id))
+    return dict(rates) if rates else None
+
+
+def _entry(model_id: str, label: str | None = None) -> dict:
+    return {
+        "id": model_id,
+        "label": label or model_id,
+        "pricing": _pricing_for(model_id),
+    }
+
+
+@dataclass
+class ModelCatalog:
+    """Injectable-everything catalog builder (test seams on every provider
+    call, plus the clock) so tests never touch the network and can assert
+    the TTL cache's call counts deterministically.
+    """
+
+    anthropic_client_factory: Optional[Callable[[], Any]] = None
+    codex_cache_path: Optional[str] = None
+    openai_http_client_factory: Optional[Callable[[], httpx.Client]] = None
+    local_probe: Optional[Callable[[], Any]] = None  # async () -> Optional[str]
+    hermes_probe: Optional[Callable[[], Any]] = None  # async () -> dict (model_readout.get_hermes_models shape)
+    clock: Callable[[], float] = field(default=time.monotonic)
+
+    provider_call_count: int = field(default=0, init=False)
+
+    _cached: Optional[dict] = field(default=None, init=False, repr=False)
+    _cached_at: Optional[float] = field(default=None, init=False, repr=False)
+
+    async def get(self, *, ttl_seconds: Optional[int] = None) -> dict:
+        ttl = ttl_seconds if ttl_seconds is not None else settings.agent_model_catalog_ttl_seconds
+        now = self.clock()
+        if self._cached is not None and self._cached_at is not None and (now - self._cached_at) < ttl:
+            return {**self._cached, "stale": False}
+        try:
+            fresh = await self._fetch_all()
+        except Exception as exc:  # noqa: BLE001 — any single engine's provider failure
+            logger.warning("model catalog refresh failed: %s", exc)
+            if self._cached is not None:
+                return {**self._cached, "stale": True}
+            raise
+        self._cached = fresh
+        self._cached_at = now
+        return {**fresh, "stale": False}
+
+    async def _fetch_all(self) -> dict:
+        engines = {
+            "claude": await self._fetch_claude(),
+            "codex": await self._fetch_codex(),
+            "local": await self._fetch_local(),
+            "hermes": await self._fetch_hermes(),
+        }
+        return {
+            "engines": engines,
+            "refreshed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+
+    # ------------------------------------------------------------------
+    # Per-engine fetchers
+    # ------------------------------------------------------------------
+
+    async def _fetch_claude(self) -> list[dict]:
+        if not settings.anthropic_api_key:
+            return []  # unconfigured, not a failure — mirrors get_hermes_models()
+        self.provider_call_count += 1
+        client = (self.anthropic_client_factory or self._default_anthropic_client)()
+
+        def _list_sync() -> list[dict]:
+            page = client.models.list()
+            return [_entry(m.id, getattr(m, "display_name", None) or m.id) for m in page.data]
+
+        return await asyncio.to_thread(_list_sync)
+
+    @staticmethod
+    def _default_anthropic_client():
+        import anthropic
+        return anthropic.Anthropic(api_key=settings.anthropic_api_key)
+
+    async def _fetch_codex(self) -> list[dict]:
+        path = os.path.expanduser(self.codex_cache_path or settings.codex_models_cache_path)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            models = data.get("models") or []
+            if models:
+                return [
+                    _entry(m.get("slug") or m.get("id"), m.get("display_name"))
+                    for m in models if m.get("slug") or m.get("id")
+                ]
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            pass
+        return await self._fetch_codex_fallback()
+
+    async def _fetch_codex_fallback(self) -> list[dict]:
+        if not settings.openai_api_key:
+            return []  # unconfigured, not a failure
+        self.provider_call_count += 1
+        client = (self.openai_http_client_factory or (lambda: httpx.Client(timeout=_OPENAI_TIMEOUT)))()
+
+        def _list_sync() -> list[dict]:
+            resp = client.get(
+                _OPENAI_MODELS_URL,
+                headers={"Authorization": f"Bearer {settings.openai_api_key}"},
+            )
+            resp.raise_for_status()
+            data = resp.json().get("data") or []
+            return [_entry(m["id"]) for m in data if isinstance(m, dict) and m.get("id")]
+
+        try:
+            return await asyncio.to_thread(_list_sync)
+        finally:
+            close = getattr(client, "close", None)
+            if callable(close):
+                close()
+
+    async def _fetch_local(self) -> list[dict]:
+        probe = self.local_probe or self._default_local_probe
+        model = await probe()
+        return [_entry(model)] if model else []
+
+    @staticmethod
+    async def _default_local_probe() -> Optional[str]:
+        from api.services.model_readout import _probe_live_model
+        return await _probe_live_model(settings.local_llm_url)
+
+    async def _fetch_hermes(self) -> list[dict]:
+        probe = self.hermes_probe or self._default_hermes_probe
+        readout = await probe()
+        chat = (readout or {}).get("hermes_chat") or {}
+        model = chat.get("model") if chat.get("status") == "ok" else None
+        return [_entry(model)] if model else []
+
+    @staticmethod
+    async def _default_hermes_probe() -> dict:
+        from api.services.model_readout import get_hermes_models
+        return await get_hermes_models()
+
+
+# Process-wide singleton — mirrors model_readout.py's in-memory-only
+# pattern (resets on restart, matching every other live-observed cache in
+# this module). Tests construct their own ModelCatalog() with stub
+# providers instead of touching this singleton.
+_catalog: Optional[ModelCatalog] = None
+
+
+def get_model_catalog() -> ModelCatalog:
+    global _catalog
+    if _catalog is None:
+        _catalog = ModelCatalog()
+    return _catalog

--- a/api/services/agent_worker/preflight.py
+++ b/api/services/agent_worker/preflight.py
@@ -50,6 +50,12 @@ ROUTE_CODEX = "codex"
 # (the `routing not in KNOWN_ROUTES` check below), not be treated as a
 # legitimate model-chosen route needing its own corroboration carve-out.
 ROUTE_REMOTE = "remote"
+# `hermes` is the #851 route for the `#hermes` tag (or a board card
+# assigned to the Hermes engine): the turn opens a Hermes conversation via
+# `HermesExecutor` instead of running a local CLI. Like ROUTE_CLAUDE_CODE/
+# ROUTE_CODEX, preflight's own JSON schema never emits this directly — it's
+# set exclusively by `_apply_tag_overrides` from the `#hermes` tag.
+ROUTE_HERMES = "hermes"
 
 # All routing destinations `parse_preflight_response` accepts from the model,
 # and the same set `settings.agent_default_route` (#707) is validated
@@ -61,7 +67,7 @@ ROUTE_REMOTE = "remote"
 # `ROUTE_CLAUDE` (which is also excluded from default-route substitution by
 # `_apply_default_route`'s `original_routing` guard, just via a different
 # mechanism — see that function's docstring, point 3a).
-KNOWN_ROUTES = (ROUTE_LOCAL, ROUTE_CLAUDE, ROUTE_CLAUDE_CODE, ROUTE_CODEX, ROUTE_ASK)
+KNOWN_ROUTES = (ROUTE_LOCAL, ROUTE_CLAUDE, ROUTE_CLAUDE_CODE, ROUTE_CODEX, ROUTE_HERMES, ROUTE_ASK)
 
 # Allowed expected-output shapes. Used to phrase the final Telegram summary.
 OUTPUT_KINDS = ("text", "file", "external_action", "structured")
@@ -675,7 +681,7 @@ _ROUTE_TITLE_CORROBORATION: dict[str, re.Pattern[str]] = {
 # of these means `_apply_route_corroboration` must not second-guess the
 # result with a title-cue check: a tag IS the operator naming the engine.
 _ROUTE_OVERRIDE_TAG_NAMES = frozenset(
-    {"local", "claude", "codex", "cloud", "cloud-haiku", "cloud-sonnet"}
+    {"local", "claude", "codex", "hermes", "cloud", "cloud-haiku", "cloud-sonnet"}
 )
 
 
@@ -690,6 +696,9 @@ def _apply_tag_overrides(result: PreflightResult, tags: list[str], title: str = 
       `#local`        → routing=local, model=local
       `#claude`       → routing=code   (Claude Code CLI, subscription-billed)
       `#codex`        → routing=codex  (Codex CLI, subscription-billed)
+      `#hermes`       → routing=hermes (Hermes conversation, #851; model is
+                         whatever Hermes reports per turn — nothing for
+                         preflight to select among ALLOWED_MODELS)
       `#cloud-haiku`  → routing=claude, model=claude-haiku-4-5   (Anthropic API, explicit)
       `#cloud-sonnet` → routing=claude, model=claude-sonnet-5    (Anthropic API, explicit)
       `#cloud`        → routing=remote, model=""  (#809: the configured remote
@@ -726,6 +735,16 @@ def _apply_tag_overrides(result: PreflightResult, tags: list[str], title: str = 
         result.routing_reason = "#codex tag present"
         result.routing_explicit = True
         result.model = ""  # CLI picks its own model from ~/.codex/config.toml
+        return result
+    if "hermes" in normalized:
+        # (#851) Hermes route — dispatched through HermesExecutor, which
+        # opens a Hermes conversation instead of running a local CLI.
+        # Hermes reports its own model per turn (model_readout.py); nothing
+        # for preflight to select among ALLOWED_MODELS.
+        result.routing = ROUTE_HERMES
+        result.routing_reason = "#hermes tag present"
+        result.routing_explicit = True
+        result.model = ""
         return result
     if "cloud-haiku" in normalized:
         result.routing = ROUTE_CLAUDE

--- a/api/services/agent_worker/remote_spawn.py
+++ b/api/services/agent_worker/remote_spawn.py
@@ -1,0 +1,282 @@
+"""ssh mechanism for running (and killing) an executor's CLI subprocess on a
+board-assigned host other than the API host (#851).
+
+One mechanism serves both remote execution and the remote kill path:
+
+- `resolve_host_target()` looks up a board-facing host name in
+  `settings.agent_hosts` (operator config, `{name: ssh_target}`). An empty
+  host, or a host equal to the API's own hostname, means "local" — the
+  executors' existing `spawn_fn` seam is used unchanged. A name not in the
+  registry is a hard failure (`HostResolutionError`) with no ssh call made.
+- `build_remote_argv()` wraps a local CLI invocation (the exact argv the
+  executor would run locally) into an ssh call that also strips every
+  provider credential on the remote side (mirrors each executor's own
+  `_clean_env`) and captures the remote process group id as the first line
+  of stdout, so the kill path can reach it later.
+- `kill_remote_process_group()` runs `ssh <target> kill -- -<pgid>` through
+  an injectable runner, so tests never invoke a real `ssh`.
+
+Kept as its own module (rather than inside either executor) because both
+`ClaudeCodeExecutor` and `CodexExecutor` need it, and so does the operator
+kill endpoint (`api/routes/agents.py`) for a session whose `host` is set.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import queue
+import shlex
+import socket
+import subprocess
+import threading
+from typing import Callable, Optional
+
+from config.settings import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+def api_host_name() -> str:
+    """Short hostname of the machine running this process.
+
+    Deliberately duplicates `api.routes.agents.api_host_name()`'s one-line
+    body rather than importing it: services must not depend on routes (that
+    module already imports `SessionStore` from this package — importing
+    back would invert the dependency and risk a cycle). Both call sites
+    strip the domain suffix the same way, so a value from either function
+    reads identically.
+    """
+    return socket.gethostname().split(".")[0]
+
+
+# (round 1, finding #2) A small static list of concrete credential env-var
+# names, unioned into every `env_names_matching_prefixes()` result below —
+# NOT filtered to just what THIS process's own environment happens to
+# contain. `env_names_matching_prefixes` alone enumerates names present in
+# the worker's own `os.environ`; a worker installed with no
+# ANTHROPIC_*/CLAUDE*/OPENAI_ vars set at all (a subscription/OAuth
+# install, the common case) would otherwise unset nothing on the remote
+# host, silently inheriting whatever a registered host's own non-
+# interactive shell exports — the exact API-billing leak `_clean_env`'s
+# local strip exists to prevent (see its docstring), just on the remote
+# side. `env -u` on a name that was never set is a no-op, so unconditionally
+# including these costs nothing.
+CANONICAL_CREDENTIAL_ENV_NAMES: frozenset[str] = frozenset({
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CLAUDECODE",
+    # Codex/OpenAI equivalent of ANTHROPIC_API_KEY — the credential name a
+    # remote host's shell would export to make Codex API-billed instead of
+    # subscription-billed through the CLI.
+    "OPENAI_API_KEY",
+})
+
+
+def env_names_matching_prefixes(prefixes: tuple[str, ...], keep: frozenset[str] = frozenset()) -> list[str]:
+    """Names to `env -u` on a remote spawn: every name in the CURRENT
+    process's environment matching any of `prefixes`, UNIONED with
+    `CANONICAL_CREDENTIAL_ENV_NAMES` (both minus `keep`) — see that
+    constant's docstring for why the union, not just the local scan, is
+    required for the "must NOT inherit" guarantee to hold on a clean
+    worker install."""
+    local_matches = {k for k in os.environ if k.startswith(prefixes)}
+    return sorted((local_matches | CANONICAL_CREDENTIAL_ENV_NAMES) - keep)
+
+
+class HostResolutionError(Exception):
+    """Raised by `resolve_host_target()` when `host` names a machine that
+    isn't in `settings.agent_hosts` — the caller must fail the task closed
+    (`#agent-failed`) rather than ever invoking ssh."""
+
+
+# First line of the remote wrapper's stdout, echoed before the real
+# command's own output begins — see `build_remote_argv()`.
+PGID_LINE_PREFIX = "PGID:"
+
+
+def is_local_host(host: str | None, api_host_name: str) -> bool:
+    """True when `host` means "run on this API host" — unset/blank, or an
+    exact match for the API's own short hostname."""
+    host = (host or "").strip()
+    return not host or host == api_host_name
+
+
+def resolve_host_target(host: str | None, api_host_name: str) -> Optional[str]:
+    """Return the ssh target for `host`, or `None` when `host` means local.
+
+    Raises `HostResolutionError` when `host` is set, isn't the API host,
+    and isn't a key in `settings.agent_hosts` — the caller must not spawn
+    anything (locally or over ssh) in that case.
+    """
+    if is_local_host(host, api_host_name):
+        return None
+    target = settings.agent_hosts.get(host)
+    if not target:
+        raise HostResolutionError(
+            f"host {host!r} is not configured in LIFEOS_AGENT_HOSTS"
+        )
+    return target
+
+
+def build_remote_argv(
+    argv: list[str],
+    *,
+    target: str,
+    unset_env_names: list[str],
+    connect_timeout: Optional[int] = None,
+) -> list[str]:
+    """Wrap a local CLI invocation into an ssh call to `target`.
+
+    The remote command:
+      1. Unsets every name in `unset_env_names` (mirrors the executor's own
+         `_clean_env`, so a remote session can't inherit the operator's
+         Anthropic/Claude credentials any more than a local one can).
+      2. Runs under `setsid` inside a tiny `bash -c` wrapper that echoes
+         `PGID:<pid>` as its very first stdout line — `$$` inside a fresh
+         `setsid` shell is both the pid and the process-group id — before
+         `exec`-ing the real argv, so the group leader replaces the wrapper
+         process and every later stdout line is the CLI's own output. The
+         caller strips that first line (see `read_remote_pgid_line()`) and
+         records the pgid for the remote kill path.
+    """
+    timeout = connect_timeout if connect_timeout is not None else settings.agent_ssh_connect_timeout
+    unset_flags: list[str] = []
+    for name in unset_env_names:
+        unset_flags.extend(["-u", name])
+    inner = shlex.join(["env", *unset_flags, *argv])
+    remote_command = f"setsid bash -c 'echo \"{PGID_LINE_PREFIX}$$\"; exec \"$@\"' _ {inner}"
+    return [
+        "ssh",
+        "-o", "BatchMode=yes",
+        "-o", f"ConnectTimeout={timeout}",
+        target,
+        "--",
+        remote_command,
+    ]
+
+
+def build_remote_launcher_argv(
+    argv: list[str], *, target: str, connect_timeout: Optional[int] = None,
+) -> list[str]:
+    """Wrap a launcher command (the `/resume`/`/focus` WezTerm invocation)
+    into an ssh call to `target`, with no pgid capture and no credential
+    stripping — unlike `build_remote_argv` (the executor spawn path), a
+    launcher doesn't need a kill target (it's a short-lived terminal
+    spawner, not the long-running CLI session itself) and inherits no
+    provider credentials in the first place.
+    """
+    timeout = connect_timeout if connect_timeout is not None else settings.agent_ssh_connect_timeout
+    return [
+        "ssh",
+        "-o", "BatchMode=yes",
+        "-o", f"ConnectTimeout={timeout}",
+        target,
+        "--",
+        shlex.join(argv),
+    ]
+
+
+def read_remote_pgid_line(line: str) -> Optional[int]:
+    """Parse the `PGID:<n>` line a remote-wrapped subprocess echoes first.
+    Returns None if `line` isn't that line (caller then treats it as real
+    stdout — defensive, shouldn't happen in practice)."""
+    line = line.rstrip("\n")
+    if not line.startswith(PGID_LINE_PREFIX):
+        return None
+    try:
+        return int(line[len(PGID_LINE_PREFIX):].strip())
+    except ValueError:
+        return None
+
+
+def read_line_with_deadline(stream, timeout: float) -> tuple[str, bool]:
+    """Read one line from `stream` with a bounded wait (round 1, finding
+    #3). Both executors block on `stream.readline()` for the `PGID:` line
+    BEFORE their own wall-clock watchdog starts — `ssh -o ConnectTimeout`
+    bounds only the TCP handshake, not a stall during auth or a host that
+    accepts the connection but never answers, so an unbounded `readline()`
+    here can hang the caller's thread forever.
+
+    Runs the read on a daemon thread rather than `select.select` so this
+    works uniformly whether `stream` is a real OS pipe or a test double
+    (fakes generally have no `fileno()`). Returns `(line, timed_out)`:
+    `timed_out` is True and `line` is `""` when nothing arrived within
+    `timeout` seconds — the reader thread is left running (daemon, so it
+    exits with the process) rather than joined, since a genuinely hung
+    stream has no clean way to unblock `readline()` from here; callers
+    that hit `timed_out` are expected to terminate the owning subprocess,
+    which closes the pipe's write end and unblocks the reader.
+    """
+    result: "queue.Queue[str]" = queue.Queue(maxsize=1)
+
+    def _reader() -> None:
+        try:
+            result.put(stream.readline())
+        except Exception:  # noqa: BLE001 — surface as empty/no-line, not a crash
+            result.put("")
+
+    thread = threading.Thread(target=_reader, daemon=True)
+    thread.start()
+    try:
+        return result.get(timeout=timeout), False
+    except queue.Empty:
+        return "", True
+
+
+def last_nonempty_line(text: str) -> str:
+    """Last non-blank line of `text` (round 1, finding #4) — used to fold
+    an ssh failure's stderr (e.g. `ssh: connect to host studio port 22:
+    Connection refused`) into an executor's failure reason instead of
+    leaving it reachable only via the transcript's `stderr_tail`."""
+    for line in reversed((text or "").splitlines()):
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+KillRunner = Callable[[list[str]], "subprocess.CompletedProcess"]
+
+
+def _default_kill_runner(argv: list[str]) -> "subprocess.CompletedProcess":
+    return subprocess.run(argv, capture_output=True, timeout=15, check=False)  # noqa: S603
+
+
+def kill_remote_process_group(
+    *,
+    target: str,
+    pgid: int,
+    connect_timeout: Optional[int] = None,
+    runner: Optional[KillRunner] = None,
+) -> bool:
+    """Run `ssh <target> kill -- -<pgid>` (SIGTERM to the whole remote
+    process group) through an injectable `runner` — production default is a
+    real `subprocess.run`; tests inject a fake that records the argv and
+    never touches the network.
+
+    Best-effort: any exception or non-zero exit is logged and swallowed —
+    mirrors `_kill_local_subprocess`'s contract (a kill failure must not
+    break the rest of teardown).
+    """
+    timeout = connect_timeout if connect_timeout is not None else settings.agent_ssh_connect_timeout
+    argv = [
+        "ssh",
+        "-o", "BatchMode=yes",
+        "-o", f"ConnectTimeout={timeout}",
+        target,
+        "kill", "--", f"-{pgid}",
+    ]
+    run = runner or _default_kill_runner
+    try:
+        result = run(argv)
+        returncode = getattr(result, "returncode", 0)
+        if returncode != 0:
+            logger.warning("remote kill on %s (pgid %s) exited %s", target, pgid, returncode)
+            return False
+        return True
+    except Exception as exc:  # noqa: BLE001 — best-effort, mirrors local kill
+        logger.warning("remote kill on %s (pgid %s) failed: %s", target, pgid, exc)
+        return False

--- a/api/services/agent_worker/session_store.py
+++ b/api/services/agent_worker/session_store.py
@@ -113,6 +113,65 @@ class Session:
     # motivation as usage_store's per-row `unpriced` column from #613/#661,
     # adapted here to an accumulating total rather than one row per turn).
     unpriced: bool = False
+    # (#851) Board-assignment fields. `host` is a name from
+    # `settings.agent_hosts` ("" / None = the API host); `model` and
+    # `effort` are the board's own picker values, threaded into the
+    # executor's argv at spawn time. `conversation_id` is set only for
+    # routing="hermes" sessions (the Hermes conversation this card opened).
+    # `remote_pgid` is the process-group id a remote-spawned subprocess
+    # echoed back on its first stdout line — used by the operator kill
+    # endpoint to reach it over ssh (see `remote_spawn.py`).
+    host: str | None = None
+    model: str | None = None
+    effort: str | None = None
+    conversation_id: str | None = None
+    remote_pgid: int | None = None
+
+
+# Engine -> storage id prefix for the `cli_sessions` table (#849). Matches
+# the `cc:` / `cx:` convention `CCWezTermStore` and the transcript-scan
+# snapshot already use, so a cli_sessions row and its transcript-derived
+# counterpart share one id in the /agents snapshot union.
+CLI_ENGINE_PREFIXES = {"claude_code": "cc", "codex": "cx"}
+
+# Lifecycle events the hook script posts. Anything else is a caller bug —
+# the route rejects it with 422 rather than silently no-op'ing.
+CLI_SESSION_EVENTS = frozenset({
+    "session_start", "user_prompt_submit", "stop", "session_end",
+})
+
+CLI_STATUS_IDLE = "idle"
+CLI_STATUS_RUNNING = "running"
+CLI_STATUS_ENDED = "ended"
+
+# Prompt previews are truncated to this many characters before storage
+# (issue #849 acceptance criteria).
+CLI_PROMPT_PREVIEW_MAX = 200
+
+
+@dataclass
+class CliSession:
+    """Mirrors one row in the `cli_sessions` table — a Claude Code or Codex
+    CLI session registered by `scripts/lifeos-agent-hook.sh`, from any
+    machine on the tailnet. Status is event-driven (set by the hook's
+    lifecycle posts), unlike the local transcript scan's file-age guess.
+    """
+
+    session_id: str  # cc:<uuid> or cx:<uuid> — shares the snapshot id space
+    engine: str  # "claude_code" | "codex"
+    host: str
+    status: str  # idle | running | ended
+    started_at: int
+    last_event_at: int
+    cwd: str | None = None
+    transcript_path: str | None = None
+    branch: str | None = None
+    model: str | None = None
+    prompt_preview: str | None = None
+    task_id: str | None = None
+    pane_id: int | None = None
+    wezterm_pid: int | None = None
+    ended_at: int | None = None
 
 
 _SCHEMA = """
@@ -141,7 +200,12 @@ CREATE TABLE IF NOT EXISTS sessions (
     claude_code_session_id    TEXT,  -- Claude Code (or Codex) CLI session UUID for routing="claude_code"/"codex"
     claude_code_model         TEXT,  -- Claude tier for routing="claude_code" (haiku/sonnet/opus); NULL = CLI default (opus)
     bot                       TEXT,  -- Telegram bot that owns this session's notices; NULL = primary (#348)
-    unpriced                  INTEGER NOT NULL DEFAULT 0  -- sticky: any record_spend call priced an unknown model (#669)
+    unpriced                  INTEGER NOT NULL DEFAULT 0,  -- sticky: any record_spend call priced an unknown model (#669)
+    host                      TEXT,  -- board-assigned host name (#851); NULL/"" = the API host
+    model                     TEXT,  -- board-assigned model id (#851), passed to the executor's --model flag
+    effort                    TEXT,  -- board-assigned effort level (#851): low|medium|high|max
+    conversation_id           TEXT,  -- Hermes conversation id (#851, routing='hermes' only)
+    remote_pgid               INTEGER  -- process-group id echoed by a remote-spawned subprocess (#851)
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
@@ -256,6 +320,29 @@ CREATE TABLE IF NOT EXISTS managed_cursor (
     tool_loop_signature              TEXT,
     tool_loop_count                  INTEGER NOT NULL DEFAULT 0,
     tool_calls_since_message         INTEGER NOT NULL DEFAULT 0
+);
+
+-- Cross-machine Claude Code / Codex CLI sessions (#849). One row per
+-- session, registered by scripts/lifeos-agent-hook.sh from any host on the
+-- tailnet via POST /api/agents/cli-sessions/events. `session_id` is the
+-- cc:/cx:-prefixed id (see CLI_ENGINE_PREFIXES) so it shares the id space
+-- the /agents snapshot union keys transcript-derived rows on.
+CREATE TABLE IF NOT EXISTS cli_sessions (
+    session_id       TEXT PRIMARY KEY,
+    engine           TEXT NOT NULL,
+    host             TEXT NOT NULL,
+    cwd              TEXT,
+    transcript_path  TEXT,
+    branch           TEXT,
+    model            TEXT,
+    status           TEXT NOT NULL,
+    prompt_preview   TEXT,
+    task_id          TEXT,
+    pane_id          INTEGER,
+    wezterm_pid      INTEGER,
+    started_at       INTEGER NOT NULL,
+    last_event_at    INTEGER NOT NULL,
+    ended_at         INTEGER
 );
 """
 
@@ -404,6 +491,20 @@ class SessionStore:
                     "ALTER TABLE managed_cursor ADD COLUMN tool_calls_since_message "
                     "INTEGER NOT NULL DEFAULT 0"
                 )
+            # Idempotent migration block for card assignment (#851): host,
+            # model, effort, conversation_id, remote_pgid. Old rows stay
+            # NULL — "no assignment recorded" for a pre-#851 session.
+            sess_cols = {row["name"] for row in conn.execute("PRAGMA table_info(sessions)")}
+            if "host" not in sess_cols:
+                conn.execute("ALTER TABLE sessions ADD COLUMN host TEXT")
+            if "model" not in sess_cols:
+                conn.execute("ALTER TABLE sessions ADD COLUMN model TEXT")
+            if "effort" not in sess_cols:
+                conn.execute("ALTER TABLE sessions ADD COLUMN effort TEXT")
+            if "conversation_id" not in sess_cols:
+                conn.execute("ALTER TABLE sessions ADD COLUMN conversation_id TEXT")
+            if "remote_pgid" not in sess_cols:
+                conn.execute("ALTER TABLE sessions ADD COLUMN remote_pgid INTEGER")
 
     # ------------------------------------------------------------------
     # Session CRUD
@@ -423,6 +524,9 @@ class SessionStore:
         origin: str | None = None,
         claude_code_model: str | None = None,
         bot: str | None = None,
+        host: str | None = None,
+        model: str | None = None,
+        effort: str | None = None,
     ) -> Session:
         """Insert a new session row. Raises sqlite3.IntegrityError if `task_id`
         already has a row — the caller should treat that as a lost-race signal.
@@ -433,6 +537,11 @@ class SessionStore:
 
         `origin="operator"` marks a root-spawned session (no #agent task) so
         the worker's spawned-session dispatch claims it (#235).
+
+        `host`/`model`/`effort` (#851) are the board-assignment fields
+        extracted from the task's `[key:: value]` fields — see
+        `assignment.extract_assignment()`. All three default to None
+        ("no assignment" — the routing/executor default applies).
         """
         sid = session_id or new_session_id()
         root_sid = root_session_id or sid
@@ -444,8 +553,9 @@ class SessionStore:
                     task_id, session_id, status, routing, budget_json,
                     started_at, last_activity_at,
                     expected_output, parent_session_id,
-                    root_session_id, spawn_depth, origin, claude_code_model, bot
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    root_session_id, spawn_depth, origin, claude_code_model, bot,
+                    host, model, effort
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     task_id, sid, status, routing,
@@ -453,6 +563,7 @@ class SessionStore:
                     now, now,
                     expected_output, parent_session_id,
                     root_sid, spawn_depth, origin, claude_code_model, bot,
+                    host, model, effort,
                 ),
             )
         return Session(
@@ -470,6 +581,9 @@ class SessionStore:
             origin=origin,
             claude_code_model=claude_code_model,
             bot=bot,
+            host=host,
+            model=model,
+            effort=effort,
         )
 
     def get(self, task_id: str) -> Session | None:
@@ -618,6 +732,49 @@ class SessionStore:
                     _now(),
                     task_id,
                 ),
+            )
+
+    def set_assignment(
+        self,
+        task_id: str,
+        *,
+        host: str | None = None,
+        model: str | None = None,
+        effort: str | None = None,
+    ) -> None:
+        """Record the board-assignment fields (#851) onto a session row.
+        Called once at dispatch time, right after routing/budget are set,
+        so the executor reads `session.host`/`.model`/`.effort` the same
+        way it already reads `session.claude_code_model`."""
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE sessions
+                SET host = ?, model = ?, effort = ?, last_activity_at = ?
+                WHERE task_id = ?
+                """,
+                (host, model, effort, _now(), task_id),
+            )
+
+    def set_conversation_id(self, task_id: str, conversation_id: str) -> None:
+        """Attach a Hermes conversation id (#851, routing='hermes') to a
+        session — mirrors `set_managed_session_id`."""
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE sessions SET conversation_id = ?, last_activity_at = ? "
+                "WHERE task_id = ?",
+                (conversation_id, _now(), task_id),
+            )
+
+    def set_remote_pgid(self, task_id: str, pgid: int) -> None:
+        """Record the process-group id a remote-spawned subprocess echoed
+        back on its first stdout line (#851) — read by the operator kill
+        endpoint to reach it over ssh (see `remote_spawn.py`)."""
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE sessions SET remote_pgid = ?, last_activity_at = ? "
+                "WHERE task_id = ?",
+                (pgid, _now(), task_id),
             )
 
     def set_managed_session_id(self, task_id: str, managed_id: str) -> None:
@@ -1223,6 +1380,55 @@ class SessionStore:
             )
         return True
 
+    def deposit_answer_by_id(self, question_id: int, answer: str) -> bool:
+        """Record an answer for an open question by its own row id (#850).
+
+        Board-drawer sibling of `deposit_answer` (keyed by Telegram message
+        id) and `deposit_answer_by_session_id` (keyed by session): the
+        `/agents` board addresses one `pending_questions` row directly by the
+        id `list_open_questions` returned it under. Sets exactly the columns
+        `deposit_answer` sets, so `worker.py::_process_clarification_answers`
+        consumes it unchanged on its next tick — the same path a Telegram
+        reply takes. Returns True if a matching open (unanswered, not timed
+        out) question existed and was updated; False otherwise.
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT id FROM pending_questions "
+                "WHERE id = ? AND answered_at IS NULL AND timed_out = 0 "
+                "AND kind != 'status_anchor'",
+                (int(question_id),),
+            ).fetchone()
+            if not row:
+                return False
+            conn.execute(
+                "UPDATE pending_questions "
+                "SET answer = ?, answered_at = ? WHERE id = ?",
+                (answer, _now(), row["id"]),
+            )
+        return True
+
+    def list_open_questions(self) -> list[dict]:
+        """List unanswered, unprocessed, not-timed-out questions (#850).
+
+        Powers `GET /api/agents/pending-questions` — the board's "waiting on
+        an answer" list. Scoped to `kind IN ('clarification', 'goal_approval')`
+        — the two kinds `worker.py::_process_clarification_answers` treats as
+        real questions awaiting a reply. `status_anchor` rows are routing
+        plumbing, and `followup` rows are completion notices (see
+        `notify_task_completed`), not questions — a Review card should not
+        render a fake pending-question badge for one. Oldest first, so the
+        board's list is stable as new questions arrive.
+        """
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM pending_questions "
+                "WHERE answered_at IS NULL AND processed = 0 AND timed_out = 0 "
+                "AND kind IN ('clarification', 'goal_approval') "
+                "ORDER BY id ASC",
+            ).fetchall()
+        return [dict(r) for r in rows]
+
     def delete_session(self, session_id: str) -> None:
         """Hard-delete a session and its queued messages/questions/turns.
 
@@ -1368,6 +1574,158 @@ class SessionStore:
                 (int(question_id),),
             )
 
+    # ------------------------------------------------------------------
+    # Cross-machine CLI sessions (#849)
+    # ------------------------------------------------------------------
+
+    def record_cli_session_event(
+        self,
+        *,
+        engine: str,
+        event: str,
+        session_id: str,
+        host: str,
+        cwd: str | None = None,
+        transcript_path: str | None = None,
+        branch: str | None = None,
+        model: str | None = None,
+        prompt: str | None = None,
+        task_id: str | None = None,
+        pane_id: int | None = None,
+        wezterm_pid: int | None = None,
+    ) -> CliSession:
+        """Apply one hook lifecycle event to the `cli_sessions` table.
+
+        Status machine: `session_start` -> `idle`; `user_prompt_submit` ->
+        `running` (and stores `prompt` truncated to CLI_PROMPT_PREVIEW_MAX
+        chars); `stop` -> `idle`; `session_end` -> `ended`. The row is
+        created on the first event seen for a session_id regardless of
+        which event that is — a hook installed mid-session, or one whose
+        session_start post was lost, still registers the session on its
+        next event rather than silently vanishing.
+
+        Fields present on the event (cwd, branch, model, task_id, pane_id,
+        wezterm_pid) overwrite the stored value; omitted (`None`) fields
+        leave whatever an earlier event already captured. `ended_at` is set
+        on `session_end` and cleared on `session_start` (a resumed session
+        sends session_start again, which un-ends it); `stop` and
+        `user_prompt_submit` leave it as-is.
+
+        Caller (the route) validates `engine` is a key of
+        CLI_ENGINE_PREFIXES and `event` is in CLI_SESSION_EVENTS — this
+        method assumes both are already valid.
+        """
+        storage_id = f"{CLI_ENGINE_PREFIXES[engine]}:{session_id}"
+        now = _now()
+
+        if event == "session_start":
+            status = CLI_STATUS_IDLE
+        elif event == "user_prompt_submit":
+            status = CLI_STATUS_RUNNING
+        elif event == "stop":
+            status = CLI_STATUS_IDLE
+        else:  # session_end — validated by the caller
+            status = CLI_STATUS_ENDED
+
+        prompt_preview = (
+            prompt[:CLI_PROMPT_PREVIEW_MAX]
+            if event == "user_prompt_submit" and prompt is not None
+            else None
+        )
+
+        with self._connect() as conn:
+            existing = conn.execute(
+                "SELECT * FROM cli_sessions WHERE session_id = ?", (storage_id,)
+            ).fetchone()
+
+            if event == "session_end":
+                ended_at = now
+            elif event == "session_start":
+                ended_at = None
+            else:
+                ended_at = existing["ended_at"] if existing is not None else None
+
+            if existing is None:
+                conn.execute(
+                    """
+                    INSERT INTO cli_sessions (
+                        session_id, engine, host, cwd, transcript_path,
+                        branch, model, status, prompt_preview, task_id,
+                        pane_id, wezterm_pid, started_at, last_event_at,
+                        ended_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        storage_id, engine, host, cwd, transcript_path,
+                        branch, model, status, prompt_preview, task_id,
+                        pane_id, wezterm_pid, now, now, ended_at,
+                    ),
+                )
+            else:
+                conn.execute(
+                    """
+                    UPDATE cli_sessions SET
+                        engine = ?,
+                        host = ?,
+                        cwd = COALESCE(?, cwd),
+                        transcript_path = COALESCE(?, transcript_path),
+                        branch = COALESCE(?, branch),
+                        model = COALESCE(?, model),
+                        status = ?,
+                        prompt_preview = COALESCE(?, prompt_preview),
+                        task_id = COALESCE(?, task_id),
+                        pane_id = COALESCE(?, pane_id),
+                        wezterm_pid = COALESCE(?, wezterm_pid),
+                        last_event_at = ?,
+                        ended_at = ?
+                    WHERE session_id = ?
+                    """,
+                    (
+                        engine, host, cwd, transcript_path, branch, model,
+                        status, prompt_preview, task_id, pane_id,
+                        wezterm_pid, now, ended_at, storage_id,
+                    ),
+                )
+            row = conn.execute(
+                "SELECT * FROM cli_sessions WHERE session_id = ?", (storage_id,)
+            ).fetchone()
+        return self._row_to_cli_session(row)
+
+    def get_cli_session(self, session_id: str) -> CliSession | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM cli_sessions WHERE session_id = ?", (session_id,)
+            ).fetchone()
+        return self._row_to_cli_session(row) if row else None
+
+    def list_cli_sessions(self, limit: int = 500) -> list[CliSession]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM cli_sessions ORDER BY last_event_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return [self._row_to_cli_session(r) for r in rows]
+
+    @staticmethod
+    def _row_to_cli_session(row: sqlite3.Row) -> CliSession:
+        return CliSession(
+            session_id=row["session_id"],
+            engine=row["engine"],
+            host=row["host"],
+            status=row["status"],
+            started_at=row["started_at"],
+            last_event_at=row["last_event_at"],
+            cwd=row["cwd"],
+            transcript_path=row["transcript_path"],
+            branch=row["branch"],
+            model=row["model"],
+            prompt_preview=row["prompt_preview"],
+            task_id=row["task_id"],
+            pane_id=row["pane_id"],
+            wezterm_pid=row["wezterm_pid"],
+            ended_at=row["ended_at"],
+        )
+
     @staticmethod
     def _row_to_session(row: sqlite3.Row) -> Session:
         return Session(
@@ -1424,4 +1782,9 @@ class SessionStore:
             ),
             bot=(row["bot"] if "bot" in row.keys() else None),
             unpriced=(bool(row["unpriced"]) if "unpriced" in row.keys() else False),
+            host=(row["host"] if "host" in row.keys() else None),
+            model=(row["model"] if "model" in row.keys() else None),
+            effort=(row["effort"] if "effort" in row.keys() else None),
+            conversation_id=(row["conversation_id"] if "conversation_id" in row.keys() else None),
+            remote_pgid=(row["remote_pgid"] if "remote_pgid" in row.keys() else None),
         )

--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -34,11 +34,13 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from api.services.agent_worker.completion_signal import has_positive_completion_signal
+from api.services.agent_worker.assignment import extract_assignment
 from api.services.agent_worker.preflight import (
     ROUTE_ASK,
     ROUTE_CLAUDE,
     ROUTE_CLAUDE_CODE,
     ROUTE_CODEX,
+    ROUTE_HERMES,
     ROUTE_LOCAL,
     ROUTE_REMOTE,
     PreflightResult,
@@ -265,6 +267,25 @@ def _split_frontmatter(text: str) -> tuple[str, str]:
     return text[: m.end()], text[m.end():]
 
 
+def _resolve_json_pointer(doc: Any, pointer: str) -> Any:
+    """Minimal RFC 6901 JSON Pointer resolver — enough for `done_when`'s
+    `pointer` field (`/status`, `/nested/field`), no external dependency.
+    An empty pointer (or `/`) returns `doc` itself. Raises `KeyError`/
+    `IndexError`/`TypeError` for a pointer that doesn't resolve, same as
+    dict/list indexing would — the worker's tick treats that as a failed
+    check for this card, not a crash."""
+    if not pointer or pointer == "/":
+        return doc
+    cur = doc
+    for raw_part in pointer.lstrip("/").split("/"):
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if isinstance(cur, list):
+            cur = cur[int(part)]
+        else:
+            cur = cur[part]
+    return cur
+
+
 def _worker_label(routing: str | None, served_by: str = "") -> str:
     """Telegram-message prefix that names the route — operator wants to
     know at a glance whether a result came from local Gemma or cloud
@@ -289,6 +310,8 @@ def _worker_label(routing: str | None, served_by: str = "") -> str:
         return label
     if routing == ROUTE_CLAUDE:
         return "Cloud agent worker"
+    if routing == ROUTE_HERMES:
+        return "Hermes agent worker"
     return "Agent worker"
 
 
@@ -300,6 +323,7 @@ _ENGINE_LABELS = {
     "claude": "cloud Claude",
     "local": "local Gemma",
     "remote": "remote provider",
+    "hermes": "Hermes",
 }
 
 
@@ -411,6 +435,7 @@ class Worker:
         managed_executor=None,    # injectable ManagedExecutor for tests
         claude_code_executor=None,  # injectable ClaudeCodeExecutor for tests
         codex_executor=None,        # injectable CodexExecutor for tests
+        hermes_executor=None,       # injectable HermesExecutor for tests (#851)
         cli_pool=None,              # injectable dispatch pool; tests pass _SynchronousPool
     ) -> None:
         self.api_base = (api_base or os.environ.get("LIFEOS_API_URL", "http://localhost:8000")).rstrip("/")
@@ -440,6 +465,11 @@ class Worker:
         )
         self._owns_http_client = http_client is None
         self._http = http_client or httpx.Client(timeout=10.0)
+        # Human-queue done_when poll (#852) — throttled independently of the
+        # main tick interval, which runs far more often (60s) than the
+        # default human-queue poll (300s). 0.0 so the very first tick always
+        # checks.
+        self._last_human_queue_check = 0.0
         self._preflight_caller = preflight_caller  # None → use Anthropic SDK by default
         self._local_executor = local_executor  # lazily instantiated on first use
         self._remote_executor = remote_executor  # lazily instantiated on first #cloud task (#809)
@@ -451,6 +481,7 @@ class Worker:
         # bot. Bypassed entirely when a test injects `_claude_code_executor`.
         self._claude_code_executors: dict[str, object] = {}
         self._codex_executor = codex_executor  # lazily instantiated on first /codex task
+        self._hermes_executor = hermes_executor  # lazily instantiated on first hermes task (#851)
         # CLI dispatches (claude_code/codex) are long-running subprocesses — both
         # spawned children/operator root-spawns AND top-level #agent tasks routed
         # to a CLI engine (#753) go through this pool via _submit_cli_dispatch.
@@ -656,6 +687,12 @@ class Worker:
 
     def tick(self) -> int:
         """Process one poll cycle. Returns the number of tasks handled (for tests)."""
+        # Resolve Human-queue cards whose done_when condition now passes.
+        # Runs before the spend-cap guard below: it never starts a new
+        # task or spends money, so it must not stop just because the
+        # worker is paused or near its daily cap (#852 R2).
+        self._process_human_queue()
+
         # Use the configured per-task default budget as the "can I afford to
         # start the cheapest task right now?" estimate. Calling with 0.0 would
         # let claims through even at cap=0 — see SpendTracker.can_start_task
@@ -1302,6 +1339,72 @@ class Worker:
                 f"(Task remains at #{BLOCKED_TAG}. Reply to the original "
                 f"question to unblock, or re-tag with #{AGENT_TAG} to retry.)"
             )
+
+    def _process_human_queue(self) -> None:
+        """Resolve open Human-queue cards whose `done_when` check now passes
+        (#852). Throttled to `settings.human_queue_poll_seconds` — `tick()`
+        itself may run far more often. Talks to the store through the HTTP
+        API, not the in-process TaskManager, matching every other cross-
+        process access in this worker (the worker and the API may run on
+        different hosts). Never raises: a listing failure, a single card's
+        check failure/error, or a resolve failure is logged and skipped —
+        the untouched card is picked up again next tick.
+        """
+        now = time.time()
+        if now - self._last_human_queue_check < settings.human_queue_poll_seconds:
+            return
+        self._last_human_queue_check = now
+
+        try:
+            resp = self._http.get(f"{self.api_base}/api/tasks/human-queue")
+            resp.raise_for_status()
+            cards = resp.json().get("cards", [])
+        except Exception as exc:
+            logger.warning("human-queue tick: failed to list cards: %s", exc)
+            return
+
+        for card in cards:
+            done_when = card.get("done_when")
+            if not done_when:
+                continue
+            try:
+                passed, check_desc = self._check_human_queue_done_when(done_when)
+            except Exception as exc:
+                logger.warning(
+                    "human-queue tick: done_when check errored for %s: %s", card.get("id"), exc
+                )
+                continue
+            if not passed:
+                continue
+            try:
+                resp = self._http.put(
+                    f"{self.api_base}/api/tasks/human-queue/{card['id']}/resolve",
+                    json={"note": f"Auto-resolved: {check_desc}"},
+                )
+                resp.raise_for_status()
+            except Exception as exc:
+                logger.warning("human-queue tick: failed to resolve %s: %s", card.get("id"), exc)
+                continue
+            logger.info("human-queue: resolved %s (%s)", card.get("id"), check_desc)
+
+    def _check_human_queue_done_when(self, done_when: dict) -> tuple[bool, str]:
+        """Evaluate one card's `done_when`. Returns `(passed, description)`;
+        raises on a malformed check or a request/IO error — the caller
+        treats that the same as a failed check (card left untouched)."""
+        dw_type = done_when.get("type")
+        if dw_type == "endpoint":
+            path = done_when["path"]
+            pointer = done_when.get("pointer", "")
+            equals = done_when.get("equals")
+            resp = self._http.get(f"{self.api_base}{path}", timeout=5.0)
+            resp.raise_for_status()
+            value = _resolve_json_pointer(resp.json(), pointer)
+            desc = f"endpoint {path}{pointer} == {equals!r}"
+            return value == equals, desc
+        if dw_type == "file_exists":
+            path = done_when["path"]
+            return os.path.exists(path), f"file_exists {path}"
+        raise ValueError(f"unsupported done_when type {dw_type!r}")
 
     def ask_user_via_telegram(
         self,
@@ -2418,6 +2521,18 @@ class Worker:
         )
         return self._codex_executor
 
+    def _get_hermes_executor(self):
+        """Lazy-construct the HermesExecutor for board-assigned #hermes
+        sessions (#851)."""
+        if self._hermes_executor is not None:
+            return self._hermes_executor
+        from api.services.agent_worker.hermes_executor import HermesExecutor
+        self._hermes_executor = HermesExecutor(
+            session_store=self.session_store,
+            transcript_store=self.transcript_store,
+        )
+        return self._hermes_executor
+
     def _fetch_task(self, task_id: str) -> dict[str, Any] | None:
         try:
             resp = self._http.get(f"{self.api_base}/api/tasks/{task_id}")
@@ -2494,6 +2609,17 @@ class Worker:
             budget=budget_json,
             expected_output=pre.expected_output,
             preset_class=pre.preset_class,
+        )
+        # (#851) Board-assignment fields — model/effort/host, plus
+        # assigned_by (bookkeeping only; routing itself already comes from
+        # the assignee tag, see assignment.py's module docstring and
+        # preflight's `_apply_route_corroboration`, which never
+        # second-guesses a tagged route). Set unconditionally: an
+        # untagged/non-board task's fields are simply empty, so this is a
+        # no-op write of NULLs for every pre-#851 task shape.
+        assignment = extract_assignment(task.get("fields"))
+        self.session_store.set_assignment(
+            task_id, host=assignment.host, model=assignment.model, effort=assignment.effort,
         )
         session = self.session_store.get(task_id)  # refresh
 
@@ -2608,6 +2734,22 @@ class Worker:
             # `_poll_managed_sessions` in the next tick will pick it up.
             if outcome.status == STATUS_FAILED:
                 self._handle_outcome(session, task, outcome)
+            return
+
+        # (#851) Hermes route: open a Hermes conversation with the card's
+        # title/notes as the opening turn. A single HTTP round trip to the
+        # configured backend — short enough (unlike the CLI routes below)
+        # to run inline on the tick thread rather than through the CLI
+        # dispatch pool.
+        if pre.routing == ROUTE_HERMES:
+            hermes = self._get_hermes_executor()
+            try:
+                outcome = hermes.execute(session, task)
+            except Exception as exc:
+                logger.exception("hermes executor crashed for %s: %s", task_id, exc)
+                self._mark_failed(session, task, f"executor crashed: {exc}")
+                return
+            self._handle_outcome(session, task, outcome)
             return
 
         # CLI routes (#claude → Claude Code, #codex → Codex). Synthesize the

--- a/api/services/atomic_write.py
+++ b/api/services/atomic_write.py
@@ -1,0 +1,54 @@
+"""Shared atomic file-write helper.
+
+Writes a temp file in the target's own directory, fsyncs it, then renames it
+into place with ``os.replace``. A reader (Obsidian, Syncthing, a watcher) that
+opens the target path mid-write always sees either the old content or the new
+content in full — never a partial write, since ``os.replace`` is atomic on
+the same filesystem and a temp file in the same directory guarantees that.
+
+Used by ``task_manager.py`` and ``scheduler_store.py`` so both vault stores
+share one atomic-write implementation instead of each hand-rolling it.
+"""
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Atomically write ``content`` to ``path``, creating parent dirs as needed."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def atomic_write_lines(
+    path: Path,
+    lines: list[str],
+    newline: str = "\n",
+    trailing_newline: bool = True,
+) -> None:
+    """Atomically write ``lines`` to ``path``, joined by ``newline``.
+
+    ``newline`` and ``trailing_newline`` let a caller preserve a file's
+    original line-terminator convention (e.g. CRLF) and whether it ended
+    with a trailing terminator, across a rewrite that only touches a few
+    lines. ``scheduler_store.py`` never calls this helper (it writes whole
+    files via ``atomic_write_text``), so its behavior is unaffected by
+    these defaults.
+    """
+    content = newline.join(lines)
+    if trailing_newline:
+        content += newline
+    atomic_write_text(path, content)

--- a/api/services/human_queue.py
+++ b/api/services/human_queue.py
@@ -1,0 +1,307 @@
+"""Human queue: fire-and-forget cards any agent can file for the operator (#852).
+
+A human-queue card is a task (`api/services/task_manager.py`) with tag
+`human` and status `blocked` ("open"). This module is the single place that
+knows the card shape (`fields`: `key`, `source_host`, `source_cwd`,
+`source_session`, `done_when`) and its dedupe/resolve rules, so the REST
+routes (`api/routes/tasks.py`) and the native chat tool (`api/services/
+agent_tools.py`) both agree on it. The morning briefing surfaces open cards
+by calling the native chat tool's `list` action directly, the same way
+`/chat` does, rather than through a helper here. The worker's `done_when`
+poll tick (`api/services/agent_worker/worker.py`) talks to this queue over
+the HTTP API instead — see that module for why.
+
+`done_when` is stored as a compact JSON string in the `done_when` field
+(fields values may not contain a newline or `<!--`, but JSON free of those
+round-trips cleanly through the markdown task line — see
+`task_manager._validate_text_fields`).
+"""
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from api.services.task_manager import Task, get_task_manager
+
+logger = logging.getLogger(__name__)
+
+TAG = "human"
+STATUS_OPEN = "blocked"
+
+# `done_when` types. Deliberately excludes a `shell` type — a remote-
+# execution surface reachable by any agent (see the issue's Out of Scope).
+_ENDPOINT_TYPE = "endpoint"
+_FILE_EXISTS_TYPE = "file_exists"
+
+# Dedupe key shape — kept narrow because a key is interpolated unescaped
+# into a URL path segment (`PUT /api/tasks/human-queue/{id_or_key}/resolve`
+# and the sync integration's `sync:<source>` keys); `/`, `?`, `#` would
+# split the path or start a query/fragment, making the card unresolvable
+# by key. Word characters plus `.`, `:`, `-` cover every key this codebase
+# files (`sync:gmail`, `monarch-reauth`) with room for more. `\Z` (not `$`)
+# so a trailing newline can't sneak past the anchor — `$` matches just
+# before a final `\n`, `re.match` doesn't require consuming the whole
+# string, so `"abc\n"` would otherwise pass.
+_KEY_RE = re.compile(r"^[\w.:-]+\Z")
+
+# `equals` must be JSON-scalar — anything else can't round-trip through the
+# compact JSON stored in the `done_when` field, or through the worker's `==`
+# comparison against a JSON-Pointer-extracted value.
+_SCALAR_TYPES = (str, int, float, bool, type(None))
+
+
+class DoneWhenError(ValueError):
+    """Raised for a malformed `done_when`. The route layer maps this to
+    HTTP 422, same as `task_manager.TaskManager`'s own `ValueError`s."""
+
+
+def _reject_bracket(name: str, value: str) -> None:
+    """`task_manager._validate_text_fields` rejects a `]` anywhere in a
+    `fields` value (done_when is stored as one compact-JSON fields value),
+    which would otherwise surface as an opaque `fields['done_when'] must
+    not contain ']'` error with no hint of which done_when key was at
+    fault. Check each string sub-value up front so the error names it."""
+    if "]" in value:
+        raise DoneWhenError(f"done_when.{name} must not contain ']'")
+
+
+def validate_done_when(done_when: Optional[dict]) -> Optional[dict]:
+    """Validate and normalize a `done_when` dict, or return None unchanged.
+
+    Only `{type: "endpoint", path, pointer, equals}` and
+    `{type: "file_exists", path}` are accepted; anything else raises
+    `DoneWhenError`. Not implemented as FastAPI/pydantic field validation —
+    `api/main.py`'s global `RequestValidationError` handler converts every
+    pydantic validation failure to HTTP 400, but the issue requires 422 for
+    an invalid `done_when` — so this is a manual check the route layer
+    catches and maps to 422 itself, matching the existing
+    `_require_valid_status` pattern in `api/routes/tasks.py`.
+
+    `path` (`endpoint`) must be a string starting with `/` and not `//` —
+    the worker builds the request URL as `f"{api_base}{path}"`
+    (`agent_worker/worker.py`), so an unvalidated `path` like `@host/x` or
+    `//host/x` would re-parse the authority and make the worker's
+    `done_when` poll an SSRF primitive reachable by any agent that can file
+    a card. For `endpoint`, `path` also may not contain `?` or `#` — a
+    query string would let the filer smuggle request parameters into the
+    worker's poll GET, a query-driven side-effecting local request
+    reachable the same way; `file_exists` `path` must be a non-empty
+    string. `pointer` must be a string; `equals` must be a JSON scalar.
+    """
+    if done_when is None:
+        return None
+    if not isinstance(done_when, dict):
+        raise DoneWhenError("done_when must be an object")
+    dw_type = done_when.get("type")
+    if dw_type == _ENDPOINT_TYPE:
+        missing = [k for k in ("path", "pointer", "equals") if k not in done_when]
+        if missing:
+            raise DoneWhenError(
+                f"done_when type 'endpoint' missing required key(s): {', '.join(missing)}"
+            )
+        path, pointer, equals = done_when["path"], done_when["pointer"], done_when["equals"]
+        if not isinstance(path, str) or not path.startswith("/") or path.startswith("//"):
+            raise DoneWhenError("done_when.path must be a string starting with '/' (not '//')")
+        if "?" in path or "#" in path:
+            # A query string or fragment lets the filer smuggle arbitrary
+            # query parameters into the worker's poll GET — a query-driven
+            # side-effecting local request reachable by any agent that can
+            # file a card. `path` is meant to name a fixed status endpoint,
+            # not carry request parameters.
+            raise DoneWhenError("done_when.path must not contain '?' or '#'")
+        if not isinstance(pointer, str):
+            raise DoneWhenError("done_when.pointer must be a string")
+        if not isinstance(equals, _SCALAR_TYPES):
+            raise DoneWhenError("done_when.equals must be a string, number, boolean, or null")
+        _reject_bracket("path", path)
+        _reject_bracket("pointer", pointer)
+        if isinstance(equals, str):
+            _reject_bracket("equals", equals)
+        return {
+            "type": _ENDPOINT_TYPE,
+            "path": path,
+            "pointer": pointer,
+            "equals": equals,
+        }
+    if dw_type == _FILE_EXISTS_TYPE:
+        if "path" not in done_when:
+            raise DoneWhenError("done_when type 'file_exists' missing required key: path")
+        path = done_when["path"]
+        if not isinstance(path, str) or not path:
+            raise DoneWhenError("done_when.path must be a non-empty string")
+        _reject_bracket("path", path)
+        return {"type": _FILE_EXISTS_TYPE, "path": path}
+    raise DoneWhenError(
+        f"invalid done_when type {dw_type!r}; must be 'endpoint' or 'file_exists'"
+    )
+
+
+def _has_tag(task: Task, tag: str) -> bool:
+    return any(t.lstrip("#").lower() == tag for t in task.tags)
+
+
+def _find_open_card_by_key(key: str) -> Optional[Task]:
+    manager = get_task_manager()
+    for t in manager.list_tasks(tag=TAG, status=STATUS_OPEN):
+        if t.fields.get("key") == key:
+            return t
+    return None
+
+
+def _find_any_card(id_or_key: str) -> Optional[Task]:
+    """Find the human-queue (tag `human`) card matched by task id or dedupe
+    key, for resolve. The key lookup is OPEN-only (`_find_open_card_by_key`)
+    rather than an all-status scan: `resolve_card` only ever resolves an
+    open card anyway, and once a key has both a done card (from a prior
+    resolve) and a reopened open card, an all-status scan could return
+    either one depending on list order — sometimes the done card, which
+    `resolve_card` then rejects as not-open, turning a legitimate
+    resolve-by-key into a spurious 404. An id or key that only matches a
+    non-human task, or matches nothing, is "not found" from this queue's
+    perspective.
+    """
+    manager = get_task_manager()
+    task = manager.get(id_or_key)
+    if task is not None and _has_tag(task, TAG):
+        return task
+    return _find_open_card_by_key(id_or_key)
+
+
+def add_card(
+    title: str,
+    notes: Optional[str] = None,
+    key: Optional[str] = None,
+    done_when: Optional[dict] = None,
+    source_host: Optional[str] = None,
+    source_cwd: Optional[str] = None,
+    source_session: Optional[str] = None,
+) -> Task:
+    """File a human-queue card, or update the matching OPEN card if `key`
+    is already open — no duplicate, notes replaced, `updated_at` advances
+    (`TaskManager.update` always restamps it). A `key` whose only match is a
+    DONE card is treated as unclaimed: a fresh open card is created.
+
+    Raises `DoneWhenError` (422) for a malformed `done_when`, or `ValueError`
+    (422) for `title`/`notes`/field content that would corrupt the task line,
+    or a `key` that doesn't match `^[\\w.:-]+$` — see
+    `task_manager._validate_text_fields`. Never touches the calling
+    session's own status; this is fire-and-forget, unlike the worker's
+    blocking `lifeos_agent_user_ask`.
+    """
+    if key and not _KEY_RE.match(key):
+        raise ValueError(f"key {key!r} must match ^[\\w.:-]+\\Z (letters, digits, '.', ':', '-', '_')")
+    if key and not key.strip("."):
+        # A key of only dots ("." or "..") passes _KEY_RE but is a path
+        # segment that URL clients normalize away (dot-segment resolution,
+        # RFC 3986 §5.2.4) before it ever reaches the resolve route,
+        # making the card unresolvable by key.
+        raise ValueError(f"key {key!r} must contain at least one character other than '.'")
+    validated_done_when = validate_done_when(done_when)
+    fields: dict[str, str] = {}
+    if key:
+        fields["key"] = key
+    if source_host:
+        fields["source_host"] = source_host
+    if source_cwd:
+        fields["source_cwd"] = source_cwd
+    if source_session:
+        fields["source_session"] = source_session
+    if validated_done_when is not None:
+        fields["done_when"] = json.dumps(validated_done_when, separators=(",", ":"))
+
+    manager = get_task_manager()
+    existing = _find_open_card_by_key(key) if key else None
+    if existing is not None:
+        update_kwargs: dict[str, Any] = {"notes": notes}
+        if fields:
+            update_kwargs["fields"] = fields
+        task = manager.update(existing.id, **update_kwargs)
+        if task is not None:
+            return task
+        # Rare race: the card was deleted between the lookup above and the
+        # update (e.g. an operator deleted it by hand in Obsidian just now).
+        # Fall through and file a fresh card rather than raising.
+
+    return manager.create(
+        description=title,
+        status=STATUS_OPEN,
+        tags=[TAG],
+        notes=notes,
+        fields=fields,
+    )
+
+
+def resolve_card(id_or_key: str, note: Optional[str] = None) -> Optional[Task]:
+    """Mark the OPEN human-queue card matched by task id or dedupe key done,
+    appending `note` to its notes body. Returns None if no open card matches
+    — the route layer maps that to HTTP 404."""
+    card = _find_any_card(id_or_key)
+    if card is None or card.status != STATUS_OPEN:
+        return None
+
+    resolution = f"Resolved: {note}" if note else "Resolved."
+    new_notes = f"{card.notes}\n\n{resolution}" if card.notes else resolution
+    return get_task_manager().update(card.id, status="done", notes=new_notes)
+
+
+def _age_hours(task: Task, now: Optional[datetime] = None) -> Optional[float]:
+    """Hours since `updated_at` — for a card that has never been touched
+    since filing, `TaskManager.create` stamps `updated_at` at creation time,
+    so this is the card's age. Refiling an existing open card (dedupe)
+    advances `updated_at`, resetting the age clock — intentional: it means
+    an agent re-observed the same problem just now."""
+    if not task.updated_at:
+        return None
+    try:
+        ts = datetime.fromisoformat(task.updated_at)
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    now = now or datetime.now(timezone.utc)
+    return round((now - ts).total_seconds() / 3600.0, 1)
+
+
+def _card_to_dict(task: Task, now: Optional[datetime] = None) -> dict:
+    """Build the dict shape returned by the REST list route, the native
+    chat tool, and (via the REST route) the worker's `done_when` poll —
+    this is the single read path all three share. `done_when` is re-run
+    through `validate_done_when` here, not just at write time
+    (`add_card`): the generic task-update API can write directly to a
+    task's `fields`, so a stored `done_when` isn't guaranteed to still be
+    the shape the write path validated. An invalid or malformed value
+    (including the SSRF-shaped paths `validate_done_when` rejects) is
+    dropped to `None` rather than handed to the worker, which builds a
+    request URL directly from `done_when.path`."""
+    done_when = None
+    raw = task.fields.get("done_when")
+    if raw:
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("human_queue: card %s has unparseable done_when field", task.id)
+        else:
+            try:
+                done_when = validate_done_when(parsed)
+            except DoneWhenError:
+                logger.warning("human_queue: card %s has invalid done_when field", task.id)
+    return {
+        "id": task.id,
+        "title": task.description,
+        "key": task.fields.get("key"),
+        "notes": task.notes,
+        "age_hours": _age_hours(task, now),
+        "source_host": task.fields.get("source_host"),
+        "source_cwd": task.fields.get("source_cwd"),
+        "source_session": task.fields.get("source_session"),
+        "done_when": done_when,
+    }
+
+
+def list_open_cards() -> list[dict]:
+    """Open (`blocked`, tag `human`) cards as plain dicts — the shape both
+    the REST route and the native chat tool return."""
+    manager = get_task_manager()
+    now = datetime.now(timezone.utc)
+    return [_card_to_dict(t, now) for t in manager.list_tasks(tag=TAG, status=STATUS_OPEN)]

--- a/api/services/scheduler_store.py
+++ b/api/services/scheduler_store.py
@@ -46,6 +46,7 @@ from croniter import croniter
 from zoneinfo import ZoneInfo
 
 from config.settings import settings
+from api.services.atomic_write import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -398,7 +399,7 @@ class SchedulerStore:
             "last_updated": datetime.now(timezone.utc).isoformat(),
             "schedules": [e.to_dict() for e in self._entries.values()],
         }
-        self.index_path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+        atomic_write_text(self.index_path, json.dumps(data, indent=2, default=str))
         self._write_dashboard()
 
     # ------------------------------------------------------------------
@@ -411,12 +412,12 @@ class SchedulerStore:
         return []
 
     def _write_inbox_lines(self, lines: list[str]):
-        self.inbox_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        atomic_write_text(self.inbox_path, "\n".join(lines) + "\n")
 
     def _ensure_inbox(self):
         if not self.inbox_path.exists():
-            self.inbox_path.write_text(
-                "---\ntype: scheduler\n---\n# Scheduler Inbox\n\n", encoding="utf-8"
+            atomic_write_text(
+                self.inbox_path, "---\ntype: scheduler\n---\n# Scheduler Inbox\n\n"
             )
 
     def _insert_block_at_top(self, block: list[str]):
@@ -662,7 +663,7 @@ class SchedulerStore:
                 return  # no-op write avoids triggering the watcher
         except Exception:
             pass
-        dashboard.write_text(content, encoding="utf-8")
+        atomic_write_text(dashboard, content)
 
     def _build_dashboard_content(self) -> str:
         now = datetime.now(timezone.utc)

--- a/api/services/task_manager.py
+++ b/api/services/task_manager.py
@@ -9,18 +9,29 @@ Task line format (Dataview inline fields):
 
 Storage: LifeOS/Tasks/{Context}.md files in the vault
 Index:   data/task_index.json for fast API queries
+
+Tasks are addressed by their ``<!-- id:xxxx -->`` comment, not by cached line
+number — a write locates its task's block by id on every mutation, exactly
+like ``scheduler_store.py`` locates schedule blocks. This is what lets a task
+survive an external edit that inserts lines above it before the file watcher
+reindexes. ``line_number``/``source_file`` on ``Task`` remain informational
+(refreshed after every write) but are never used to address a write.
+
+See docs/specs/technical/task-management.md for the full design.
 """
+import copy
 import json
 import logging
 import re
 import threading
 import uuid
 from dataclasses import dataclass, field, asdict
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, timedelta, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from config.settings import settings
+from api.services.atomic_write import atomic_write_text, atomic_write_lines
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +51,79 @@ SYMBOL_TO_STATUS = {v: k for k, v in STATUS_TO_SYMBOL.items()}
 
 VALID_STATUSES = set(STATUS_TO_SYMBOL.keys())
 
+# Inline fields with a dedicated Task attribute — everything else parsed from
+# `[key:: value]` lands in `Task.fields` and round-trips untouched, which is
+# how operator fields (host, effort, model, key) and any future field survive
+# without parser changes.
+_KNOWN_FIELD_KEYS = {"due", "priority", "created", "done", "cancelled", "updated"}
+
+# Field keys that already address a dedicated Task attribute (or the id
+# comment itself) — accepting them through the free-form `fields` dict would
+# let a caller write a second, conflicting `[key:: value]` onto the line, or
+# forge `[id:: ...]`/`[updated:: ...]` outright. Rejected by
+# `_validate_text_fields`.
+_RESERVED_FIELD_KEYS = _KNOWN_FIELD_KEYS | {"id"}
+_FIELD_KEY_RE = re.compile(r"^\w+$")
+
+# Retries after an initial write attempt that loses a compare-and-swap race
+# against a concurrent external edit (see TaskManager._cas_rewrite).
+_CAS_MAX_RETRIES = 3
+
+
+def _validate_text_fields(
+    description: Optional[str] = None,
+    notes: Optional[str] = None,
+    fields: Optional[dict] = None,
+) -> None:
+    """Reject description/notes/fields content that would corrupt the task
+    line's format or hijack another task's id comment when written back.
+
+    A newline in `description` or a `fields` value would split the single
+    checkbox line; a `]` would truncate an inline field and leak the rest
+    into the description; an HTML comment opener (`<!--`) could forge a new
+    `<!-- id:.. -->`, hijacking another task's id on the next reindex. Notes
+    lines are allowed to be multi-line (that's their whole point) but not
+    `\\r` (would desync from the `\\n`-joined body) or `<!--`. A `fields` key
+    must be a bare word (`_format_task_line` interpolates it directly as
+    `[key:: value]`) and must not shadow a reserved key (see
+    `_RESERVED_FIELD_KEYS`).
+
+    Raises `ValueError` — never silently truncates or strips, since that
+    would surprise the caller by saving something other than what was sent.
+    The route layer maps `ValueError` to HTTP 422.
+    """
+    if description is not None:
+        for bad in ("\n", "\r", "]", "<!--"):
+            if bad in description:
+                raise ValueError(f"description must not contain {bad!r}")
+    if notes is not None:
+        for line in notes.split("\n"):
+            for bad in ("\r", "<!--"):
+                if bad in line:
+                    raise ValueError(f"notes must not contain {bad!r}")
+    if fields:
+        for key, value in fields.items():
+            if not _FIELD_KEY_RE.match(key):
+                raise ValueError(f"invalid fields key {key!r}: must match ^\\w+$")
+            if key in _RESERVED_FIELD_KEYS:
+                raise ValueError(f"'{key}' is a reserved field and cannot be set via fields")
+            if value is None:
+                continue
+            for bad in ("\n", "\r", "]", "<!--"):
+                if bad in value:
+                    raise ValueError(f"fields[{key!r}] must not contain {bad!r}")
+
+
+class TaskConflictError(Exception):
+    """Raised when a write loses the compare-and-swap race against a
+    concurrent external edit `_CAS_MAX_RETRIES` times in a row. The route
+    layer maps this to HTTP 409."""
+
+
+class _TagAbsentError(Exception):
+    """Internal signal: swap_tag's `from_tag` is no longer present after a
+    CAS retry re-read the task (e.g. someone else already swapped it)."""
+
 
 @dataclass
 class Task:
@@ -53,8 +137,11 @@ class Task:
     created_date: str = ""  # YYYY-MM-DD
     done_date: Optional[str] = None  # YYYY-MM-DD
     cancelled_date: Optional[str] = None  # YYYY-MM-DD
+    updated_at: Optional[str] = None  # ISO-8601 with UTC offset
     tags: list[str] = field(default_factory=list)
     reminder_id: Optional[str] = None
+    notes: Optional[str] = None
+    fields: dict[str, str] = field(default_factory=dict)
     source_file: str = ""
     line_number: int = 0
 
@@ -66,11 +153,62 @@ class Task:
         # Handle tags being stored as non-list
         if "tags" in data and not isinstance(data.get("tags"), list):
             data["tags"] = []
+        if "fields" in data and not isinstance(data.get("fields"), dict):
+            data["fields"] = {}
         return cls(**{k: data[k] for k in cls.__dataclass_fields__ if k in data})
 
 
 def _today() -> str:
     return date.today().isoformat()
+
+
+def _now_iso() -> str:
+    """Current time as ISO-8601 with an explicit UTC offset."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _mtime_or_none(path: Path) -> Optional[int]:
+    try:
+        return path.stat().st_mtime_ns
+    except FileNotFoundError:
+        return None
+
+
+def _read_lines(path: Path) -> list[str]:
+    if path.exists():
+        return path.read_text(encoding="utf-8").splitlines()
+    return []
+
+
+def _read_lines_with_terminator(path: Path) -> tuple[list[str], str, bool]:
+    """Read `path` split into lines (terminators stripped) plus its detected
+    line terminator and whether it ended with a trailing terminator — both
+    needed to preserve a file's original formatting across a rewrite that
+    only touches a few lines. Reads raw bytes (not `Path.read_text`, whose
+    text-mode universal-newline translation would silently turn CRLF into
+    LF before we ever got a look at it). Missing/empty file → ([], "\n",
+    True), matching the append-a-trailing-newline default most vault files
+    already have."""
+    if not path.exists():
+        return [], "\n", True
+    raw = path.read_bytes()
+    if not raw:
+        return [], "\n", True
+    newline = "\r\n" if b"\r\n" in raw else "\n"
+    trailing_newline = raw.endswith(newline.encode("ascii"))
+    return raw.decode("utf-8").splitlines(), newline, trailing_newline
+
+
+# Syncthing conflict copies and temp files: never indexed as a task source,
+# never trigger or survive a reindex. Exposed read-only via list_conflicts().
+# Matches the substring regardless of the timestamp/suffix that follows it,
+# per the criterion "*.sync-conflict-*" (not just Syncthing's own format).
+_CONFLICT_RE = re.compile(r"\.sync-conflict-")
+
+
+def is_conflict_file(path: Path) -> bool:
+    name = path.name
+    return bool(_CONFLICT_RE.search(name)) or name.startswith(".syncthing.")
 
 
 class TaskManager:
@@ -79,6 +217,15 @@ class TaskManager:
 
     Markdown files in LifeOS/Tasks/ are the source of truth.
     data/task_index.json is a query cache rebuilt from markdown.
+
+    Writes locate their task's block by id (`_find_task_block_span`) rather
+    than by cached line number, so a concurrent external edit that shifts
+    line numbers can't misdirect a write — mirroring `SchedulerStore`. Each
+    write is protected by a compare-and-swap on the file's mtime
+    (`_cas_rewrite`): if the mtime changes between our read and our rename,
+    someone else wrote to the file in between, so we reindex (absorbing
+    their change) and retry, up to `_CAS_MAX_RETRIES` times, before raising
+    `TaskConflictError`.
     """
 
     TASKS_FOLDER = "LifeOS/Tasks"
@@ -88,7 +235,20 @@ class TaskManager:
         self.index_path = Path(index_path) if index_path else DEFAULT_INDEX_PATH
         self.tasks_dir = self.vault_path / self.TASKS_FOLDER
         self._tasks: dict[str, Task] = {}
-        self._lock = threading.Lock()
+        # Exact raw main-line text last written or seen for each task id,
+        # this process's lifetime only (never persisted — see docs/specs/
+        # technical/task-management.md "External-edit detection" for why a
+        # sidecar file isn't needed). Used to tell a genuine external edit
+        # apart from our own prior write echoing back through the watcher;
+        # comparing against this exact string (rather than reformatting the
+        # prior Task and hoping it matches) is what keeps a hand-authored
+        # line's exact formatting — no "TODO", no created date — stable
+        # across repeated reindexes instead of getting rewritten every time.
+        self._last_written_line: dict[str, str] = {}
+        # Reentrant: a CAS retry inside a mutating call (create/update/
+        # swap_tag/delete, all lock-held) invokes reindex_file(), which also
+        # takes this lock — a plain Lock would self-deadlock on that retry.
+        self._lock = threading.RLock()
 
         self.index_path.parent.mkdir(parents=True, exist_ok=True)
         self.tasks_dir.mkdir(parents=True, exist_ok=True)
@@ -118,10 +278,10 @@ class TaskManager:
         """Persist index to disk."""
         data = {
             "description": "LifeOS Task Index (cache — regenerated from vault markdown)",
-            "last_updated": datetime.utcnow().isoformat(),
+            "last_updated": _now_iso(),
             "tasks": [t.to_dict() for t in self._tasks.values()],
         }
-        self.index_path.write_text(json.dumps(data, indent=2, default=str))
+        atomic_write_text(self.index_path, json.dumps(data, indent=2, default=str))
 
     # ------------------------------------------------------------------
     # CRUD
@@ -131,38 +291,56 @@ class TaskManager:
         self,
         description: str,
         context: str = "Inbox",
+        status: str = "todo",
         priority: str = "",
         due_date: Optional[str] = None,
         tags: Optional[list[str]] = None,
         reminder_id: Optional[str] = None,
+        notes: Optional[str] = None,
+        fields: Optional[dict[str, str]] = None,
     ) -> Task:
-        """Create a new task at the top of its context file, update index."""
+        """Create a new task at the top of its context file, update index.
+
+        Raises `ValueError` (-> HTTP 422 at the route layer) for an
+        unrecognized `status`, or for `description`/`notes`/`fields` content
+        that would corrupt the task line or hijack another task's id — see
+        `_validate_text_fields`.
+        """
+        if status is not None and status not in VALID_STATUSES:
+            raise ValueError(
+                f"Invalid status '{status}'. Must be one of: {', '.join(sorted(VALID_STATUSES))}"
+            )
+        _validate_text_fields(description=description, notes=notes, fields=fields)
         with self._lock:
             task = Task(
                 id=uuid.uuid4().hex[:8],
                 description=description,
-                status="todo",
+                status=status or "todo",
                 context=context,
                 priority=priority,
                 due_date=due_date,
                 created_date=_today(),
+                updated_at=_now_iso(),
                 tags=tags or [],
                 reminder_id=reminder_id,
+                notes=notes,
+                fields=dict(fields) if fields else {},
             )
-            file_path = self._get_context_file(context)
-            line = _format_task_line(task)
-            insert_at = _insert_task_at_top(file_path, line)
+            if task.status == "done" and not task.done_date:
+                task.done_date = _today()
+            if task.status == "cancelled" and not task.cancelled_date:
+                task.cancelled_date = _today()
 
-            # Bump line numbers for existing tasks in the same file that
-            # sit at or below the insertion point (pushed down by 1).
-            for t in self._tasks.values():
-                if t.source_file == str(file_path) and t.line_number >= insert_at:
-                    t.line_number += 1
+            file_path = self._get_context_file(context)
+            block = _format_task_block(task)
+            start_line = self._cas_insert_at_top(file_path, block)
 
             task.source_file = str(file_path)
-            task.line_number = insert_at
+            task.line_number = start_line
 
             self._tasks[task.id] = task
+            self._last_written_line[task.id] = block[0]
+            self._reposition_file(file_path)
             self._save_index()
             self._write_dashboard()
             logger.info(f"Created task {task.id}: {description}")
@@ -176,31 +354,84 @@ class TaskManager:
         return self.update(task_id, status="done")
 
     def update(self, task_id: str, **kwargs) -> Optional[Task]:
-        """Update a task. Supports: description, status, context, priority, due_date, tags."""
+        """Update a task. Supports: description, status, context, priority,
+        due_date, tags, notes, fields. `fields={"k": None}` removes key `k`;
+        `fields={"k": "v"}` sets it. Raises `TaskConflictError` (-> HTTP 409)
+        if the write keeps losing the CAS race against a concurrent edit;
+        `ValueError` (-> HTTP 422) for an unrecognized `status` or hostile
+        `description`/`notes`/`fields` content — see `_validate_text_fields`.
+        """
+        fields_patch = kwargs.pop("fields", None)
+        if "status" in kwargs and kwargs["status"] is not None and kwargs["status"] not in VALID_STATUSES:
+            raise ValueError(
+                f"Invalid status '{kwargs['status']}'. "
+                f"Must be one of: {', '.join(sorted(VALID_STATUSES))}"
+            )
+        _validate_text_fields(
+            description=kwargs.get("description"), notes=kwargs.get("notes"), fields=fields_patch
+        )
         with self._lock:
-            task = self._tasks.get(task_id)
-            if not task:
+            current = self._tasks.get(task_id)
+            if not current:
                 return None
 
-            old_context = task.context
+            old_context = current.context
             new_context = kwargs.get("context", old_context)
 
-            # Apply updates
-            for key, value in kwargs.items():
-                if key == "status" and value == "done" and task.status != "done":
-                    task.done_date = _today()
-                elif key == "status" and value == "cancelled" and task.status != "cancelled":
-                    task.cancelled_date = _today()
-                if hasattr(task, key) and value is not None:
-                    setattr(task, key, value)
+            def apply(t: Task) -> Task:
+                # Copy first — `t` is `self._tasks[task_id]` itself, and this
+                # closure is invoked fresh on every CAS retry via `compute()`
+                # (see `_cas_rewrite`). Mutating it in place would make a
+                # losing attempt's edits visible through `self.get(task_id)`
+                # immediately, even though nothing was ever persisted; only
+                # the CAS success branch below may rebind `self._tasks`.
+                t = copy.copy(t)
+                for key, value in kwargs.items():
+                    if key == "status" and value == "done" and t.status != "done":
+                        t.done_date = _today()
+                    elif key == "status" and value == "cancelled" and t.status != "cancelled":
+                        t.cancelled_date = _today()
+                    if hasattr(t, key) and value is not None:
+                        setattr(t, key, value)
+                if fields_patch:
+                    merged = dict(t.fields)
+                    for k, v in fields_patch.items():
+                        if v is None:
+                            merged.pop(k, None)
+                        else:
+                            merged[k] = v
+                    t.fields = merged
+                t.updated_at = _now_iso()
+                return t
 
-            # Context change = move between files
             if new_context != old_context:
-                self._move_task_between_files(task, old_context, new_context)
+                task = apply(current)
+                moved = self._move_task_between_files(task, old_context, new_context)
+                if not moved:
+                    # Task's block is no longer in its source file (an
+                    # external delete raced us) — reconcile like the
+                    # same-context branch does for `found=False` below,
+                    # rather than raising.
+                    self._tasks.pop(task_id, None)
+                    self._last_written_line.pop(task_id, None)
+                    self._save_index()
+                    self._write_dashboard()
+                    return None
+                self._tasks[task_id] = task
             else:
-                # Rewrite line in place
-                new_line = _format_task_line(task)
-                _replace_line_in_file(Path(task.source_file), task.line_number, new_line)
+                path = Path(current.source_file)
+
+                def compute() -> Task:
+                    return apply(self._tasks[task_id])
+
+                found, task = self._cas_rewrite(path, task_id, compute)
+                if not found:
+                    self._tasks.pop(task_id, None)
+                    self._last_written_line.pop(task_id, None)
+                    self._save_index()
+                    self._write_dashboard()
+                    return None
+                self._reposition_file(path)
 
             self._save_index()
             self._write_dashboard()
@@ -219,44 +450,63 @@ class TaskManager:
         from_norm = from_tag.lstrip("#").lower()
         to_norm = to_tag.lstrip("#")  # preserve operator-provided case
         with self._lock:
-            task = self._tasks.get(task_id)
-            if not task:
+            current = self._tasks.get(task_id)
+            if not current:
                 return False
+            if not any(t.lstrip("#").lower() == from_norm for t in current.tags):
+                return False
+
+            path = Path(current.source_file)
+
+            def compute() -> Task:
+                t = self._tasks[task_id]
+                try:
+                    idx = next(
+                        i for i, tag in enumerate(t.tags)
+                        if tag.lstrip("#").lower() == from_norm
+                    )
+                except StopIteration:
+                    raise _TagAbsentError()
+                # Copy first, same reasoning as `update.apply` — `t` is
+                # `self._tasks[task_id]` itself, and this closure runs fresh
+                # on every CAS retry; only the success branch in
+                # `_cas_rewrite` may rebind `self._tasks`.
+                new_task = copy.copy(t)
+                new_tags = list(t.tags)
+                new_tags[idx] = to_norm
+                new_task.tags = new_tags
+                new_task.updated_at = _now_iso()
+                return new_task
 
             try:
-                idx = next(
-                    i for i, t in enumerate(task.tags)
-                    if t.lstrip("#").lower() == from_norm
-                )
-            except StopIteration:
+                found, task = self._cas_rewrite(path, task_id, compute)
+            except _TagAbsentError:
+                return False
+            if not found:
+                self._tasks.pop(task_id, None)
+                self._last_written_line.pop(task_id, None)
+                self._save_index()
+                self._write_dashboard()
                 return False
 
-            new_tags = list(task.tags)
-            new_tags[idx] = to_norm
-            task.tags = new_tags
-
-            new_line = _format_task_line(task)
-            _replace_line_in_file(Path(task.source_file), task.line_number, new_line)
+            self._reposition_file(path)
             self._save_index()
             self._write_dashboard()
             logger.info(f"swap_tag {task_id}: {from_norm} → {to_norm}")
             return True
 
     def delete(self, task_id: str) -> bool:
-        """Remove a task from its file and index."""
+        """Remove a task (and any notes body) from its file and index."""
         with self._lock:
             task = self._tasks.get(task_id)
             if not task:
                 return False
 
-            _remove_line_from_file(Path(task.source_file), task.line_number)
-
-            # Adjust line numbers for tasks in same file after deleted line
-            for t in self._tasks.values():
-                if t.source_file == task.source_file and t.line_number > task.line_number:
-                    t.line_number -= 1
-
-            del self._tasks[task_id]
+            path = Path(task.source_file)
+            self._cas_rewrite(path, task_id, lambda: None)
+            self._tasks.pop(task_id, None)
+            self._last_written_line.pop(task_id, None)
+            self._reposition_file(path)
             self._save_index()
             self._write_dashboard()
             logger.info(f"Deleted task {task_id}")
@@ -302,16 +552,49 @@ class TaskManager:
             for tag, count in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0].lower()))
         ]
 
+    def list_conflicts(self) -> list[dict]:
+        """List Syncthing conflict/temp files sitting in the tasks folder.
+
+        Never indexed as tasks and never reindexed — surfaced here so a
+        client (the board) can warn the operator to resolve them by hand.
+        """
+        if not self.tasks_dir.exists():
+            return []
+        results = []
+        for p in self.tasks_dir.iterdir():
+            if p.is_file() and is_conflict_file(p):
+                try:
+                    mtime = datetime.fromtimestamp(p.stat().st_mtime, tz=timezone.utc).isoformat()
+                except OSError:
+                    continue
+                results.append({"name": p.name, "mtime": mtime})
+        results.sort(key=lambda r: r["mtime"], reverse=True)
+        return results
+
     # ------------------------------------------------------------------
     # Reindex
     # ------------------------------------------------------------------
 
     def reindex_file(self, file_path: str):
-        """Parse a single task file and update index entries for it."""
+        """Parse a single task file and update index entries for it.
+
+        Also performs id write-back (a task line lacking `<!-- id:.. -->`
+        gets one appended, minimally, with every other byte of the line and
+        every non-task line untouched) and external-edit detection (a task
+        line that no longer matches what the API last wrote gets a fresh
+        `[updated::]` stamp; every other line is left alone). The write-back
+        (if any) is itself CAS-protected on the file's mtime, bounded to
+        `_CAS_MAX_RETRIES` re-read-and-reparse attempts; on persistent
+        conflict it logs a warning and skips the write for this pass rather
+        than raising — the watcher will fire again for whatever caused the
+        conflict.
+        """
         path = Path(file_path)
         # Dashboard.md is auto-generated; never index it as a task source.
         # (Also prevents a watcher feedback loop when we regenerate it below.)
         if path.name == "Dashboard.md":
+            return
+        if is_conflict_file(path):
             return
 
         if not path.exists():
@@ -320,55 +603,341 @@ class TaskManager:
                 to_remove = [tid for tid, t in self._tasks.items() if t.source_file == str(path)]
                 for tid in to_remove:
                     del self._tasks[tid]
+                    self._last_written_line.pop(tid, None)
                 if to_remove:
                     self._save_index()
                     self._write_dashboard()
             return
 
         with self._lock:
-            # Remove old entries for this file
-            to_remove = [tid for tid, t in self._tasks.items() if t.source_file == str(path)]
+            file_tasks: dict[str, Task] = {}
+            for attempt in range(_CAS_MAX_RETRIES + 1):
+                mtime_before = _mtime_or_none(path)
+                try:
+                    lines, newline, trailing_newline = _read_lines_with_terminator(path)
+                except Exception as e:
+                    logger.warning(f"Could not read {file_path}: {e}")
+                    return
+
+                # Snapshot before this attempt's parse so an abandoned
+                # attempt (retry or final skip below) can't leave behind
+                # `_last_written_line` entries seeded from a parse that
+                # never reached disk — those would let a later CAS check
+                # believe an unwritten (possibly re-minted) id's line is
+                # the last-known-good one.
+                last_written_snapshot = dict(self._last_written_line)
+                new_lines, file_tasks, rewrite_needed = self._reparse_lines(
+                    lines, str(path), self._tasks
+                )
+                if not rewrite_needed:
+                    break
+
+                mtime_now = _mtime_or_none(path)
+                if mtime_now == mtime_before:
+                    atomic_write_lines(path, new_lines, newline=newline, trailing_newline=trailing_newline)
+                    break
+                self._last_written_line = last_written_snapshot
+                if attempt >= _CAS_MAX_RETRIES:
+                    logger.warning(
+                        f"reindex_file: persistent write conflict on {file_path}; "
+                        "skipping the id/restamp write-back this pass"
+                    )
+                    # Abandon entirely — do not merge this parse's tasks
+                    # (some ids may have been freshly minted and never
+                    # written to disk) into the index, and do not touch
+                    # the index file or dashboard. The watcher will fire
+                    # again for whatever caused the conflict.
+                    return
+                # Someone else wrote in between — re-read and re-parse
+                # against the freshest content on the next attempt.
+
+            # Only tasks NOT present in this parse are gone from this file —
+            # everything `_reparse_lines` just repopulated must survive, or
+            # every reindex would immediately forget the external edit it
+            # was meant to detect (a task restamped this pass would vanish
+            # from the index a moment after being restamped).
+            to_remove = [
+                tid for tid, t in self._tasks.items()
+                if t.source_file == str(path) and tid not in file_tasks
+            ]
             for tid in to_remove:
                 del self._tasks[tid]
-
-            # Parse file
-            try:
-                lines = path.read_text(encoding="utf-8").splitlines()
-            except Exception as e:
-                logger.warning(f"Could not read {file_path}: {e}")
-                return
-
-            for line_num, line in enumerate(lines, start=1):
-                task = _parse_task_line(line, str(path), line_num)
-                if task:
-                    self._tasks[task.id] = task
+                self._last_written_line.pop(tid, None)
+            self._tasks.update(file_tasks)
 
             self._save_index()
             self._write_dashboard()
 
     def rebuild_index(self):
-        """Full re-parse of all LifeOS/Tasks/*.md files."""
-        self._tasks.clear()
-        if not self.tasks_dir.exists():
-            self._save_index()
-            return
+        """Full re-parse of all LifeOS/Tasks/*.md files.
 
-        for md_file in sorted(self.tasks_dir.glob("*.md")):
-            if md_file.name == "Dashboard.md":
-                continue
-            try:
-                lines = md_file.read_text(encoding="utf-8").splitlines()
-            except Exception as e:
-                logger.warning(f"Could not read {md_file}: {e}")
-                continue
-            for line_num, line in enumerate(lines, start=1):
-                task = _parse_task_line(line, str(md_file), line_num)
-                if task:
-                    self._tasks[task.id] = task
+        Ids are deduplicated across the whole rebuild, not just within a
+        single file: `seen_ids` threads forward so a task carrying an id
+        already claimed by an earlier file in this same pass is treated
+        exactly like a same-file duplicate (fresh id minted, old comment
+        stripped) rather than letting the last file parsed silently win in
+        `self._tasks`. A single-file `reindex_file` cannot make this call —
+        it has no way to tell a genuine cross-file duplicate from an
+        operator cutting a task line out of one file and pasting it into
+        another — so it always passes no `seen_ids` and keeps its existing
+        single-file semantics.
+        """
+        prior = self._tasks
+        rebuilt: dict[str, Task] = {}
+        seen_ids: set[str] = set()
+        if self.tasks_dir.exists():
+            for md_file in sorted(self.tasks_dir.glob("*.md")):
+                if md_file.name == "Dashboard.md" or is_conflict_file(md_file):
+                    continue
+                try:
+                    lines, newline, trailing_newline = _read_lines_with_terminator(md_file)
+                except Exception as e:
+                    logger.warning(f"Could not read {md_file}: {e}")
+                    continue
+                new_lines, file_tasks, rewrite_needed = self._reparse_lines(
+                    lines, str(md_file), prior, seen_ids
+                )
+                if rewrite_needed:
+                    atomic_write_lines(md_file, new_lines, newline=newline, trailing_newline=trailing_newline)
+                rebuilt.update(file_tasks)
+                seen_ids.update(file_tasks.keys())
 
+        self._tasks = rebuilt
+        self._last_written_line = {
+            tid: line for tid, line in self._last_written_line.items() if tid in rebuilt
+        }
         self._save_index()
         self._write_dashboard()
         logger.info(f"Rebuilt task index: {len(self._tasks)} tasks")
+
+    def _reparse_lines(
+        self,
+        lines: list[str],
+        file_path: str,
+        prior: dict[str, Task],
+        seen_ids: Optional[set[str]] = None,
+    ) -> tuple[list[str], dict[str, Task], bool]:
+        """Parse `lines` (belonging to `file_path`) into fresh tasks.
+
+        Returns `(new_lines, tasks_for_this_file, rewrite_needed)`. Must be
+        called with `self._lock` held (reads `prior` for reminder_id merge-
+        forward, and `self._last_written_line` for external-edit detection).
+        A task lacking an id comment gets one appended to its raw line only
+        — nothing else about that line changes. A task whose raw line
+        differs from `self._last_written_line[task.id]` (the exact text we
+        last wrote or saw for it) is treated as an external edit: the parsed
+        values win and the line is rewritten with a fresh `[updated::]`
+        stamp. A task id with no prior record at all (first time this
+        process has seen it) is taken as-is, no restamp — there is nothing
+        to compare against. Every other line — task or not — is copied
+        through byte-for-byte. A checkbox line inside a fenced (``` or ~~~)
+        code block is never a task line (see `_iter_lines_with_fence_state`).
+        A second block carrying an id already claimed earlier in this parse
+        (same-file duplicate), or already present in the caller-supplied
+        `seen_ids` (a cross-file duplicate from an earlier file in the same
+        `rebuild_index` pass — `None` when called from `reindex_file`, which
+        only ever sees one file), is treated as if it had no id at all — its
+        stale/duplicated comment is replaced with a freshly minted one,
+        rather than left to fight the earlier occurrence for the same id on
+        every future parse.
+        """
+        out_lines: list[str] = []
+        file_tasks: dict[str, Task] = {}
+        rewrite_needed = False
+        fence = dict(_iter_lines_with_fence_state(lines))
+        idx, n = 0, len(lines)
+        while idx < n:
+            if fence.get(idx):
+                out_lines.append(lines[idx])
+                idx += 1
+                continue
+            block = _match_task_block(lines, idx, file_path)
+            if block is None:
+                out_lines.append(lines[idx])
+                idx += 1
+                continue
+            end, task, had_id = block
+            raw_main_line = lines[idx]
+            body_lines = lines[idx + 1:end]
+
+            if had_id and (
+                task.id in file_tasks or (seen_ids is not None and task.id in seen_ids)
+            ):
+                had_id = False
+                task.id = uuid.uuid4().hex[:8]
+                raw_main_line = _ID_RE.sub("", raw_main_line).rstrip()
+
+            if had_id:
+                prior_task = prior.get(task.id)
+                if prior_task is not None and prior_task.reminder_id is not None and task.reminder_id is None:
+                    task.reminder_id = prior_task.reminder_id
+                last_written = self._last_written_line.get(task.id)
+                if last_written is not None and last_written != raw_main_line:
+                    task.updated_at = _now_iso()
+                    new_main_line = _format_task_line(task)
+                    out_lines.append(new_main_line)
+                    out_lines.extend(body_lines)
+                    rewrite_needed = True
+                    self._last_written_line[task.id] = new_main_line
+                else:
+                    out_lines.append(raw_main_line)
+                    out_lines.extend(body_lines)
+                    self._last_written_line[task.id] = raw_main_line
+            else:
+                new_main_line = raw_main_line.rstrip("\n") + f" <!-- id:{task.id} -->"
+                out_lines.append(new_main_line)
+                out_lines.extend(body_lines)
+                rewrite_needed = True
+                self._last_written_line[task.id] = new_main_line
+
+            file_tasks[task.id] = task
+            idx = end
+
+        return out_lines, file_tasks, rewrite_needed
+
+    # ------------------------------------------------------------------
+    # Compare-and-swap file writes (id-addressed)
+    # ------------------------------------------------------------------
+
+    def _cas_rewrite(
+        self, path: Path, task_id: str, compute: Callable[[], Optional[Task]]
+    ) -> tuple[bool, Optional[Task]]:
+        """Rewrite (or delete) the block for `task_id` in `path`.
+
+        `compute()` is invoked fresh on every attempt against the current
+        `self._tasks[task_id]` and returns the `Task` to write, or `None` to
+        delete the block. Protected by compare-and-swap on the file's mtime:
+        read mtime, read+locate the block, compute the new content, then
+        check the mtime again right before writing. A mismatch means a
+        concurrent external writer touched the file in between — reindex
+        (absorbing their change) and retry, up to `_CAS_MAX_RETRIES` times,
+        then raise `TaskConflictError`.
+
+        Returns `(found, task_or_none)`. `found=False` means the task's block
+        was not present in the file at all (e.g. externally deleted) — not a
+        CAS conflict, so the caller should reconcile rather than retry.
+
+        Before computing the replacement, also checks whether the on-disk
+        block reflects an edit `reindex_file` hasn't absorbed yet — the raw
+        line differs from the last line the API wrote/saw, or the on-disk
+        notes body differs from the in-memory task's. Under the watcher's 2s
+        debounce this is the normal case for an edit that just landed, not a
+        rare race: without this check `compute()` would build its
+        replacement from stale in-memory state and silently overwrite the
+        edit. On either mismatch, absorb it via `reindex_file` and retry
+        (counts toward `_CAS_MAX_RETRIES`) instead of computing against
+        stale state.
+        """
+        for attempt in range(_CAS_MAX_RETRIES + 1):
+            mtime_before = _mtime_or_none(path)
+            lines, newline, trailing_newline = _read_lines_with_terminator(path)
+            span = _find_task_block_span(lines, task_id)
+            if span is None:
+                return False, None
+            start, end = span
+
+            if self._external_edit_pending(lines, start, task_id):
+                if attempt < _CAS_MAX_RETRIES:
+                    self.reindex_file(str(path))
+                    continue
+                raise TaskConflictError(f"Too many conflicting writes to {path}")
+
+            result = compute()
+            new_block = _format_task_block(result) if result is not None else []
+            new_lines = lines[:start] + new_block + lines[end:]
+            mtime_now = _mtime_or_none(path)
+            if mtime_now == mtime_before:
+                atomic_write_lines(path, new_lines, newline=newline, trailing_newline=trailing_newline)
+                if result is not None:
+                    self._tasks[task_id] = result
+                    self._last_written_line[task_id] = new_block[0]
+                else:
+                    self._last_written_line.pop(task_id, None)
+                return True, result
+            if attempt < _CAS_MAX_RETRIES:
+                self.reindex_file(str(path))
+                continue
+            raise TaskConflictError(f"Too many conflicting writes to {path}")
+        raise TaskConflictError(f"Too many conflicting writes to {path}")
+
+    def _external_edit_pending(self, lines: list[str], start: int, task_id: str) -> bool:
+        """True if the on-disk block at `lines[start]` carries an edit
+        `_cas_rewrite` hasn't absorbed into `self._tasks` yet: the raw line
+        text no longer matches the last line the API wrote or saw for this
+        id, or the on-disk notes body no longer matches the in-memory
+        task's. Must be called with `self._lock` held."""
+        last_written = self._last_written_line.get(task_id)
+        if last_written is not None and lines[start] != last_written:
+            return True
+        in_memory = self._tasks.get(task_id)
+        if in_memory is not None:
+            on_disk_block = _match_task_block(lines, start)
+            if on_disk_block is not None:
+                _, on_disk_task, _ = on_disk_block
+                if on_disk_task.notes != in_memory.notes:
+                    return True
+        return False
+
+    def _cas_insert_at_top(self, path: Path, block: list[str]) -> int:
+        """Insert `block` above the first existing task block. Returns its
+        1-indexed start line. CAS-protected: re-reads the file and retries
+        on a concurrent external write, up to `_CAS_MAX_RETRIES` times."""
+        for attempt in range(_CAS_MAX_RETRIES + 1):
+            mtime_before = _mtime_or_none(path)
+            lines, newline, trailing_newline = _read_lines_with_terminator(path)
+            fence = dict(_iter_lines_with_fence_state(lines))
+
+            first_idx = None
+            idx, n = 0, len(lines)
+            while idx < n:
+                if fence.get(idx):
+                    idx += 1
+                    continue
+                b = _match_task_block(lines, idx, str(path))
+                if b is not None:
+                    first_idx = idx
+                    break
+                idx += 1
+
+            if first_idx is None:
+                new_lines = lines + block if lines else list(block)
+                insert_at = len(lines) + 1
+            else:
+                new_lines = lines[:first_idx] + block + lines[first_idx:]
+                insert_at = first_idx + 1
+
+            mtime_now = _mtime_or_none(path)
+            if mtime_now == mtime_before:
+                atomic_write_lines(path, new_lines, newline=newline, trailing_newline=trailing_newline)
+                return insert_at
+            if attempt >= _CAS_MAX_RETRIES:
+                raise TaskConflictError(f"Too many conflicting writes to {path}")
+        raise TaskConflictError(f"Too many conflicting writes to {path}")
+
+    def _reposition_file(self, path: Path):
+        """Refresh `source_file`/`line_number` for every known task in `path`
+        from its current on-disk content. Purely informational bookkeeping —
+        writes never address by these fields, only by id."""
+        if not path.exists():
+            return
+        lines = _read_lines(path)
+        fence = dict(_iter_lines_with_fence_state(lines))
+        idx, n = 0, len(lines)
+        while idx < n:
+            if fence.get(idx):
+                idx += 1
+                continue
+            block = _match_task_block(lines, idx, str(path))
+            if block is None:
+                idx += 1
+                continue
+            end, task, had_id = block
+            if had_id:
+                existing = self._tasks.get(task.id)
+                if existing is not None:
+                    existing.source_file = str(path)
+                    existing.line_number = idx + 1
+            idx = end
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -382,26 +951,73 @@ class TaskManager:
                 f"---\ntype: tasks\ncontext: {context.lower()}\n---\n"
                 f"# {context} Tasks\n\n"
             )
-            file_path.write_text(template, encoding="utf-8")
+            atomic_write_text(file_path, template)
         return file_path
 
-    def _move_task_between_files(self, task: Task, old_context: str, new_context: str):
-        """Remove from old file, append to new file."""
-        old_path = Path(task.source_file)
-        _remove_line_from_file(old_path, task.line_number)
+    def _move_task_between_files(self, task: Task, old_context: str, new_context: str) -> bool:
+        """Move `task`'s block from its old context file to `new_context`'s.
 
-        # Adjust line numbers for tasks in old file after removed line
-        for t in self._tasks.values():
-            if t.source_file == str(old_path) and t.line_number > task.line_number:
-                t.line_number -= 1
+        Returns False if the task's block is no longer present in the
+        source file (externally deleted) — the caller should reconcile like
+        `update` does for `found=False`, not treat it as a conflict.
+
+        Inserts into the destination BEFORE removing from the source, so a
+        destination-side conflict can never lose the task: if the insert
+        raises, the source is untouched. If the source removal itself then
+        raises (a source-side conflict, after the insert already
+        succeeded), best-effort removes the just-inserted destination block
+        before re-raising, so the task isn't left duplicated in both files.
+
+        `self._last_written_line[task.id]` is updated to the destination's
+        just-written line only if the source-side removal raises (right
+        before the best-effort rollback), so that rollback's own
+        `_external_edit_pending` check compares against the destination
+        content it should — not a stale pointer at the source line — and
+        never mistakes the freshly inserted block for an unabsorbed
+        external edit. Leaving the pointer at the source line during the
+        ordinary (non-conflict) path avoids a spurious mismatch against the
+        untouched source line, which would otherwise trigger a needless
+        reindex and extra write on every ordinary move. If the rollback
+        still can't restore clean state, `self._tasks`/`_last_written_line`
+        are reset to their pre-move values before the original exception is
+        re-raised, so the index is never left pointing at a file with no
+        block for this id while the block survives intact elsewhere.
+        """
+        old_path = Path(task.source_file)
+        old_lines = _read_lines(old_path)
+        if _find_task_block_span(old_lines, task.id) is None:
+            return False
+
+        prev_task = self._tasks.get(task.id)
+        prev_line = self._last_written_line.get(task.id)
 
         new_path = self._get_context_file(new_context)
-        new_line = _format_task_line(task)
-        _append_to_file(new_path, new_line)
+        block = _format_task_block(task)
+        start_line = self._cas_insert_at_top(new_path, block)
+
+        try:
+            self._cas_rewrite(old_path, task.id, lambda: None)
+        except TaskConflictError:
+            self._last_written_line[task.id] = block[0]
+            try:
+                self._cas_rewrite(new_path, task.id, lambda: None)
+            except TaskConflictError:
+                pass
+            if prev_task is not None:
+                self._tasks[task.id] = prev_task
+            if prev_line is not None:
+                self._last_written_line[task.id] = prev_line
+            else:
+                self._last_written_line.pop(task.id, None)
+            raise
+        self._reposition_file(old_path)
 
         task.source_file = str(new_path)
-        task.line_number = _count_lines(new_path)
+        task.line_number = start_line
         task.context = new_context
+        self._last_written_line[task.id] = block[0]
+        self._reposition_file(new_path)
+        return True
 
     def _write_dashboard(self):
         """Regenerate Dashboard.md from current task state.
@@ -420,7 +1036,7 @@ class TaskManager:
                 return  # No-op write avoids triggering watchers
         except Exception:
             pass
-        dashboard.write_text(content, encoding="utf-8")
+        atomic_write_text(dashboard, content)
 
     def _build_dashboard_content(self) -> str:
         tasks = list(self._tasks.values())
@@ -562,16 +1178,47 @@ class TaskManager:
 # Module-level helpers (pure functions)
 # ======================================================================
 
-# Regex for parsing a task line
-_TASK_LINE_RE = re.compile(
-    r'^- \[(.)\] TODO\s+'   # checkbox + TODO keyword
-    r'(.+?)'                # description (non-greedy)
-    r'\s*$'                  # end of line
-)
-
 _INLINE_FIELD_RE = re.compile(r'\[(\w+)::\s*([^\]]*)\]')
 _TAG_RE = re.compile(r'#([\w-]+)')
 _ID_RE = re.compile(r'<!--\s*id:(\w+)\s*-->')
+# Any checkbox line counts as a task line — the literal "TODO" keyword is no
+# longer required to parse (kept only because _format_task_line still emits
+# it, for backward compatibility with existing vault content and the
+# Obsidian Tasks dashboard queries in Dashboard.md).
+_CHECKBOX_RE = re.compile(r'^- \[(.)\]\s+(?:TODO\s+)?')
+# Notes body: an indented blockquote line directly beneath a task line,
+# exactly like a scheduler entry's message_content body.
+_BODY_LINE_RE = re.compile(r'^\s+>\s?(.*)$')
+_BODY_INDENT = "    "
+
+_FENCE_RE = re.compile(r'^(```|~~~)')
+
+
+def _iter_lines_with_fence_state(lines: list[str]):
+    """Yield `(idx, in_fence)` for every line in `lines`. `in_fence` is True
+    for a line inside — or opening/closing — a ``` or ~~~ fenced code block.
+    A checkbox line inside a fence is documentation/example text, never a
+    real task: every scanner that walks task lines (`_reparse_lines`,
+    `_cas_insert_at_top`, `_find_task_block_span`, `_reposition_file`) skips
+    a line this marks `True` instead of handing it to `_match_task_block`.
+    """
+    in_fence = False
+    marker = None
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if in_fence:
+            yield idx, True
+            if stripped.startswith(marker):
+                in_fence = False
+                marker = None
+            continue
+        m = _FENCE_RE.match(stripped)
+        if m:
+            marker = m.group(1)
+            in_fence = True
+            yield idx, True
+        else:
+            yield idx, False
 
 
 def _format_task_line(task: Task) -> str:
@@ -584,11 +1231,21 @@ def _format_task_line(task: Task) -> str:
         parts.append(f"[due:: {task.due_date}]")
     if task.priority:
         parts.append(f"[priority:: {task.priority}]")
-    parts.append(f"[created:: {task.created_date}]")
+    # Omitted (not emitted as an empty field) when unset, e.g. a hand-
+    # authored line that only just got its id minted on reindex — a task
+    # created through the API always has one (create() sets it to today).
+    if task.created_date:
+        parts.append(f"[created:: {task.created_date}]")
     if task.done_date:
         parts.append(f"[done:: {task.done_date}]")
     if task.cancelled_date:
         parts.append(f"[cancelled:: {task.cancelled_date}]")
+    if task.updated_at:
+        parts.append(f"[updated:: {task.updated_at}]")
+
+    # Operator + unknown fields round-trip in their original order.
+    for key, value in task.fields.items():
+        parts.append(f"[{key}:: {value}]")
 
     # Tags
     for tag in task.tags:
@@ -601,17 +1258,33 @@ def _format_task_line(task: Task) -> str:
     return " ".join(parts)
 
 
+def _format_task_block(task: Task) -> list[str]:
+    """Task → its markdown checkbox line plus an indented ``> `` blockquote
+    body carrying `notes` (one line per content line). Empty notes emit no
+    body lines."""
+    lines = [_format_task_line(task)]
+    if task.notes:
+        for content_line in task.notes.split("\n"):
+            lines.append(f"{_BODY_INDENT}> {content_line}" if content_line else f"{_BODY_INDENT}>")
+    return lines
+
+
 def _parse_task_line(line: str, file_path: str, line_num: int) -> Optional[Task]:
-    """Parse one checkbox line into a Task, or None if not a task line."""
-    # Must be a checkbox line with TODO keyword
-    m = re.match(r'^- \[(.)\]\s+TODO\s+', line)
+    """Parse one checkbox line into a Task, or None if not a checkbox line.
+
+    The literal "TODO" keyword is optional — any `- [.] ...` checkbox line
+    counts as a task (see module docstring / docs/specs/technical/
+    task-management.md). A missing id gets a fresh one minted here; the
+    caller (reindex) is responsible for writing that id back to disk so it's
+    stable on the next parse.
+    """
+    m = _CHECKBOX_RE.match(line)
     if not m:
         return None
 
     symbol = m.group(1)
     status = SYMBOL_TO_STATUS.get(symbol, "todo")
 
-    # Extract the rest after "- [x] TODO "
     rest = line[m.end():]
 
     # Extract ID
@@ -619,9 +1292,10 @@ def _parse_task_line(line: str, file_path: str, line_num: int) -> Optional[Task]
     task_id = id_match.group(1) if id_match else uuid.uuid4().hex[:8]
 
     # Extract inline fields
-    fields = {}
+    raw_fields = {}
     for fm in _INLINE_FIELD_RE.finditer(rest):
-        fields[fm.group(1)] = fm.group(2).strip()
+        raw_fields[fm.group(1)] = fm.group(2).strip()
+    extra_fields = {k: v for k, v in raw_fields.items() if k not in _KNOWN_FIELD_KEYS}
 
     # Extract tags
     tags = _TAG_RE.findall(rest)
@@ -641,69 +1315,63 @@ def _parse_task_line(line: str, file_path: str, line_num: int) -> Optional[Task]
         description=desc,
         status=status,
         context=context,
-        priority=fields.get("priority", ""),
-        due_date=fields.get("due") or None,
-        created_date=fields.get("created", ""),
-        done_date=fields.get("done") or None,
-        cancelled_date=fields.get("cancelled") or None,
+        priority=raw_fields.get("priority", ""),
+        due_date=raw_fields.get("due") or None,
+        created_date=raw_fields.get("created", ""),
+        done_date=raw_fields.get("done") or None,
+        cancelled_date=raw_fields.get("cancelled") or None,
+        updated_at=raw_fields.get("updated") or None,
         tags=tags,
+        fields=extra_fields,
         source_file=file_path,
         line_number=line_num,
     )
 
 
-def _append_to_file(path: Path, line: str):
-    """Append a task line to file, ensuring newline before if needed."""
-    content = path.read_text(encoding="utf-8") if path.exists() else ""
-    if content and not content.endswith("\n"):
-        content += "\n"
-    content += line + "\n"
-    path.write_text(content, encoding="utf-8")
-
-
-def _insert_task_at_top(path: Path, line: str) -> int:
-    """Insert a task line above the existing first task. Returns its 1-indexed line number.
-
-    If the file has no tasks yet, appends after the header block.
-    """
-    content = path.read_text(encoding="utf-8") if path.exists() else ""
-    lines = content.splitlines()
-
-    first_task_idx = None  # 0-indexed
-    for i, existing in enumerate(lines):
-        if _parse_task_line(existing, "", i + 1) is not None:
-            first_task_idx = i
+def _match_task_block(
+    lines: list[str], idx: int, file_path: str = ""
+) -> Optional[tuple[int, Task, bool]]:
+    """If `lines[idx]` is a task line, parse it (and any body lines
+    immediately following) and return `(end, task, had_id)` — `end` is the
+    exclusive index just past the block, `had_id` says whether the raw line
+    already carried an `<!-- id:.. -->` comment. Returns None if `lines[idx]`
+    is not a task line."""
+    task = _parse_task_line(lines[idx], file_path, idx + 1)
+    if task is None:
+        return None
+    had_id = bool(_ID_RE.search(lines[idx]))
+    j, n = idx + 1, len(lines)
+    body = []
+    while j < n:
+        m = _BODY_LINE_RE.match(lines[j])
+        if not m:
             break
-
-    if first_task_idx is None:
-        # No tasks yet — append at end
-        _append_to_file(path, line)
-        return len(path.read_text(encoding="utf-8").splitlines())
-
-    new_lines = lines[:first_task_idx] + [line] + lines[first_task_idx:]
-    path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
-    return first_task_idx + 1
+        body.append(m.group(1))
+        j += 1
+    if body:
+        task.notes = "\n".join(body)
+    return j, task, had_id
 
 
-def _replace_line_in_file(path: Path, line_num: int, new_line: str):
-    """Replace a specific line (1-indexed) in a file."""
-    lines = path.read_text(encoding="utf-8").splitlines()
-    if 1 <= line_num <= len(lines):
-        lines[line_num - 1] = new_line
-        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-
-def _remove_line_from_file(path: Path, line_num: int):
-    """Remove a specific line (1-indexed) from a file."""
-    lines = path.read_text(encoding="utf-8").splitlines()
-    if 1 <= line_num <= len(lines):
-        del lines[line_num - 1]
-        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-
-def _count_lines(path: Path) -> int:
-    """Count lines in a file."""
-    return len(path.read_text(encoding="utf-8").splitlines())
+def _find_task_block_span(lines: list[str], task_id: str) -> Optional[tuple[int, int]]:
+    """Return the `(start, end)` line span of the block carrying `task_id`'s
+    id comment, or None if not found. Skips lines inside a fenced code
+    block — an id comment there is example text, not a real task."""
+    fence = dict(_iter_lines_with_fence_state(lines))
+    idx, n = 0, len(lines)
+    while idx < n:
+        if fence.get(idx):
+            idx += 1
+            continue
+        block = _match_task_block(lines, idx)
+        if block is None:
+            idx += 1
+            continue
+        end, task, had_id = block
+        if had_id and task.id == task_id:
+            return idx, end
+        idx = end
+    return None
 
 
 def _fuzzy_filter(tasks: list[Task], query: str) -> list[Task]:

--- a/api/services/task_watcher.py
+++ b/api/services/task_watcher.py
@@ -16,6 +16,8 @@ from typing import Callable, Optional
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
+from api.services.task_manager import is_conflict_file
+
 logger = logging.getLogger(__name__)
 
 _DEBOUNCE_SECONDS = 2.0
@@ -32,6 +34,8 @@ class _TaskFileHandler(FileSystemEventHandler):
     def _schedule(self, path: str):
         if path.endswith("Dashboard.md"):
             return  # Dashboard is auto-generated; never reindex it as a source
+        if is_conflict_file(Path(path)):
+            return  # Syncthing conflict copy / temp file — never a reindex source
         with self._lock:
             existing = self._pending.pop(path, None)
             if existing:

--- a/config/settings.py
+++ b/config/settings.py
@@ -7,11 +7,12 @@ import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Annotated
 
 import frontmatter
 from dotenv import dotenv_values
-from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import Field
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+from pydantic import Field, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -280,6 +281,16 @@ class Settings(BaseSettings):
                     "the Hermes text backend (optional there — Hermes may not require one), "
                     "and required from Hermes on inbound calls to "
                     "POST /api/hermes/resolve-persona (#644) — empty disables that endpoint."
+    )
+
+    agent_hook_token: str = Field(
+        default="",
+        alias="LIFEOS_AGENT_HOOK_TOKEN",
+        description="Bearer token required from scripts/lifeos-agent-hook.sh on inbound calls "
+                    "to POST /api/agents/cli-sessions/events (#849) — the endpoint that lets a "
+                    "Claude Code or Codex session on any machine register itself with /agents. "
+                    "Empty disables the endpoint (503): a fresh clone doesn't accept "
+                    "unauthenticated session writes over the tailnet until an operator sets one."
     )
 
     # Bounded lifetime for a chat turn that has detached from its client (#611):
@@ -624,6 +635,12 @@ class Settings(BaseSettings):
         alias="LIFEOS_AGENT_WORKER_POLL_SECONDS",
         description="How often the agent worker polls for new #agent tasks."
     )
+    human_queue_poll_seconds: float = Field(
+        default=300.0,
+        alias="LIFEOS_HUMAN_QUEUE_POLL_SECONDS",
+        description="How often the agent worker checks Human-queue cards' "
+                    "done_when conditions (#852)."
+    )
     agent_worker_autostart: bool = Field(
         default=False,
         alias="LIFEOS_AGENT_WORKER_AUTOSTART",
@@ -816,6 +833,25 @@ class Settings(BaseSettings):
                     "days. Older transcripts can still be opened on demand by "
                     "direct id via the events endpoint."
     )
+    codex_models_cache_path: str = Field(
+        default="~/.codex/models_cache.json",
+        alias="LIFEOS_CODEX_MODELS_CACHE_PATH",
+        description="Path to the Codex CLI's own model-catalog cache "
+                    "(`{\"fetched_at\", \"models\": [...]}`), read by "
+                    "GET /api/agents/models for the codex engine's picker "
+                    "list. Missing/unreadable/empty falls back to a live "
+                    "OpenAI models list call when LIFEOS_OPENAI_API_KEY is "
+                    "set, else an empty list (not an error)."
+    )
+    openai_api_key: str = Field(
+        default="",
+        alias="LIFEOS_OPENAI_API_KEY",
+        description="Optional OpenAI API key, used ONLY as the model-catalog "
+                    "fallback (GET /api/agents/models) when the Codex CLI's "
+                    "own models_cache.json is missing or unreadable. Never "
+                    "used to run turns — Codex sessions are subscription-"
+                    "billed through the CLI itself, never the API."
+    )
     codex_resume_enabled: bool = Field(
         default=False,
         alias="LIFEOS_CODEX_RESUME_ENABLED",
@@ -839,6 +875,65 @@ class Settings(BaseSettings):
         description="Command run *inside* the spawned terminal — the actual "
                     "`codex resume` invocation. Substitutions: `{session_id}`, "
                     "`{cwd}`. Set to empty to skip the inner command."
+    )
+    # #851: card assignment to a host other than the API host, over ssh.
+    #
+    # `NoDecode` (round-1 review, finding #8): pydantic-settings' own
+    # complex-field JSON pre-decode runs BEFORE `mode="before"` validators —
+    # for a plain `dict[str, str]` field that pre-decode raises straight out
+    # of `Settings()` on an empty string or malformed JSON, so
+    # `_parse_agent_hosts` below never even ran for those cases despite the
+    # docstring's promise. `NoDecode` opts this field out of that pre-decode
+    # so the validator receives the raw env string and its empty/invalid
+    # branches actually execute.
+    agent_hosts: Annotated[dict[str, str], NoDecode] = Field(
+        default_factory=dict,
+        alias="LIFEOS_AGENT_HOSTS",
+        description="JSON object mapping a board-facing host name (e.g. "
+                    "\"studio\") to the ssh target the worker/API should "
+                    "connect to for it (e.g. \"user@studio.example\", or a "
+                    "name from ~/.ssh/config). Operator configuration — never "
+                    "committed with real values. Default {} disables every "
+                    "remote host: a task naming a host not in this map lands "
+                    "at #agent-failed rather than running anywhere. Invalid "
+                    "JSON logs a warning and is treated as {}."
+    )
+
+    @field_validator("agent_hosts", mode="before")
+    @classmethod
+    def _parse_agent_hosts(cls, value):
+        if isinstance(value, dict):
+            return value
+        if value in (None, ""):
+            return {}
+        if isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError:
+                logger.warning("LIFEOS_AGENT_HOSTS is not valid JSON — ignoring, no remote hosts configured")
+                return {}
+            if not isinstance(parsed, dict):
+                logger.warning("LIFEOS_AGENT_HOSTS must be a JSON object — ignoring, no remote hosts configured")
+                return {}
+            return parsed
+        return {}
+
+    agent_ssh_connect_timeout: int = Field(
+        default=10,
+        alias="LIFEOS_AGENT_SSH_CONNECT_TIMEOUT",
+        description="Seconds ssh may spend establishing a connection to a "
+                    "board-assigned remote host before giving up (`ssh -o "
+                    "ConnectTimeout=<this>`). Applies to remote spawn, remote "
+                    "kill, and remote resume/focus alike."
+    )
+    agent_model_catalog_ttl_seconds: int = Field(
+        default=86400,
+        alias="LIFEOS_AGENT_MODEL_CATALOG_TTL_SECONDS",
+        description="How long GET /api/agents/models caches each engine's "
+                    "model list before re-querying providers. Default 24h — "
+                    "model catalogs change rarely and every provider call "
+                    "costs a round trip (Anthropic) or a filesystem read "
+                    "(Codex's models_cache.json)."
     )
     cc_resume_enabled: bool = Field(
         default=False,

--- a/docs/guides/AGENTS.md
+++ b/docs/guides/AGENTS.md
@@ -19,6 +19,7 @@ This directory contains operational guides — how to set up, configure, and run
 - `troubleshooting.md` — Common issues and solutions
 - `claude-code-orchestration.md` — Claude Code multi-agent orchestration patterns
 - `doctor-bot.md` — Self-repair Telegram bot: report a problem → issue → implement → ship
+- `human-queue.md` — Human queue: fire-and-forget cards agents file for the operator, `done_when` auto-resolve
 - `agent-worker-setup.md` — External agent worker prerequisites (Gemma swap, MCP HTTP transport, Cloudflare Tunnel, bearer token)
 - `agents-go-to.md` — /agents "Go To" wezterm pane setup (SessionStart hook + FD probe)
 

--- a/docs/guides/agent-worker-setup.md
+++ b/docs/guides/agent-worker-setup.md
@@ -1,7 +1,7 @@
 # Agent Worker Setup
 
 > **Status:** Complete
-> **Last Updated:** 2026-08-18
+> **Last Updated:** 2026-09-03
 > **Audience:** Operators
 
 One-time setup for the external agent worker that picks up `#agent`-tagged tasks and executes them via Claude (Anthropic Managed Agents) or a local Gemma model.
@@ -476,6 +476,74 @@ Claude Code CLI (which *does* work headless on Linux), then monitor it with
 `lifeos_agent_check`. This delegation is the supported path for any task that
 needs a real browser.
 
+## Card assignment: running a card on another machine (#851)
+
+A board card (or a `#claude`/`#codex` task carrying `host` / `model` /
+`effort` fields) can name a machine other than this API host to run on.
+The worker reaches it over ssh — no worker process runs on the remote
+machine, only the API host's own worker dispatches, and it does so by
+wrapping the identical local command in an ssh call.
+
+**Configure the registry.** `LIFEOS_AGENT_HOSTS` in `.env` is a JSON object
+mapping a board-facing host name to an ssh target:
+
+```bash
+LIFEOS_AGENT_HOSTS={"laptop": "operator@laptop.example", "studio": "studio-box"}
+```
+
+`studio-box` above is a plain `~/.ssh/config` `Host` alias — either form
+works, since the value is passed straight to `ssh`. A host name not in
+this map fails the task closed (`#agent-failed`, reason naming the host)
+without ever attempting a connection; leaving `LIFEOS_AGENT_HOSTS` unset
+(the default, `{}`) disables every remote host.
+
+**ssh prerequisites, per remote machine:**
+
+- Key-based auth already working non-interactively: `ssh -o BatchMode=yes
+  <target> echo ok` must succeed with no password/passphrase prompt (an
+  agent-loaded key, or an unencrypted key referenced by `~/.ssh/config`).
+  `BatchMode=yes` is exactly what the worker itself passes, so this is the
+  real precondition, not an approximation of it.
+- The `claude` and/or `codex` CLI installed and authenticated on the
+  remote machine's own account, the same way it is on this host (see Step 4b above for Claude Code auth,
+  [Codex MCP setup](#codex-mcp-setup-codex-path) for Codex) — the remote invocation is the literal `claude`/`codex` binary on
+  that machine's `$PATH`, so whatever makes it work locally on THAT
+  machine (not this one) has to already be true there.
+- The lifeos MCP server configured for whichever CLI runs there, exactly
+  as on this host — a remote session with no `lifeos_*` tools is blind to
+  personal data the same way a local one would be.
+- For `/resume`/`/focus`/board-open's WezTerm launcher path: WezTerm
+  installed and reachable the same way it is here — this repo doesn't yet
+  replicate `_resume_env`'s local socket-discovery logic on the remote
+  side, so the remote machine's own login-shell environment has to
+  already make `wezterm cli spawn` work unassisted.
+
+The remote spawn always unsets a small canonical list of provider
+credential names (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`,
+`OPENAI_API_KEY`, and a few others) regardless of what this API host's own
+environment contains, but names beyond that list exported by a registered
+host's own non-interactive shell are not stripped — keep provider
+credentials out of a registered host's shell startup files.
+
+**Connect timeout.** `LIFEOS_AGENT_SSH_CONNECT_TIMEOUT` (default 10
+seconds) bounds how long ssh may spend establishing the connection before
+giving up — applies to remote spawn, remote kill, and remote resume/focus
+alike. An unreachable host fails within this window with the ssh error as
+the failure reason. A remote spawn's initial handshake read (waiting for
+the `PGID:` line that confirms the remote process actually started) is
+bounded separately, at this connect timeout plus 5 seconds — it covers an
+auth stall or a host that accepts the connection but never answers, and
+fails with its own distinct reason (`host <name> did not answer within
+<n>s`) rather than the ssh connection error above.
+
+**What doesn't work remotely:** Apple-data tasks (iMessage, Photos,
+Contacts) need Full Disk Access, which is granted per-launching-process
+and can't be inherited over ssh — see
+[agent-worker.md](../specs/technical/agent-worker.md#card-assignment-851).
+The Apple Data Agent's own export/import pipeline
+([operations.md](operations.md)) is the supported path for cross-machine
+Apple data, not this mechanism.
+
 ## Cost-aware iteration
 
 Iterating on cloud `#agent` prompts has a hidden tax: every fresh managed
@@ -527,4 +595,7 @@ suggestions to keep iteration cheap:
 - [Installation](installation.md) — base LifeOS setup
 - [Configuration](configuration.md) — environment variable reference
 - [Scripts](scripts.md) — `setup-systemd.sh` and other operational scripts
+- [Human Queue](human-queue.md) — `done_when` auto-resolve checks require this worker to be running
+- [Agent Worker — Technical](../specs/technical/agent-worker.md#card-assignment-851) — Host registry and ssh spawn mechanism this guide's setup section covers operationally
+- [Operations](operations.md) — Apple Data Agent export/import, the supported path for cross-machine Apple data this guide's remote-host section can't reach
 - Epic [#98](https://github.com/nbramia/LifeOS/issues/98) — full agent-worker design

--- a/docs/guides/agents-go-to.md
+++ b/docs/guides/agents-go-to.md
@@ -1,12 +1,14 @@
 # /agents "Go To" — WezTerm setup
 
 > **Status:** Complete
-> **Last Updated:** 2026-05-28
+> **Last Updated:** 2026-09-03
 > **Audience:** Operators
 
 The /agents page's **Go To** button (and double-clicking an active node) jumps wezterm focus to the pane running the selected Claude Code session — even when several panes are working in the same project directory at once.
 
 Setup is one block in `~/.claude/settings.json` plus making sure `lsof` is installed.
+
+`scripts/install-agent-hooks.sh` + `scripts/lifeos-agent-hook.sh` (below, [§4](#4-cross-machine-session-registration)) supersede the manual hook-config steps below and also register sessions from other machines with `/agents` — not just WezTerm pane binding on this one. `claude-session-pane.sh` / `codex-session-pane.sh` and the manual `~/.claude/settings.json` block in step 2 still work unchanged for an existing install; run the installer once to get both pane binding and cross-machine registration from a single hook going forward.
 
 ---
 
@@ -71,7 +73,7 @@ You can override the API base URL with `LIFEOS_API_URL` if you run on a non-defa
 
 ## 3. Try it
 
-Open two wezterm panes in the same project directory, run `claude` in each, then open `/agents` in your browser. Both sessions should show a **Go To** button. Click it (or double-click the node in the graph) — wezterm focuses the right pane. On GNOME Wayland the focus changes inside wezterm but the window won't pop forward (compositor restriction); click the wezterm dock icon to bring it forward, the right pane will already be selected.
+Open two wezterm panes in the same project directory, run `claude` in each, then open `/agents` in your browser and open the **Graph** tab (the page now opens on the Board tab by default). Both sessions should show a **Go To** button. Click it (or double-click the node in the graph) — wezterm focuses the right pane. On GNOME Wayland the focus changes inside wezterm but the window won't pop forward (compositor restriction); click the wezterm dock icon to bring it forward, the right pane will already be selected. The board drawer's equivalent action is labelled **Focus** rather than **Go To**.
 
 If the toast says "Couldn't locate pane" — meaning the session isn't running where we can reach it, wezterm itself can't be queried, or no cached mapping exists — the most likely causes are:
 
@@ -83,12 +85,44 @@ If the toast says "Couldn't locate pane" — meaning the session isn't running w
 
 ---
 
+## 4. Cross-machine session registration
+
+`/agents` can also show Claude Code and Codex sessions running on a laptop, a second desktop — any machine that can reach the API over Tailscale. This uses a different, newer script that installs itself for both CLIs at once:
+
+```bash
+./scripts/install-agent-hooks.sh
+```
+
+Run once **on each machine** you want registered (including the one hosting the API, if you want its own CLI sessions to report a `host` too). It's idempotent — safe to re-run after an update, it only adds what's missing and never touches an existing entry from Orca, atuin, or anything else already in your hook config.
+
+The installer prints, but does not create, the two things registration needs:
+
+1. **On the API host:** set `LIFEOS_AGENT_HOOK_TOKEN` in `.env` (e.g. `openssl rand -hex 32`) and restart the API. Empty (the default) disables the endpoint entirely.
+2. **On every machine posting events** (the API host included, if you want its own sessions to carry `host`): create `~/.config/lifeos/agent-hook.env` (override the path with `$LIFEOS_AGENT_HOOK_ENV`):
+
+   ```
+   LIFEOS_API_URL=http://<api-host>:8000
+   LIFEOS_AGENT_HOOK_TOKEN=<the same token>
+   ```
+
+   `chmod 600` this file — it holds the bearer token in plaintext, and under a default `umask 022` a newly created file is world-readable to every other local account on the machine.
+
+   **On the API host itself**, keep `LIFEOS_API_URL=http://localhost:8000` (the default) rather than pointing it at the Tailscale hostname. The event endpoint only mirrors `pane_id`/`wezterm_pid` into the local WezTerm pane store — the table Go To reads — for requests that both name this host **and** arrive from loopback; posting to the Tailscale address instead of localhost means the request no longer looks like loopback to the API, so Go To stops working for sessions started on this machine.
+
+Until that file (or the equivalent environment variables) exists, `lifeos-agent-hook.sh` exits silently without posting anything — a machine you haven't set up yet just doesn't show up, it doesn't error.
+
+A session registered this way shows a `host` badge in the side panel, plus its git branch and last prompt preview when available. Its status is event-driven (accurate `running`/`idle`/`ended`), not inferred from file age. **Resume** and **Go To** only work for sessions on the machine hosting the API — clicking either on a remote-host session returns an error naming the host instead of trying (and failing) a local wezterm probe.
+
+---
+
 ## Related Documents
 
 ### Specifications
-- [Agent Viz — Product](../specs/product/agent-viz.md#operator-controls--resume-and-go-to) — Operator-facing controls overview
+- [Agent Viz — Product](../specs/product/agent-viz.md#graph-tab--operator-controls--resume-and-go-to) — Operator-facing controls overview
 - [Agent Viz — Technical](../specs/technical/agent-viz.md#claude-code-resume--go-to) — Endpoint shapes, probe algorithm, security boundaries
 
 ### Code References
 - [`api/services/cc_pane_locate.py`](../../api/services/cc_pane_locate.py) — Probe implementation
-- [`scripts/claude-session-pane.sh`](../../scripts/claude-session-pane.sh) — Hook script
+- [`scripts/claude-session-pane.sh`](../../scripts/claude-session-pane.sh) — Legacy WezTerm-only hook script (this machine only)
+- [`scripts/lifeos-agent-hook.sh`](../../scripts/lifeos-agent-hook.sh) — Cross-machine session registration hook (§4)
+- [`scripts/install-agent-hooks.sh`](../../scripts/install-agent-hooks.sh) — Idempotent installer for the hook above

--- a/docs/guides/claude-code-orchestration.md
+++ b/docs/guides/claude-code-orchestration.md
@@ -10,7 +10,7 @@ Run Claude Code tasks remotely from Telegram. Send `/claude <task>` (alias: `/cl
 
 > **For what `/claude` does and how the operator interaction works**, see [Claude Code Orchestration — product spec](../specs/product/claude-code-orchestration.md). For the worker internals see [`api/services/agent_worker/AGENTS.md`](../../api/services/agent_worker/AGENTS.md). This file is the operator how-to.
 
-> **`/codex` is the sibling surface for the Codex CLI.** Same setup pattern: install the binary (`npm i -g @openai/codex`), authenticate (`codex login`), set `LIFEOS_CODEX_RESUME_ENABLED=true` to enable Resume + Go To from `/agents`. Telegram commands are `/codex`, `/codex_status`, `/codex_cancel`. The agent-worker route is `routing='codex'`; the `#codex` task tag flips a `#agent` task to that surface. See the [Codex section in agent-viz](../specs/product/agent-viz.md#operator-controls--resume-and-go-to) and the [`LIFEOS_CODEX_*` env vars](configuration.md#codex-viz-agents-ingest-of-codex-sessions).
+> **`/codex` is the sibling surface for the Codex CLI.** Same setup pattern: install the binary (`npm i -g @openai/codex`), authenticate (`codex login`), set `LIFEOS_CODEX_RESUME_ENABLED=true` to enable Resume + Go To from `/agents`. Telegram commands are `/codex`, `/codex_status`, `/codex_cancel`. The agent-worker route is `routing='codex'`; the `#codex` task tag flips a `#agent` task to that surface. See the [Codex section in agent-viz](../specs/product/agent-viz.md#graph-tab--operator-controls--resume-and-go-to) and the [`LIFEOS_CODEX_*` env vars](configuration.md#codex-viz-agents-ingest-of-codex-sessions).
 
 ## Prerequisites
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,7 +1,7 @@
 # Configuration Guide
 
 **Status:** Complete
-**Last Updated:** 2026-08-28
+**Last Updated:** 2026-09-03
 **Audience:** Operators
 
 **This is the single authoritative reference for every `LIFEOS_*` environment variable and the third-party service variables (`ANTHROPIC_API_KEY`, `OLLAMA_*`, `SLACK_*`, `TELEGRAM_*`, `MONARCH_*`) that LifeOS reads.** Other guides reference this file rather than restating defaults — when documentation conflicts, this file wins (and `config/settings.py` wins over both, since the code is the source of truth).
@@ -159,6 +159,7 @@ The HTTP MCP transport exposes LifeOS tools to remote agents (primarily Anthropi
 |---|---|---|---|
 | `LIFEOS_AGENT_WORKER_AUTOSTART` | bool | `false` | When `true`, the worker starts on boot. Default off to require explicit opt-in. |
 | `LIFEOS_AGENT_WORKER_POLL_SECONDS` | float | `60` | Poll interval for new `#agent`-tagged tasks. |
+| `LIFEOS_HUMAN_QUEUE_POLL_SECONDS` | float | `300` | Poll interval for Human-queue `done_when` checks. See [human-queue.md](human-queue.md). |
 | `LIFEOS_AGENT_DEFAULT_BUDGET_DOLLARS` | float | `5.00` | Per-task $-cap when the task title doesn't specify one. |
 | `LIFEOS_AGENT_DEFAULT_WALL_SECONDS` | int | `14400` (4 h) | Per-task wall-time cap when title doesn't specify. |
 | `LIFEOS_AGENT_DEFAULT_MAX_TOKENS` | int | `500000` | Per-task token cap when title doesn't specify. |
@@ -203,7 +204,7 @@ Read-only ingest of Claude Code's per-session JSONL transcripts. Decision: [ADR-
 
 ## Claude Code Resume (`/agents` operator-controlled re-launch)
 
-Operator-side controls for re-opening a Claude Code session from the `/agents` UI. Used in [agent-viz product spec § Operator controls — resume](../specs/product/agent-viz.md#operator-controls--resume).
+Operator-side controls for re-opening a Claude Code session from the `/agents` UI. Used in [agent-viz product spec § Operator controls — resume and Go To](../specs/product/agent-viz.md#graph-tab--operator-controls--resume-and-go-to).
 
 | Variable | Type | Default | Sets |
 |---|---|---|---|
@@ -231,6 +232,32 @@ Mirror of the Claude Code resume controls for Codex sessions. Drives `POST /api/
 | `LIFEOS_CODEX_RESUME_ENABLED` | bool | `false` | Gates the resume UI and route for `cx:` sessions. |
 | `LIFEOS_CODEX_RESUME_CMD` | str | `wezterm cli spawn --cwd {cwd} -- {inner_command}` | Outer launcher template. Same substitution surface as `LIFEOS_CC_RESUME_CMD`. |
 | `LIFEOS_CODEX_RESUME_INNER_CMD` | str | `codex resume {session_id}` | Inner command run inside the spawned terminal. |
+
+## Cross-Machine CLI Session Registration (`/agents` from any host)
+
+Lets a Claude Code or Codex session running on any machine — not just the one hosting the API — register itself with `/agents`. See [agent-viz technical spec § Cross-machine CLI session registration](../specs/technical/agent-viz.md#cross-machine-cli-session-registration) and [guides/agents-go-to.md § 4](agents-go-to.md#4-cross-machine-session-registration) for setup.
+
+| Variable | Type | Default | Sets |
+|---|---|---|---|
+| `LIFEOS_AGENT_HOOK_TOKEN` | str | *(empty)* | Bearer token required from `scripts/lifeos-agent-hook.sh` on `POST /api/agents/cli-sessions/events`. Empty disables the endpoint (503). |
+
+The token above is set on the machine hosting the API. Each machine *posting* session events (the API host included, if you want its own sessions to carry a `host`) additionally needs a local env file the hook script reads — not a LifeOS setting, since it's per-machine and lives outside `.env`:
+
+| File | Purpose |
+|---|---|
+| `~/.config/lifeos/agent-hook.env` (override path via `$LIFEOS_AGENT_HOOK_ENV`) | Contains `LIFEOS_API_URL` and `LIFEOS_AGENT_HOOK_TOKEN` (the same token as above). Values already set in the environment take precedence over this file. Absent → the hook exits silently without posting. |
+
+## Card Assignment (`#851`, host / model / effort routing)
+
+See [guides/agent-worker-setup.md § Card assignment](agent-worker-setup.md#card-assignment-running-a-card-on-another-machine-851) for the ssh-prerequisites walkthrough and [specs/technical/agent-worker.md § Card assignment](../specs/technical/agent-worker.md#card-assignment-851) for the mechanism.
+
+| Variable | Type | Default | Sets |
+|---|---|---|---|
+| `LIFEOS_AGENT_HOSTS` | JSON object | `{}` | `{name: ssh_target}` — maps a board-facing host name to the ssh target the worker/API connects to for it. Empty disables every remote host: a task naming a host not in this map lands at `#agent-failed`. Invalid JSON logs a warning and is treated as `{}`. Operator configuration — never committed with real values. |
+| `LIFEOS_AGENT_SSH_CONNECT_TIMEOUT` | int (seconds) | `10` | How long ssh may spend establishing a connection to a remote host before giving up. Applies to remote spawn, remote kill, and remote resume/focus alike. |
+| `LIFEOS_AGENT_MODEL_CATALOG_TTL_SECONDS` | int (seconds) | `86400` | How long `GET /api/agents/models` caches each engine's model list before re-querying providers. |
+| `LIFEOS_CODEX_MODELS_CACHE_PATH` | str | `~/.codex/models_cache.json` | Path to the Codex CLI's own model-catalog cache, read by the model catalog endpoint for the codex engine's picker list. |
+| `LIFEOS_OPENAI_API_KEY` | str | *(empty)* | Optional OpenAI API key, used ONLY as the model-catalog fallback when `LIFEOS_CODEX_MODELS_CACHE_PATH` is missing/unreadable. Never used to run turns — Codex sessions are subscription-billed through the CLI itself, never the API. |
 
 ## Claude Code Orchestration (`/claude` Telegram command)
 

--- a/docs/guides/doctor-bot.md
+++ b/docs/guides/doctor-bot.md
@@ -1,7 +1,7 @@
 # Doctor Bot — Self-Repair Surface
 
 **Status:** Complete
-**Last Updated:** 2026-08-28
+**Last Updated:** 2026-09-03
 **Audience:** Operator
 
 The **doctor** bot's only job is fixing LifeOS itself. You message it when you notice LifeOS misbehaving or missing something; it converses with you to define the **goal**, locks that goal, then — on your approval — orchestrates the work end to end and reports back. It is a **goal-first orchestrator**: it supervises the implementation (subagents do the coding via `/implement`) rather than hand-coding inline, and every change lands through a reviewed, tested PR — never a direct push to `main`.
@@ -24,6 +24,8 @@ This is the operator's-eye summary; the exact contract the session runs lives in
    - **Small goal:** one branch → `/implement` → one PR → `main`.
    - **Multi-part goal:** an **integration branch** off `main`, each part landed as a sub-PR onto it (`/implement <issue> --base <integration-branch>`), then one PR integration→`main`, then cleanup.
 5. **Confirm.** It brings the canonical checkout to merged `main`, restarts (the right way — see Autonomy and safety), and confirms with the revert handle: _"Shipped: PR #N merged, server restarted. Revert with: gh pr revert N."_
+
+Once you install the [Human queue](human-queue.md) instruction paragraph in the doctor's instruction files, a repair that turns up something only you can do files a card instead of stalling, and resolves it once it observes the thing done.
 
 ## Setup
 
@@ -64,6 +66,7 @@ The doctor's machinery is generic. To add another orchestration surface, add an 
 - [Configuration](configuration.md) — `TELEGRAM_DOCTOR_*` and the specialized-bot env vars.
 - [Claude Code Orchestration](claude-code-orchestration.md) — Claude Code install/auth on the server, shared by the doctor.
 - [Agent Worker Setup](agent-worker-setup.md) — The worker that runs the doctor's sessions.
+- [Human Queue](human-queue.md) — Where the doctor files what it can't do itself
 
 ### Code References
 - [`config/telegram_bots.json`](../../config/telegram_bots.json) — Bot registry (the `doctor` entry, `orchestrates: true`).

--- a/docs/guides/human-queue.md
+++ b/docs/guides/human-queue.md
@@ -1,0 +1,188 @@
+# Human Queue
+
+**Status:** Complete
+**Last Updated:** 2026-09-03
+**Audience:** Operator, Contributor
+
+The Human queue is a shared, fire-and-forget list of things only the operator
+can do — an interactive session that notices an expired login, a nightly
+sync that fails on a stale credential, a Codex run that hits a decision it
+can't make on its own. Any agent — interactive Claude Code, the agent
+worker, `/chat`, or Hermes — can file a card without stopping, and LifeOS
+itself files cards for known operator-only failures (sync errors, an
+expired Monarch session).
+
+A card is a task ([task-management](../specs/technical/task-management.md))
+with tag `human` and status `blocked` — no new storage, no schema change.
+A Human queue lane on the `/agents` board is that same filter — derived,
+not a separate list.
+
+## The instruction paragraph
+
+Paste this into an operator-level instruction file (`CLAUDE.md`/`AGENTS.md`
+on a machine you run agents from) so every agent on that machine knows the
+convention:
+
+> When a conversation surfaces a task that only the operator can do — one
+> the conversation itself can't finish (a credential to re-enter, an
+> approval, a decision only the operator can make) — file it with
+> `lifeos_human_queue_add` (a short title, notes on what's needed and why, and
+> a stable `key` so re-observing the same problem updates one card instead of
+> piling up duplicates). When you later see the thing done, resolve it with
+> `lifeos_human_queue_resolve`. Never file work you can do yourself — file
+> only what genuinely requires the operator.
+
+The repository ships this paragraph; installing it into an operator's own
+instruction files is a manual, per-install step.
+
+## The three tools
+
+Exposed over MCP (stdio for Claude Code, HTTP for Managed Agents and
+Hermes) and as a native chat tool (`manage_human_queue`, actions
+`add`/`list`/`resolve`) for `/chat`.
+
+- **`lifeos_human_queue_add(title, notes?, key?, done_when?, source_host?, source_cwd?, source_session?)`**
+  Files a card. Never blocks or changes the calling session's own status —
+  purely fire-and-forget, unlike the worker's blocking
+  `lifeos_agent_user_ask`. `key` must match `^[\w.:-]+\Z` (letters, digits,
+  `.`, `:`, `-`, `_`) and must contain at least one character other than
+  `.` — it's interpolated unescaped into the resolve route's URL path
+  segment, so `/`, `?`, `#` are rejected (422). Filing again with
+  an already-**open** card's `key` replaces that card's notes instead of
+  creating a duplicate (`updated_at` advances). A `key` whose only match is
+  a **done** card is unclaimed — filing opens a fresh card.
+- **`lifeos_human_queue_resolve(id_or_key, note?)`**
+  Marks the matching open card done, appending `note` to its notes body.
+  404 for an id or key with no open card.
+- **`lifeos_human_queue_list()`**
+  Returns open cards: `id`, `title`, `key`, `age_hours`, `source_host`,
+  `source_cwd`, `source_session`, `notes`, `done_when`.
+
+## `done_when` — auto-resolve checks
+
+The check runs only while the agent worker is running (off by default —
+see [Agent Worker Setup](agent-worker-setup.md)); with the worker stopped,
+a `done_when` card simply stays open until someone resolves it.
+
+An optional condition, checked by the agent worker's poll tick
+(`LIFEOS_HUMAN_QUEUE_POLL_SECONDS`, default 300s — see
+[Configuration](configuration.md)) so a card resolves itself the moment the
+underlying problem is actually fixed, without anyone having to remember to
+go back and close it. Two types only:
+
+```json
+{"type": "endpoint", "path": "/api/example-service/status", "pointer": "/status", "equals": "ok"}
+```
+All three of `path`, `pointer`, and `equals` are required; `equals` must be
+a JSON scalar (string, number, boolean, or null).
+
+`path` must start with `/` and not `//`, and must not contain `?` or `#`
+(422 otherwise — a worker-side guard against a `path` like `@host/x`
+re-parsing the request's authority, or a query string turning the poll
+into a query-driven local GET). The worker GETs `path` against the local
+API it talks to, extracts the
+value at the JSON Pointer (RFC 6901) `pointer`, and compares it to
+`equals`. `pointer` uses the standard `/a/b` syntax (`""` or `"/"` selects
+the whole response body).
+
+```json
+{"type": "file_exists", "path": "/absolute/path"}
+```
+Checked with a plain filesystem `exists()` call, run **in the agent-worker
+process, on the worker's host** — not the API host. Those are usually the
+same machine, but when `LIFEOS_API_URL` points the worker at a remote API
+(see [Configuration](configuration.md)), `path` must exist on the worker's
+own filesystem, not the API server's.
+
+A card with no `done_when` just sits open until an agent (the filer, on
+observing the fix, or `/chat`/Hermes on request) resolves it by hand.
+
+A check that does not pass leaves the card untouched, retried next poll,
+but logging differs: an **errored** check (endpoint unreachable, wrong
+shape) logs a warning; a check that just evaluates **false** (the condition
+isn't true yet) logs nothing — that's the expected steady state while the
+operator hasn't acted yet. A passing check resolves the card with a note
+naming the check that passed.
+
+**Why no `shell` type.** A `done_when` check that could run an arbitrary
+command would be a remote-execution surface reachable by any agent that can
+file a card — deliberately excluded. `endpoint` and `file_exists` are
+enough to express "the service is healthy again" or "the flag file exists"
+without that risk. They are still real capability handed to any agent that
+can file a card, not inert status reads: `endpoint` makes the agent worker
+issue a GET against the given local API path every poll, and `file_exists`
+answers whether a path exists on the worker host — so both should be
+treated as available to whatever can create a `#human` task, not just to
+whoever reads cards back.
+
+## REST endpoints
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /api/tasks/human-queue` | File (or dedupe-update) a card |
+| `GET /api/tasks/human-queue` | List open cards |
+| `PUT /api/tasks/human-queue/{id_or_key}/resolve` | Resolve a card |
+
+See [API Reference](../specs/product/api-reference.md#task-endpoints) for
+request/response shapes.
+
+## What LifeOS files for itself
+
+- **Sync failures.** The nightly sync (`scripts/run_all_syncs.py`) files a
+  card keyed `sync:<source>` for any source the run summary classifies as a
+  real failure (not a disabled/unconfigured source, not a dependency skip),
+  with the error text in notes. The next successful run of that source
+  resolves it.
+- **Monarch re-authentication.** When the cached Monarch session is
+  `expired` or `missing`, the nightly sync files a card keyed
+  `monarch-reauth` with a `done_when` endpoint check against
+  `GET /api/monarch/session_status` (`pointer: /status`, `equals: "ok"`).
+  Re-authenticating (see [Operations § Monarch Money](operations.md#monarch-money-financial-data))
+  makes the worker's next tick resolve it automatically.
+
+## In `/chat`
+
+Asked "what's waiting on me", the orchestrator lists open cards with
+`manage_human_queue` (action `list`). It can also file and resolve cards in
+conversation, subject to the same "never file work you can do yourself"
+rule as every other agent.
+
+## In the morning briefing
+
+The **Morning Briefing** proactive reminder's prompt
+(`scripts/seed_proactive_reminders.py`'s `MORNING_BRIEFING_PROMPT`) has a
+**Waiting on You** section instructing the orchestrator to call
+`manage_human_queue` (action `list`) and report cards shown as 24h old or
+older, skipping the section when there are none.
+
+If your Morning Briefing scheduler entry was seeded before this section
+existed, it won't pick up the change on its own. Re-running
+`scripts/seed_proactive_reminders.py --force` does **not** update it —
+`--force` only skips the by-name existence check, and `SchedulerStore.create`
+always inserts a new entry, so it would leave you with two Morning Briefing
+schedules. Instead, either edit the existing entry's prompt by hand to add
+a **Waiting on You** paragraph like the one above, or delete that entry
+first and then re-run the seed script to recreate it from the current
+prompt.
+
+## Related Documents
+
+### Specifications
+- [Task Management — Technical](../specs/technical/task-management.md#human-queue) — The task store this queue is built on
+- [Task Management — Product](../specs/product/task-management.md) — Consumer-facing task endpoints, including the Human-queue rows
+- [API Reference](../specs/product/api-reference.md#task-endpoints) — REST contracts
+- [MCP Tools](../specs/product/mcp-tools.md) — The `lifeos_human_queue_*` tools in the full MCP catalog
+- [Agent Worker — Technical](../specs/technical/agent-worker.md) — The poll tick that resolves `done_when` cards
+- [Data & Sync — Technical](../specs/technical/data-and-sync.md#failure-notifications) — Sync failures file a card keyed `sync:<source>`
+- [Agent Viz — Product](../specs/product/agent-viz.md) — The `/agents` board's Human queue lane is the derived view of these cards
+
+### Guides
+- [Configuration](configuration.md) — `LIFEOS_HUMAN_QUEUE_POLL_SECONDS`
+- [Doctor Bot](doctor-bot.md) — Files a card when a repair needs the operator
+- [Operations](operations.md) — Monarch re-auth procedure
+
+### Code References
+- [`api/services/human_queue.py`](../../api/services/human_queue.py) — Card shape, dedupe, `done_when` validation
+- [`api/routes/tasks.py`](../../api/routes/tasks.py) — REST routes
+- [`api/services/agent_worker/worker.py`](../../api/services/agent_worker/worker.py) — `_process_human_queue` poll tick
+- [`mcp_server.py`](../../mcp_server.py) — MCP tool registration

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Operations
-> **Last Updated:** 2026-08-27
+> **Last Updated:** 2026-09-03
 > **Audience:** Operators
 
 Operational procedures that don't belong in the day-to-day coding reference: the Apple Data Agent, Monarch Money auth, and quick observability commands. Moved here from `AGENTS.md` to keep the agent-facing file lean.
@@ -37,6 +37,10 @@ Auth uses a cached session token at `data/monarch_session.pickle`. Monthly sync 
 
 Re-authenticate when the token expires (401/525), or when the nightly sync warns
 that the session is old. Run from the project root — the session path is relative.
+
+An expired or missing session also files a [Human queue](human-queue.md)
+card keyed `monarch-reauth`; the worker's next poll resolves it
+automatically once re-auth succeeds.
 
 **Preferred (works in any shell, including agent/non-TTY sessions):** reads
 `MONARCH_EMAIL` / `MONARCH_PASSWORD` from `.env` and takes the MFA code as an
@@ -226,3 +230,5 @@ value dressed up as confirmed-live.
 - [Data & Sync](../specs/technical/data-and-sync.md) — Nightly sync pipeline phases
 - [Troubleshooting](troubleshooting.md) — General operational troubleshooting
 - [Scripts Reference](scripts.md) — `auto-deploy.sh` / `auto-update-macos.sh` / `setup-launchd.sh` usage and flags
+- [Human Queue](human-queue.md) — Auto-filed `monarch-reauth` card on an expired/missing session
+- [Agent Worker Setup](agent-worker-setup.md#card-assignment-running-a-card-on-another-machine-851) — Remote-host card assignment over ssh, and why it can't reach Apple-data tasks (the FDA limitation this doc's section above documents)

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -198,3 +198,4 @@ See [API Reference § Scheduler & Telegram Endpoints](../specs/product/api-refer
 - [Agent Worker](../specs/product/agent-worker.md) — Runs `action:: agent` schedules
 - [API Reference](../specs/product/api-reference.md) — Scheduler API endpoint contracts
 - [MCP Tools](../specs/product/mcp-tools.md) — `lifeos_schedule_*` tool contracts
+- [Agent Viz](../specs/product/agent-viz.md) — The `/agents` board's Scheduled column shows entries edited here

--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -1,7 +1,7 @@
 # Scripts Reference
 
 > **Status:** Complete
-> **Last Updated:** 2026-08-28
+> **Last Updated:** 2026-09-03
 > **Audience:** Operators
 
 Reference for the operator-facing scripts under `scripts/`, with usage examples. One-off CRM entity-repair scripts (`merge_people.py`, `split_person.py`, `fix_*`, etc.), git hooks, and Claude Code worktree/session-diagnostic helpers aren't covered here — they're self-documenting via `--help` or their own docstring.
@@ -220,6 +220,8 @@ Example:
 | `install_codex_skills.py` | Convert portable LifeOS skills from `.claude/skills/` into Codex's `SKILL.md` format into `~/.codex/skills/`. Re-run after editing source skills. |
 | `register_persona_bot.py` | Safely register a new persona Telegram bot: appends its token/chat-id env vars to `.env` (append-only — a symlinked `.env` stays a symlink) and adds it to `config/telegram_bots.local.json` (seeded from the template on first use). Does not register the bot with @BotFather or restart the service — see [personas.md](personas.md#create-your-own-persona). |
 | `create-lifeos-app.sh` | Create the `LifeOS.app` Full Disk Access wrapper bundle in `/Applications` (macOS only), the FDA container cron/launchd route through for protected databases. |
+| `lifeos-agent-hook.sh` | Claude Code / Codex session-lifecycle hook — posts session_start/user_prompt_submit/stop/session_end to `POST /api/agents/cli-sessions/events` from any machine, so `/agents` shows sessions from every machine, not just this one. Installed by `install-agent-hooks.sh`; see [agents-go-to.md § 4](agents-go-to.md#4-cross-machine-session-registration). |
+| `install-agent-hooks.sh` | Idempotently installs `lifeos-agent-hook.sh` into `~/.claude/settings.json` and `~/.codex/hooks.json`. Run once per machine; safe to re-run. |
 | `preflight.sh` | Pre-flight checks (called by server.sh) |
 | `run_sync_wrapper.sh` | NVMe wake + pre-flight for nightly sync |
 | `run_sync_with_fda.sh` | FDA wrapper for phone/iMessage sync (macOS) |

--- a/docs/specs/product/agent-viz.md
+++ b/docs/specs/product/agent-viz.md
@@ -2,32 +2,79 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-05-29
+> **Last Updated:** 2026-09-03
 
-LifeOS exposes a single live page at `/agents` that shows every agent session running on the box — LifeOS agent worker tasks (`#agent`-tagged), plus local CLI sessions discovered on the filesystem from both Claude Code (`~/.claude/projects/`) and Codex (`~/.codex/sessions/`). The graph updates every 2 seconds, clicking a node opens that session's transcript in a resizable side panel, and the operator can kill any in-flight LifeOS agent or relaunch any CLI session straight from the page.
+`/agents` is a Kanban board of the operator's work queue — vault tasks, agent questions, and scheduled work in one place, organized into lanes by status and tag. A **Graph** tab keeps the earlier force-directed session graph as a secondary, read-mostly view for watching what's actively running: every LifeOS agent worker task (`#agent`-tagged), local CLI sessions discovered on the filesystem from both Claude Code (`~/.claude/projects/`) and Codex (`~/.codex/sessions/`), and Claude Code / Codex sessions registered from **any other machine** on the tailnet via a lightweight hook script.
 
-The point is one place to see what your machine is doing on your behalf: whether the agent worker is making progress on the task you left in your vault, whether a Claude Code session you forgot about is still burning tokens, whether two parallel agents have collided on the same project.
+The point is one place to see what needs attention: what's waiting on an assignment, what an agent is stuck asking about, what's scheduled to run next, and — when you want to watch the machinery — what's actually executing right now.
 
 ---
 
 ## Table of Contents
 
-1. [What you see](#what-you-see)
-2. [Two sources, one graph](#two-sources-one-graph)
-3. [Status semantics](#status-semantics)
-4. [Filters and chips](#filters-and-chips)
-5. [Side panel](#side-panel)
-6. [Operator controls — kill](#operator-controls--kill)
-7. [Operator controls — resume](#operator-controls--resume)
-8. [Privacy and exposure](#privacy-and-exposure)
-9. [Configuration knobs](#configuration-knobs)
-10. [Related Documents](#related-documents)
+1. [Kanban board](#kanban-board)
+2. [Graph tab — what you see](#graph-tab--what-you-see)
+3. [Two sources, one graph](#two-sources-one-graph)
+4. [Graph tab — Status semantics](#graph-tab--status-semantics)
+5. [Graph tab — Filters and chips](#graph-tab--filters-and-chips)
+6. [Graph tab — Side panel](#graph-tab--side-panel)
+7. [Graph tab — Operator controls — kill](#graph-tab--operator-controls--kill)
+8. [Graph tab — Operator controls — resume and Go To](#graph-tab--operator-controls--resume-and-go-to)
+9. [Privacy and exposure](#privacy-and-exposure)
+10. [Configuration knobs](#configuration-knobs)
+11. [Related Documents](#related-documents)
 
 ---
 
-## What you see
+## Kanban board
 
-The page is a force-directed graph of sessions, laid out left-to-right by recency. Each node is one session:
+The board is backed by the vault task store (`LifeOS/Tasks/`) — every card is a task, plus one card per upcoming scheduler entry. There is no separate "board" data file: a card's lane is always derived fresh from the task's status and tags, so editing a task from Obsidian, `/chat`, or a Telegram reply moves its card exactly as if it had been dragged.
+
+### Lanes
+
+| Lane | What lands here |
+|---|---|
+| **Unassigned** | An open task with no assignee tag. |
+| **Assigned** | An assignee tag is set (including `#me`) but work hasn't started. |
+| **In progress** | Status `in_progress`, or the agent worker's own `#agent-running` tag. |
+| **Human queue** | An agent is blocked on a question, or a `#human` card was filed for the operator, or the task's status is `blocked`. |
+| **Scheduled** | A scheduler entry (`docs/guides/scheduler.md`) with at least one future fire. |
+| **Review** | The agent worker's `#agent-completed` tag is set and the card hasn't been accepted yet. |
+| **Done** | Status `done` or `cancelled` (cancelled cards are hidden behind the "include cancelled" filter by default — the Done lane itself is always shown), plus scheduler entries that have fired (one-off) or been disabled (recurring). |
+
+### Assignee
+
+Assignee is a single tag, one of `#me`, `#claude`, `#codex`, `#hermes`, `#local`. Dropping a card into Assigned sets that tag and clears any other assignee tag; dropping into Unassigned clears it. Setting an assignee here is a labeling action only — it does not dispatch the task to that engine. The drawer's **Open** action starts a CLI session on an Assigned `#claude`/`#codex` card explicitly, and the worker reads the card's model/effort/host fields when it claims an `#agent` task (see [Card assignment](../technical/agent-worker.md#card-assignment-851)); today the agent worker still only claims tasks carrying its own `#agent` tag, same as before this board existed.
+
+### Cards and the drawer
+
+A card shows its title, assignee chip, model/effort chips when the task carries those fields, a host chip when a linked session is running on a known machine, its other tags, and a pulsing dot when a linked session is actively running.
+
+Clicking a card opens a drawer: an editable title and notes (notes save on blur, stored as indented `> ` lines beneath the task — see [task-management.md](task-management.md)), pickers for assignee, tags, and context, and — below those — model, effort, and host pickers for engines that accept them (`#claude`/`#codex` show all three, `#local` shows effort only, `#me`/`#hermes`/unassigned show none; model options come from the model catalog per engine, and host is free text checked against the registered hosts when the card is opened) that write the fields the executors actually read. When the card has a linked session, the drawer also shows that session's live transcript feed, the same panel the Graph tab uses. Drawer actions: **Open** (an Assigned card tagged `#claude` or `#codex` spawns the CLI on the card), **Focus** (jump to the session's terminal pane), **Kill** (stop a running session), **Answer** (reply to the agent's pending question), **Accept** (move a Review card to Done), and **Resolve** (mark a manually-filed Human queue card handled).
+
+A **New card** button opens a composer — title, optional notes, and an assignee picker — that creates a task through `POST /api/tasks`.
+
+### Pending questions
+
+When an agent asks a clarifying question, the card carrying that session shows the question text and an **Answer** button in the drawer. Answering writes the reply through the same path a Telegram reply takes — the worker resumes the session on its next tick exactly as if you'd answered by text.
+
+### Scheduled column
+
+Each card shows the entry's next fire time, a recurring badge for cron entries, and — once it has fired at least once — the most recent run's outcome and a short result snippet. The drawer's title, message, and an enabled checkbox are editable and save on blur/change through the same `PUT /api/scheduler/{id}` the `/api/scheduler` UI uses — there's no separate write path for the board. Schedule type, timing, and executor are not editable from the board; use the existing scheduler UI for those.
+
+### Filters
+
+Filters AND-compose: free-text search (title and notes), lane, assignee (including "me" and "unassigned"), host, tag, context, recency, and whether to include cancelled cards. The board updates live — an edit made directly in the vault (or by the agent worker, or by the scheduler) shows up within a few seconds without a page reload.
+
+### Out of scope (for now)
+
+Card reordering within a lane — file order is lane order. See the Kanban overhaul issue set for what's next.
+
+---
+
+## Graph tab — what you see
+
+The Graph tab is a force-directed graph of sessions, laid out left-to-right by recency. Each node is one session:
 
 | Encoding | Meaning |
 |---|---|
@@ -62,7 +109,7 @@ Between filter operations the simulation **freezes after settling** (~6s). Snaps
 
 ## Two sources, one graph
 
-The page unions three ingest paths into one rendered surface:
+The Graph tab unions three ingest paths into one rendered surface:
 
 1. **LifeOS agent worker** — every `#agent` task the worker has claimed, plus its sleeps, yields, terminal outcomes, and any spawned children. This is the same data covered by [product/agent-worker.md](agent-worker.md); the viz is the read-side view of it.
 
@@ -72,9 +119,20 @@ The page unions three ingest paths into one rendered surface:
 
 All three sources are normalized to the same shape before rendering, so filters, chips, and the side panel work identically on each kind of session. Disable an ingest path with `LIFEOS_CLAUDE_CODE_VIZ_ENABLED=false` or `LIFEOS_CODEX_VIZ_ENABLED=false` if you only want a subset.
 
+Every session, from every source, now carries a `host` field — the machine it's running on. LifeOS agent worker sessions and locally-scanned CLI transcripts always report the machine hosting the API; a session registered from elsewhere (see below) reports its own hostname.
+
+### Cross-machine CLI session registration
+
+A Claude Code or Codex session doesn't have to run on the machine hosting the API to show up here. `scripts/lifeos-agent-hook.sh`, installed for both CLIs by `scripts/install-agent-hooks.sh`, posts a lifecycle event on session start, prompt submit, stop, and session end to `POST /api/agents/cli-sessions/events` — from any machine on the tailnet, bearer-token authenticated. The API keeps a small `cli_sessions` record per session (host, cwd, branch, model, status, last prompt preview, and an optional task id read from `$LIFEOS_TASK_ID`) and merges it into the snapshot:
+
+- A session with both a registration and a local transcript (the common case on the API host itself) collapses into **one row** — status comes from the registration events (accurate: `running` right after a prompt, `idle` after Stop, `ended` after SessionEnd), while token counts and dollar cost still come from the transcript.
+- A session registered from a machine with no local transcript (every other machine) appears as its own row with `host` set to that machine's name, no token/cost detail (the hook doesn't read usage data), and status directly from the event stream — never inferred from file age.
+
+This is opt-in: the endpoint is disabled (503) until an operator sets `LIFEOS_AGENT_HOOK_TOKEN`, and each machine needs the installer run once plus a small local env file with the API URL and that same token. See [guides/agents-go-to.md](../../guides/agents-go-to.md) for setup.
+
 ---
 
-## Status semantics
+## Graph tab — Status semantics
 
 A node's color is its status. The set is slightly different per source — same broad categories, different precise meaning:
 
@@ -83,19 +141,21 @@ A node's color is its status. The set is slightly different per source — same 
 | **running** | Currently executing tool calls or LLM turns. | A live `claude` / `codex` process is running with this jsonl's cwd, **or** the file was modified in the last 10 minutes. The first is authoritative; the second is inferred. |
 | **claimed** | Worker has picked up the task but hasn't fired the executor yet (preflight is in flight). | n/a |
 | **yielded** | Paused waiting for spawned children to finish. | n/a |
+| **idle** | n/a | Registered via the session hook (#849): open and waiting for input, after a `session_start` or `stop` event. Live, not finished. |
 | **inactive** | n/a | Modified within 24h but no live process — typically you closed the terminal mid-session. Resumable. |
 | **blocked** | Waiting on a Telegram clarification from you. | n/a |
 | **completed** | Task ran to completion successfully. | jsonl is >24h old, no error in the last event. |
 | **failed** | Executor crashed, preflight rejected, or runtime error. | Last event in the jsonl was an error/tool failure (and >24h old). |
+| **ended** | n/a | Registered via the session hook (#849): a `session_end` event was received — finished. Hidden by default like completed/failed; Resume available. |
 | **budget_exceeded** | Token / wall / dollar cap breached and the session was killed externally. | n/a |
 
 A small `(inferred)` hint appears next to the status on CLI sessions whenever the status came from mtime rather than from a confirmed live process — useful to know when reading "running" on a session you don't remember starting.
 
 ---
 
-## Filters and chips
+## Graph tab — Filters and chips
 
-The top toolbar has five filter controls and four count chips. **Filters are AND-composed**; the chips reflect *what's currently visible* after the filter, not the full snapshot.
+The top toolbar has six filter controls and five count chips. **Filters are AND-composed**; the chips reflect *what's currently visible* after the filter, not the full snapshot.
 
 ### Filters
 
@@ -104,6 +164,7 @@ The top toolbar has five filter controls and four count chips. **Filters are AND
 | `include finished` checkbox | off | Off → completed / failed / budget_exceeded are hidden. On → everything shows, and the default recency window widens from 30 min to 7 days. |
 | `recency` dropdown | last 30 min (60 min, 6h, 24h, 7d, all) | Filters by `last_activity_at`. Re-defaults to a wider window when `include finished` is enabled, unless the operator has set it manually. |
 | `cwd` dropdown | all | Only Claude Code sessions are scoped to a cwd. Dropdown lists every unique cwd present in the current snapshot; auto-hides when empty (no Claude Code sessions visible). |
+| `host` dropdown | all | Limit to sessions running on a specific machine. Dropdown lists every unique `host` present in the current snapshot; auto-hides on a single-host deployment (nothing to distinguish). |
 | `route` dropdown | all (local / claude / claude_code / codex) | Filters by where the session ran — operator's local LLM, Managed Agents cloud, Claude Code CLI, or Codex CLI. |
 | `status` dropdown | all | Hard-filter by the status column from the table above. |
 
@@ -121,18 +182,21 @@ Chips re-compute after every snapshot tick, so toggling `include finished` immed
 
 ---
 
-## Side panel
+## Graph tab — Side panel
 
 Clicking any node opens a panel on the right with that session's metadata header and a live-tailing event feed. The panel header carries:
 
 - **Label** — derived from the task description (LifeOS), or the first non-empty user message (Claude Code), or the session id as a fallback. **Click it to rename:** the title becomes a text box prepopulated with the current name; Enter (or clicking away) saves, Escape cancels. A manual name is pinned durably and overrides the auto-derived label and the AI summary label everywhere the node is named (graph node, panel, search). Saving an empty value clears the override and reverts to auto-naming.
 - **cwd** — Claude Code only; the project directory the session was opened in.
+- **Branch** — the git branch of that cwd, when a registration event supplied one. Blank for sessions with no cross-machine registration (e.g. a local Claude Code transcript with no hook installed).
 - **Status badge** — same status the node is colored by, with `(inferred)` if applicable.
 - **Source** — `LifeOS agent` or `Claude Code`.
-- **Routing** — `Local`, `Claude`, or `Claude Code`.
+- **Host badge** — the machine the session is running on.
+- **Routing** — `Local`, `Claude Code`, `Codex`, `Remote`, `Hermes`, or `Claude`.
 - **Cost** — `total_dollars` to 4 decimals. For Claude Code, this is cache-aware accounting (separately tracking input, output, cache_creation @ 1.25× and cache_read @ 0.10×).
 - **Tokens** — `input↓ / output↑`.
 - **Depth badge** — if the session is a child, shows spawn depth.
+- **Last prompt preview** — the most recent prompt submitted, truncated to 200 characters, when a registration event supplied one.
 
 The event feed is newest-on-top. Backfill arrives first (the last 50 events by default), then live updates stream in via SSE. Each event has:
 
@@ -146,7 +210,7 @@ Clicking the same node again, the `×` button, or empty background area closes t
 
 ---
 
-## Operator controls — kill
+## Graph tab — Operator controls — kill
 
 LifeOS agent sessions in non-terminal states get a red **Kill** button in the panel header. Clicking it opens a confirmation modal asking for an optional reason (logged to the transcript) before firing the request.
 
@@ -161,7 +225,7 @@ CLI sessions (Claude Code and Codex) do not get a Kill button — the page has n
 
 ---
 
-## Operator controls — resume and Go To
+## Graph tab — Operator controls — resume and Go To
 
 CLI sessions (Claude Code AND Codex) get up to two buttons:
 
@@ -177,13 +241,16 @@ If a cached pane has gone stale (typical: user closed the tab), the activate-pan
 
 Resume + Go To are **off by default** because spawning GUI terminals from a systemd service depends on the operator's desktop environment. Enable with `LIFEOS_CC_RESUME_ENABLED=true` for Claude Code sessions and `LIFEOS_CODEX_RESUME_ENABLED=true` for Codex; each flag also gates Go To for its respective source. Customize launchers via `LIFEOS_CC_RESUME_CMD` / `LIFEOS_CODEX_RESUME_CMD` if you don't use WezTerm — substitutions `{cwd}`, `{cwd_url}`, `{session_id}`, `{session_id_url}`, and `{inner_command}` are available. The probe-based Go To is WezTerm-specific (it reads `wezterm cli list`'s `tty_name`); non-WezTerm launchers can still use Resume but Go To will respond 404.
 
+A session registered from another host (see "Cross-machine CLI session registration" above) resumes and focuses over ssh when that host is one of the operator's registered hosts (see [Card assignment](../technical/agent-worker.md#card-assignment-851)) — the same launcher runs remotely, so Resume and Go To work wherever the session actually lives. Only a host the operator hasn't registered still 409s: the error names that host, so the operator knows to go there instead of getting a silent no-op or a misleading 404.
+
 ---
 
 ## Privacy and exposure
 
-- The page only displays sessions running on **this** machine. No cross-host federation.
-- Transcript payloads are truncated to 240 chars in the feed previews — click an event to see the full payload only on demand.
-- The kill and resume endpoints are **local-network only**. They must not be exposed via Tailscale Funnel or the public MCP HTTP transport (the gates live in [api/routes/agents.py](../../../api/routes/agents.py); see the technical spec for the threat model).
+- The transcript scan and Resume/Go To/kill primitives only ever touch **this** machine. Cross-machine visibility is opt-in and one-directional: another machine's hook posts a small lifecycle event (host, cwd, branch, status, a truncated prompt preview) to this API — this API never reaches out to, or reads files from, another machine.
+- The registration endpoint (`POST /api/agents/cli-sessions/events`) is bearer-token gated and disabled by default (503 until `LIFEOS_AGENT_HOOK_TOKEN` is set) — unlike the kill/resume endpoints below, it's meant to be reachable over Tailscale, since that's the whole point.
+- Transcript payloads are truncated to 240 chars in the feed previews — click an event to see the full payload only on demand. A registered session's prompt preview is truncated to 200 characters at the source.
+- The kill, resume, and pane-bind (`/cc-pane-bind`, `/cx-pane-bind`) endpoints are **local-network only**. They must not be exposed via Tailscale Funnel or the public MCP HTTP transport (the gates live in [api/routes/agents.py](../../../api/routes/agents.py); see the technical spec for the threat model). Resume and Go To act on sessions recorded as running on this API's own host directly, and on a registered host over ssh; a session on an unregistered host returns an error naming that host instead.
 - Claude Code ingest is strictly read-only — LifeOS opens jsonl files for reading and never writes back.
 
 ---
@@ -197,24 +264,29 @@ All in `.env`. None are required — the defaults work for the standard LifeOS i
 | `LIFEOS_CLAUDE_CODE_VIZ_ENABLED` | Surface Claude Code CLI sessions alongside agent worker sessions. Set false to scope the viz to LifeOS sessions only. | `true` |
 | `LIFEOS_CLAUDE_CODE_PROJECTS_DIR` | Where to find Claude Code transcripts. | `~/.claude/projects` |
 | `LIFEOS_CLAUDE_CODE_LOOKBACK_DAYS` | Discovery window — older jsonl files are excluded from the snapshot (they can still be loaded by direct session id). | `7` |
-| `LIFEOS_CC_RESUME_ENABLED` | Enable the Resume and Focus buttons. | `false` |
+| `LIFEOS_CC_RESUME_ENABLED` | Enable the Resume and Focus buttons, and the board drawer's **Open** action for `#claude` cards. | `false` |
 | `LIFEOS_CC_RESUME_CMD` | Launcher command. Substitutions: `{session_id}`, `{cwd}`, `{session_id_url}`, `{cwd_url}`, `{inner_command}`. The default uses WezTerm's CLI to open a tab AND run the resume in one shot. | `wezterm cli spawn --cwd {cwd} -- {inner_command}` |
 | `LIFEOS_CC_RESUME_INNER_CMD` | The command run *inside* the spawned terminal — the actual `claude --resume` invocation. Substituted into `{inner_command}` of the launcher template. | `claude --dangerously-skip-permissions --resume {session_id}` |
 | `LIFEOS_CC_RESUME_ENV_FILE` | Optional `key=value` file pinning `DISPLAY` / `XAUTHORITY` / `WAYLAND_DISPLAY` / `DBUS_SESSION_BUS_ADDRESS` for the spawned terminal. | `` (inherit systemd env) |
 | `LIFEOS_CODEX_VIZ_ENABLED` | Surface Codex CLI sessions alongside the other sources. | `true` |
 | `LIFEOS_CODEX_SESSIONS_DIR` | Where to find Codex rollout JSONLs. | `~/.codex/sessions` |
 | `LIFEOS_CODEX_LOOKBACK_DAYS` | Discovery window for Codex rollouts. | `7` |
-| `LIFEOS_CODEX_RESUME_ENABLED` | Enable Resume + Go To for `cx:` sessions. | `false` |
+| `LIFEOS_CODEX_RESUME_ENABLED` | Enable Resume + Go To for `cx:` sessions, and the board drawer's **Open** action for `#codex` cards. | `false` |
 | `LIFEOS_CODEX_RESUME_CMD` | Codex launcher template. Same substitution surface as `LIFEOS_CC_RESUME_CMD`. | `wezterm cli spawn --cwd {cwd} -- {inner_command}` |
 | `LIFEOS_CODEX_RESUME_INNER_CMD` | Inner command inside the spawned terminal — the actual `codex resume` invocation. | `codex resume {session_id}` |
+| `LIFEOS_AGENT_HOOK_TOKEN` | Bearer token required from `scripts/lifeos-agent-hook.sh` on `POST /api/agents/cli-sessions/events`. Empty (default) disables the endpoint (503) — a fresh clone accepts no cross-machine session data until this is set. | `` |
 
 ---
 
 ## Related Documents
 
 - [ADR-011: External Agent Ingest](../../adr/011-external-agent-ingest.md) — Why Claude Code sessions surface read-only via a foreign-schema adapter
-- [Agent Viz — Technical](../technical/agent-viz.md) — Endpoint shapes, D3 force config, status inference rules, security boundaries
+- [Agent Viz — Technical](../technical/agent-viz.md) — Endpoint shapes, D3 force config, status inference rules, security boundaries, and the board's lane-derivation rules
 - [Agent Worker](agent-worker.md) — The other half of the picture: how `#agent` tasks get claimed and run
 - [Claude Code Orchestration (product)](claude-code-orchestration.md) — The orchestrator that spawns the Claude Code sessions surfaced here
 - [Agent Worker — Technical](../technical/agent-worker.md) — Sessions, transcripts, kill primitives
 - [Architecture](../technical/architecture.md) — Where the viz fits in the broader code structure
+- [Task Management](task-management.md) — The vault task store the board's cards are backed by
+- [Human Queue](../../guides/human-queue.md) — How `#human` cards are filed and auto-resolved by agents and the nightly sync
+- [Scheduler Guide](../../guides/scheduler.md) — How the Scheduled column's entries are created and edited
+- [API Reference](api-reference.md) — Board, pending-question, and lane-move endpoint shapes

--- a/docs/specs/product/agent-worker.md
+++ b/docs/specs/product/agent-worker.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-08-18
+> **Last Updated:** 2026-09-03
 
 LifeOS includes an external **agent worker** that picks up tasks you've tagged `#agent` and completes them autonomously — running locally on a self-hosted LLM or on Anthropic's Managed Agents cloud, with budget caps you can specify in the task title and full audit transcripts on every run. When the agent finishes (or gets stuck), it notifies you on Telegram. If it has a question mid-run, it asks via Telegram and waits for your reply.
 
@@ -60,6 +60,7 @@ Optional sub-tags steer routing:
 | `#cloud-sonnet` | Forces routing to Claude Sonnet on Anthropic Managed Agents. Same connector access and billing as `#cloud-haiku`. |
 | `#claude` | Forces routing to Claude Code CLI (the same surface as `/claude`). Billed against your Claude Pro subscription rather than per-token. Good for code/filesystem/browser work where the cloud connectors aren't needed. |
 | `#codex` | Forces routing to Codex CLI (the same surface as `/codex`). Billed against your ChatGPT subscription. Same caveat as `#claude`. |
+| `#hermes` | Forces routing to the Hermes backend the persona bots use. Opens a Hermes conversation seeded with the card's title and notes; the task's cost is whatever Hermes reports, not a per-token Anthropic charge. The card's open endpoint returns a `/chat?conversation=<id>` deep link for such a task rather than spawning a terminal session; the board drawer's **Open** button is currently shown for `#claude`/`#codex` cards only. |
 
 Without an explicit routing tag, the preflight reads the title. "With local agent" / "using gemma" force local, and naming an engine, model, or "anthropic"/"api" ("use claude", "with opus", "use the anthropic api") routes there — you asked, so it dispatches. A bare "cloud" in the title no longer counts (since #809, "cloud" means the remote provider, not Anthropic) — it falls through to the confirmation question below like any other guess.
 
@@ -67,7 +68,7 @@ Without an explicit routing tag, the preflight reads the title. "With local agen
 
 To skip the question entirely for a task you know needs the remote provider, tag it `#cloud`; for one that needs Anthropic's own cloud connectors, tag it `#cloud-haiku` or `#cloud-sonnet`.
 
-Tag precedence (first match wins): `#local` → `#claude` → `#codex` → `#cloud-haiku` → `#cloud-sonnet` → `#cloud`. The CLI routes (`#claude`, `#codex`) skip the cost-confirmation gate because they're subscription-billed, and so does `#cloud` (the remote provider is priced but isn't the confirmation ceremony's Anthropic "expensive exception"); per-session dollar rollups still appear in `/agents` via the rollout ingest (the `cc:` and `cx:` session rows).
+Tag precedence (first match wins): `#local` → `#claude` → `#codex` → `#hermes` → `#cloud-haiku` → `#cloud-sonnet` → `#cloud`. The CLI routes (`#claude`, `#codex`) skip the cost-confirmation gate because they're subscription-billed, and so does `#hermes` (billed however Hermes bills, not a per-token Anthropic charge) and `#cloud` (the remote provider is priced but isn't the confirmation ceremony's Anthropic "expensive exception"); per-session dollar rollups still appear in `/agents` via the rollout ingest (the `cc:` and `cx:` session rows).
 
 ---
 

--- a/docs/specs/product/api-reference.md
+++ b/docs/specs/product/api-reference.md
@@ -2,12 +2,13 @@
 
 **Status:** Complete
 **Owner:** API Gateway
-**Last Updated:** 2026-08-28
+**Last Updated:** 2026-09-03
 
-Catalog of every HTTP endpoint LifeOS exposes, with request/response shapes. Two adjacent catalogs split out for size:
+Catalog of every HTTP endpoint LifeOS exposes, with request/response shapes. Three adjacent catalogs split out for size:
 
 - **CRM endpoints** (`/api/crm/*`) → [api-crm.md](api-crm.md)
 - **MCP tool catalog** (Claude Code / Managed Agents tools) → [mcp-tools.md](mcp-tools.md)
+- **Agent activity endpoints** (`/api/agents/*` — snapshot, kill, resume, cross-machine CLI session registration) → [Agent Viz — Technical](../technical/agent-viz.md#endpoints)
 
 ---
 
@@ -18,18 +19,21 @@ Catalog of every HTTP endpoint LifeOS exposes, with request/response shapes. Two
 3. [Google Integration](#google-integration)
 4. [Messaging Endpoints](#messaging-endpoints)
 5. [CRM Endpoints — see api-crm.md](api-crm.md)
-6. [Memories Endpoints](#memories-endpoints)
-7. [Conversations Endpoints](#conversations-endpoints)
-8. [Briefing Endpoints](#briefing-endpoints)
-9. [People Endpoints](#people-endpoints)
-10. [Photos Endpoints](#photos-endpoints)
-11. [Task Endpoints](#task-endpoints)
-12. [Scheduler & Telegram Endpoints](#scheduler--telegram-endpoints)
-13. [Monarch Money Endpoints](#monarch-money-endpoints)
-14. [Job Queue Endpoints](#job-queue-endpoints)
-15. [Performance Trace Endpoints](#performance-trace-endpoints)
-16. [Admin Endpoints](#admin-endpoints)
-17. [MCP Tools — see mcp-tools.md](mcp-tools.md)
+6. [Agent Activity Endpoints — see agent-viz.md](../technical/agent-viz.md#endpoints)
+7. [Memories Endpoints](#memories-endpoints)
+8. [Conversations Endpoints](#conversations-endpoints)
+9. [Briefing Endpoints](#briefing-endpoints)
+10. [People Endpoints](#people-endpoints)
+11. [Photos Endpoints](#photos-endpoints)
+12. [Task Endpoints](#task-endpoints)
+13. [Agent Board Endpoints](#agent-board-endpoints)
+14. [Scheduler & Telegram Endpoints](#scheduler--telegram-endpoints)
+15. [Monarch Money Endpoints](#monarch-money-endpoints)
+16. [Job Queue Endpoints](#job-queue-endpoints)
+17. [Performance Trace Endpoints](#performance-trace-endpoints)
+18. [Admin Endpoints](#admin-endpoints)
+19. [Card Assignment Endpoints](#card-assignment-endpoints-851)
+20. [MCP Tools — see mcp-tools.md](mcp-tools.md)
 
 ---
 
@@ -91,9 +95,9 @@ Streaming chat with an agentic pipeline. Claude autonomously decides which tools
 **Pipeline routing (in order of priority):**
 1. **Ambiguous task/reminder** — asks user for clarification (task vs reminder vs both).
 2. **Claude intent** — terminal, filesystem, browser tasks. Yields `claude_intent` event for Telegram to spawn Claude Code.
-3. **Agentic loop** — everything else (including compose, tasks, reminders). Claude gets 21 tools and up to 5 rounds to fetch data and synthesize an answer. See `api/services/agent_tools.py::TOOL_DEFINITIONS` for the canonical list — count `len(TOOL_DEFINITIONS)` to re-derive this number.
+3. **Agentic loop** — everything else (including compose, tasks, reminders). Claude gets 22 tools and up to 5 rounds to fetch data and synthesize an answer. See `api/services/agent_tools.py::TOOL_DEFINITIONS` for the canonical list — count `len(TOOL_DEFINITIONS)` to re-derive this number.
 
-**Agentic loop tools (21):**
+**Agentic loop tools (22):**
 
 | Tool | Description |
 |------|-------------|
@@ -108,6 +112,7 @@ Streaming chat with an agentic pipeline. Claude autonomously decides which tools
 | `person_info` | Lookup or briefing (action: lookup/briefing) |
 | `search_finances` | Monarch Money live data (action: accounts/transactions/cashflow/budgets) |
 | `manage_tasks` | Create, list, or complete tasks (action: create/list/complete) |
+| `manage_human_queue` | File, list, or resolve Human-queue cards — things only the operator can do (action: add/list/resolve) |
 | `manage_schedules` | Create or list schedules (action: create/list; schedule_action: notify/prompt/endpoint/agent). `manage_reminders` kept as a deprecated alias |
 | `create_email_draft` | Gmail draft (returns a draft_id; never sends) |
 | `send_email_draft` | Send an existing Gmail draft by draft_id (gated: only after the user confirms in a later turn — a draft created this turn cannot be sent) |
@@ -738,12 +743,16 @@ Create a task. Stored as an Obsidian Tasks-compatible markdown checkbox in the v
 {
   "description": "Call dentist",
   "context": "Personal",
+  "status": "todo",
   "priority": "high",
   "due_date": "2025-02-10",
   "tags": ["health"],
-  "reminder_id": "optional-linked-reminder-uuid"
+  "reminder_id": "optional-linked-reminder-uuid",
+  "notes": "Ask about the Tuesday afternoon slot",
+  "fields": {"host": "laptop"}
 }
 ```
+`context`, `status`, `notes`, `fields`, and `reminder_id` are all optional.
 
 ### GET /api/tasks
 
@@ -756,13 +765,21 @@ List/filter tasks.
 - `due_before` (string): YYYY-MM-DD, tasks due before this date
 - `query` (string): Fuzzy text search across task descriptions
 
+### GET /api/tasks/conflicts
+
+List Syncthing conflict copies / in-progress temp files sitting in the tasks
+folder (`name`, `mtime` each) — never indexed as tasks, surfaced so a client
+can prompt the operator to resolve them by hand.
+
 ### GET /api/tasks/{id}
 
 Get a specific task.
 
 ### PUT /api/tasks/{id}
 
-Update a task (description, status, context, priority, due_date, tags).
+Update a task (description, status, context, priority, due_date, tags,
+notes, fields). `fields` merges into the task's operator/unknown fields — a
+string value sets a field, a `null` value removes it.
 
 ### PUT /api/tasks/{id}/complete
 
@@ -771,6 +788,120 @@ Mark a task as done (adds done date automatically).
 ### DELETE /api/tasks/{id}
 
 Delete a task.
+
+### POST /api/tasks/human-queue
+
+File a Human-queue card — a task with status `blocked` and tag `human` —
+for something only the operator can do. See the
+[Human Queue guide](../../guides/human-queue.md).
+
+**Request:**
+```json
+{
+  "title": "Re-authenticate the example-service session",
+  "notes": "Login expired; re-run the interactive login script.",
+  "key": "example-service-reauth",
+  "done_when": {"type": "endpoint", "path": "/api/example-service/status", "pointer": "/status", "equals": "ok"},
+  "source_host": "example-host",
+  "source_cwd": "/home/example/project"
+}
+```
+`notes`, `key`, `done_when`, `source_host`, `source_cwd`, and `source_session`
+are all optional. Filing again with an already-open `key` updates that
+card's notes instead of creating a duplicate. The request returns `422` for
+a malformed `key` or `done_when` — see the
+[Human Queue guide](../../guides/human-queue.md#done_when--auto-resolve-checks)
+for the exact rules.
+
+### GET /api/tasks/human-queue
+
+List open Human-queue cards. Returns `{"cards": [...], "total": N}`; each
+card carries `id`, `title`, `key`, `age_hours`,
+`source_host`/`source_cwd`/`source_session`, `notes`, `done_when`.
+
+### PUT /api/tasks/human-queue/{id_or_key}/resolve
+
+Mark a card done, by task id or dedupe key. `note` (optional) is appended to
+the card's notes. Returns `404` for an id or key with no open card.
+
+All task-mutating endpoints can return `409` if a concurrent external edit
+keeps winning a compare-and-swap race on the underlying file — retry the
+request.
+
+---
+
+## Agent Board Endpoints
+
+The `/agents` Kanban board (see [Agent Viz](agent-viz.md)). Lanes are derived
+from task status/tags on every read — there is no stored lane field. See
+[Agent Viz — Technical](../technical/agent-viz.md) for the derivation rules
+and the SSE update cadence.
+
+### GET /api/agents/board
+
+Full board view model, always built fresh (never cached): `{lanes:
+{unassigned, assigned, in_progress, human_queue, scheduled, review, done},
+generated_at}`. `kind` (`"task"` | `"schedule"`) is the first field of every
+card and the only discriminator between the two shapes below — both kinds
+can land in the `done` lane. Each task card carries `kind: "task"`, `id,
+title, notes, status, tags, assignee, fields, context, updated_at, session
+(nullable), pending_question (nullable)`. Each scheduled card carries `kind:
+"schedule"`, `id, name, message_content, enabled, next_fire_at, recurring,
+last_run {at, outcome, snippet} (nullable)`.
+
+### GET /api/agents/board/stream
+
+SSE stream of the board view model — emits a full `board` event whenever
+the lanes change. Reads through a short-lived shared cache (see
+[Agent Viz — Technical](../technical/agent-viz.md#board-cache)); `GET
+/api/agents/board` above never does.
+
+### PUT /api/agents/board/cards/{id}/lane
+
+Move a task card to a lane, writing the corresponding status/tag at once —
+or writing nothing and returning an error. Body: `{lane, assignee?}`.
+`lane: "done"` marks the task done; `lane: "unassigned"` clears the
+assignee tag; `lane: "assigned"` requires `assignee` (one of
+`me`/`claude`/`codex`/`hermes`/`local`) and replaces any existing assignee
+tag. `review` and `scheduled` can't be set directly (derived from a tag
+and the scheduler store, respectively) and return **400**.
+
+Three **409** cases, no write in any of them:
+- The card is worker-owned (`agent-running` or `agent-blocked` tag
+  present) and `lane` is `in_progress` or `done` — the worker owns this
+  card while it's running or waiting on an answer; answer the question or
+  kill the session first.
+- The card's assignee is an agent engine that hasn't been claimed by the
+  worker yet and `lane` is `in_progress` — only the agent worker claims
+  agent-assigned tasks.
+- The card is a pending review (`agent-completed` tag without `accepted`)
+  and `lane` is `in_progress` or `human_queue` — accept or reject the
+  review first. `lane: "done"` on a pending review still succeeds and acts
+  as accept (adds `accepted`), same as `POST .../accept`.
+
+On success, the response's `lane` is the card's actual landed lane, which
+for `lane: "assigned"`/`"unassigned"` (tags-only writes) can differ from
+the requested lane if a higher-priority signal still applies — e.g. a
+Human-queue card assigned to someone stays in Human queue. The web board
+toasts when this happens.
+
+### POST /api/agents/board/cards/{id}/accept
+
+Move a Review card to Done by adding the `accepted` tag. Idempotent.
+Returns **409** if the card isn't in the Review lane and isn't already
+accepted.
+
+### GET /api/agents/pending-questions
+
+List unanswered agent questions: `{questions: [{id, task_id, session_id,
+question, asked_at, bot}]}`.
+
+### POST /api/agents/pending-questions/{id}/answer
+
+Answer a pending question. Body: `{answer}`, 1-4096 characters — an empty,
+whitespace-only, or over-length answer returns **400**. Writes the same
+columns a Telegram reply would — the agent worker resumes the session on
+its next tick unchanged.
 
 ---
 
@@ -972,13 +1103,31 @@ Get usage summary with stats for 24h, 7d, 30d, and all-time. Includes daily cost
 
 ---
 
+## Card Assignment Endpoints (#851)
+
+Card kill/resume/focus/registration endpoints are documented in [agent-viz.md § Endpoints](../technical/agent-viz.md#endpoints) alongside the rest of the `/agents` operator-control surface, per item 6 of this file's Table of Contents. These two are new to this issue and don't fit that page's visualization framing, so they're listed here instead — full mechanism in [agent-worker.md § Card assignment](../technical/agent-worker.md#card-assignment-851).
+
+### GET /api/agents/models
+
+Per-engine model catalog for the board's assignment pickers: `{engines: {claude: [...], codex: [...], local: [...], hermes: [...]}, refreshed_at, stale}`, each entry `{id, label, pricing}`. Cached for `LIFEOS_AGENT_MODEL_CATALOG_TTL_SECONDS` (default 24h); `stale: true` means the last successful refresh, not this one, is being served.
+
+### POST /api/agents/board/cards/{id}/open
+
+Open an Assigned card (`status == "todo"`, a recognized assignee tag, no session already running against it) — `409` otherwise. `claude`/`codex` spawn the interactive CLI in a terminal (local, or over ssh for a registered `host` field), seeded with the card's title/notes and `LIFEOS_TASK_ID` in the environment; `hermes` returns `{open_url: "/chat?conversation=<id>"}` once the card has a Hermes conversation, else `409`.
+
+`409` also covers: a second open on the same card within a 30-second grace window after the first open claimed it but before its session has registered (`card open is already in progress` — guards a double-click racing the spawn, not a permanent lock); and a `host` field naming a value absent from `LIFEOS_AGENT_HOSTS` (`host '<name>' is not configured in LIFEOS_AGENT_HOSTS`).
+
+---
 
 ## Related Documents
 
 - [api-crm.md](api-crm.md) — `/api/crm/*` HTTP endpoints (split out from this file)
 - [mcp-tools.md](mcp-tools.md) — MCP tool catalog (the canonical home — was previously duplicated here)
+- [Agent Viz — Technical](../technical/agent-viz.md) — `/api/agents/*` endpoints in detail, including cross-machine CLI session registration
+- [Agent Worker — Technical](../technical/agent-worker.md) — Card assignment mechanism behind the Card Assignment Endpoints above
 - [Data & Sync](../technical/data-and-sync.md) — Data sources and sync pipeline
 - [Chat UI](chat-ui.md) — Chat interface product spec
 - [Client Surfaces](../technical/client-surfaces.md) — HTTP consumers and breaking-change policy
 - [CRM UI](crm-ui.md) — CRM index pointing at the four product sub-specs
 - [Configuration](../../guides/configuration.md) — Env vars referenced by several endpoints (LIFEOS_USER_NAME, LIFEOS_WORK_DOMAIN, etc.)
+- [Agent Viz](agent-viz.md) — The `/agents` Kanban board these endpoints back

--- a/docs/specs/product/mcp-tools.md
+++ b/docs/specs/product/mcp-tools.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** API Gateway
-> **Last Updated:** 2026-08-19
+> **Last Updated:** 2026-09-03
 
 MCP (Model Context Protocol) server that exposes LifeOS capabilities to AI assistants like Claude Code.
 
@@ -90,6 +90,16 @@ Tasks can also be managed via natural language chat. See [Task Management spec](
 | `lifeos_task_update` | Update a task's description, status, context, priority, due date, or tags |
 | `lifeos_task_complete` | Mark a task as done |
 | `lifeos_task_delete` | Delete a task |
+
+### Human Queue Tools
+
+Fire-and-forget cards for something only the operator can do. See the [Human Queue guide](../../guides/human-queue.md).
+
+| Tool | Description |
+|------|-------------|
+| `lifeos_human_queue_add` | File a card for the operator; dedupes on an optional key |
+| `lifeos_human_queue_list` | List open cards waiting on the operator |
+| `lifeos_human_queue_resolve` | Mark a card done by id or key, with a resolution note |
 
 ### Scheduler & Telegram Tools
 

--- a/docs/specs/product/task-management.md
+++ b/docs/specs/product/task-management.md
@@ -2,9 +2,9 @@
 
 > **Status:** Complete
 > **Owner:** Task Management
-> **Last Updated:** 2026-02-19
+> **Last Updated:** 2026-09-03
 
-LifeOS provides a task management system fully integrated with Obsidian Tasks plugin. Tasks are stored as markdown checkboxes in your vault and can be managed via chat, API, or Obsidian.
+LifeOS stores tasks as markdown checkboxes in your vault, in a format the Obsidian Tasks plugin can query and display, and manages them via chat, API, or Obsidian. Any checkbox line in `LifeOS/Tasks/*.md` counts as a task — you don't need to type LifeOS's own conventions by hand, and a plain hand-written checklist item is picked up on the next reindex. LifeOS's non-standard statuses (In Progress, Deferred, Blocked, Urgent — see below) render as generic checkboxes in Obsidian until you add them under the Tasks plugin's own "Custom statuses" settings; the plugin doesn't know about them out of the box.
 
 ## Storage Format
 
@@ -15,6 +15,16 @@ LifeOS provides a task management system fully integrated with Obsidian Tasks pl
 Example task line:
 ```
 - [ ] TODO Call dentist [due:: 2025-02-10] [created:: 2025-02-07] #health <!-- id:abc123 -->
+```
+
+A task can also carry a multi-line notes body, stored as indented `> ` lines
+beneath the task line, and operator fields (`host`, `effort`, `model`, `key`,
+or any custom `[key:: value]`) that round-trip through any edit unchanged:
+
+```
+- [ ] TODO Call dentist [due:: 2025-02-10] [created:: 2025-02-07] [host:: laptop] #health <!-- id:abc123 -->
+    > Ask about the Tuesday afternoon slot
+    > Bring insurance card
 ```
 
 ## Custom Statuses
@@ -30,6 +40,11 @@ LifeOS uses checkbox symbols to represent task states:
 | Deferred | `[>]` | Postponed |
 | Blocked | `[?]` | Waiting on dependency |
 | Urgent | `[!]` | High priority |
+
+In Progress, Deferred, Blocked, and Urgent are LifeOS conventions, not
+Obsidian Tasks plugin defaults — add them under the plugin's own settings
+(Tasks → Custom statuses) if you want Obsidian to show and filter on them
+correctly. Todo and Done need no configuration.
 
 ## Creating Tasks
 
@@ -49,11 +64,20 @@ curl -X POST http://localhost:8000/api/tasks \
   -d '{
     "description": "Call dentist",
     "context": "Personal",
+    "status": "blocked",
     "priority": "high",
     "due_date": "2025-02-10",
-    "tags": ["health"]
+    "tags": ["health"],
+    "notes": "Ask about the Tuesday afternoon slot",
+    "fields": {"host": "laptop"}
   }'
 ```
+
+`context`, `status`, `notes`, and `fields` are all optional — omit `context`
+for Inbox, `status` for `todo`. Note: the chat/Telegram assistant's task tool
+always files new tasks in Inbox regardless of what you say, to avoid it
+guessing a wrong context — file directly to a context via the API or MCP
+tools, or move the task afterward.
 
 ### Via MCP Tools
 
@@ -106,9 +130,15 @@ curl -X PUT http://localhost:8000/api/tasks/{id} \
   -H "Content-Type: application/json" \
   -d '{
     "status": "in_progress",
-    "priority": "high"
+    "priority": "high",
+    "notes": "Waiting on the pharmacy callback",
+    "fields": {"host": null}
   }'
 ```
+
+`notes` replaces the notes body outright. `fields` is a merge, not a
+replacement: a string value sets that field, a `null` value removes it, and
+any field you don't mention is left alone.
 
 ### Delete Tasks
 
@@ -130,10 +160,12 @@ Create a task with an associated reminder in one command:
 "add a task to call the dentist and remind me Friday at 3pm"
 ```
 
-The system will:
-1. Create the task
-2. Create a reminder for Friday 3pm
-3. Link them via `reminder_id` field
+This is chat orchestration, not a single API call: the assistant creates the
+task, creates a schedule for Friday 3pm, and links them by passing the
+schedule's id as the task's `reminder_id`. Calling the task and schedule
+APIs directly does the same in two calls — pass `reminder_id` on
+`POST /api/tasks` (see [Scheduler Guide](../../guides/scheduler.md) for
+creating the schedule itself).
 
 ## Obsidian Dashboard
 
@@ -148,29 +180,53 @@ The dashboard includes:
 - Blocked tasks
 - Recently completed tasks
 
-The dashboard uses Obsidian Tasks plugin queries and updates automatically as tasks change in Obsidian. It is created by TaskManager on initialization if it doesn't already exist.
+The dashboard uses Obsidian Tasks plugin queries and regenerates on every
+task change through the API immediately, and within a few seconds of an
+edit made directly in Obsidian (the file watcher debounces external edits
+before reindexing). It is created by TaskManager on initialization if it
+doesn't already exist.
+
+A Syncthing conflict copy or in-progress temp file in `LifeOS/Tasks/` is
+never shown on the dashboard and never indexed as a task — it's surfaced
+instead via `GET /api/tasks/conflicts` so a client can prompt you to resolve
+it by hand.
 
 ## API Reference
 
 | Method | Endpoint | Parameters | Description |
 |--------|----------|------------|-------------|
-| POST | `/api/tasks` | description, context, priority, due_date, tags, reminder_id | Create a task |
+| POST | `/api/tasks` | description, context, status, priority, due_date, tags, reminder_id, notes, fields | Create a task |
 | GET | `/api/tasks` | status, context, tag, due_before, query | List/filter tasks |
+| GET | `/api/tasks/conflicts` | - | List Syncthing conflict/temp files sitting in the tasks folder |
 | GET | `/api/tasks/{id}` | - | Get specific task |
-| PUT | `/api/tasks/{id}` | description, status, context, priority, due_date, tags | Update a task |
+| PUT | `/api/tasks/{id}` | description, status, context, priority, due_date, tags, notes, fields | Update a task |
 | PUT | `/api/tasks/{id}/complete` | - | Mark as done |
 | DELETE | `/api/tasks/{id}` | - | Delete a task |
+| POST | `/api/tasks/human-queue` | title, notes, key, done_when, source_host, source_cwd, source_session | File (or dedupe-update) a Human-queue card |
+| GET | `/api/tasks/human-queue` | - | List open Human-queue cards |
+| PUT | `/api/tasks/human-queue/{id_or_key}/resolve` | note | Resolve a Human-queue card |
+
+A task response also includes `updated_at` (an ISO-8601 timestamp with a UTC
+offset, stamped on every create/update/complete/swap-tag) alongside the
+fields above.
 
 ## Technical Details
 
-- Task files are the source of truth (markdown in vault)
+- Task files are the source of truth (markdown in vault); writes are atomic (a reader never sees a partial file)
 - `data/task_index.json` is a query cache rebuilt from markdown
 - Vault file watcher triggers automatic reindexing on changes
+- A task keeps its identity across an external edit that shifts its line number — writes locate it by id, not by a cached position
 - Compatible with Obsidian Tasks plugin for viewing/editing in Obsidian
 - Uses Dataview inline field format for metadata
+
+See [Task Management — Technical](../technical/task-management.md) for how
+id-addressed writes, the notes body, and conflict-file handling actually work.
 
 ## Related Documents
 
 - [API Reference](api-reference.md) -- Task API endpoint contracts
+- [Task Management — Technical](../technical/task-management.md) -- Engineering internals: id-addressed CAS writes, notes body, external-edit detection, conflict files
 - [Scheduler Guide](../../guides/scheduler.md) -- Schedules; the `agent` action writes `#agent` tasks here
 - [Agent Worker](agent-worker.md) -- Tasks tagged `#agent` are picked up by the autonomous worker for hands-free completion
+- [Human Queue](../../guides/human-queue.md) -- Human-queue cards are tasks tagged `human` with status `blocked`
+- [Agent Viz](agent-viz.md) -- The `/agents` Kanban board is a card-per-task view backed by this store

--- a/docs/specs/technical/AGENTS.md
+++ b/docs/specs/technical/AGENTS.md
@@ -13,6 +13,7 @@ This directory contains technical specifications — how the system is built fro
 - `scheduler.md` — Scheduler internals (markdown source of truth + index cache, round-trip, watcher reindex, firing/dispatch)
 - `search-indexing.md` — Hybrid search internals (vector + BM25 fusion, embedding pipeline integration)
 - `security-privacy.md` — Auth, network exposure, data-at-rest, privacy invariants
+- `task-management.md` — Task store internals (id-addressed CAS writes, notes body, external-edit detection, conflict-file handling)
 
 ## Key Principles
 

--- a/docs/specs/technical/agent-viz.md
+++ b/docs/specs/technical/agent-viz.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-05-29
+> **Last Updated:** 2026-09-03
 
 Engineering view of the `/agents` page — endpoint shapes, ingest paths, status inference, layout, and security boundaries. For the consumer view see [product/agent-viz.md](../product/agent-viz.md).
 
@@ -12,19 +12,21 @@ Engineering view of the `/agents` page — endpoint shapes, ingest paths, status
 
 1. [Architecture overview](#architecture-overview)
 2. [Endpoints](#endpoints)
-3. [Snapshot shape](#snapshot-shape)
-4. [LifeOS agent ingest](#lifeos-agent-ingest)
-5. [Claude Code ingest](#claude-code-ingest)
-6. [Status inference (Claude Code)](#status-inference-claude-code)
-7. [Live process detection](#live-process-detection)
-8. [Snapshot caching](#snapshot-caching)
-9. [D3 force-graph](#d3-force-graph)
-10. [Side-panel SSE](#side-panel-sse)
-11. [Operator kill](#operator-kill)
-12. [Claude Code resume](#claude-code-resume)
-13. [Worker resilience](#worker-resilience)
-14. [Security boundaries](#security-boundaries)
-15. [Related Documents](#related-documents)
+3. [Kanban board](#kanban-board)
+4. [Snapshot shape](#snapshot-shape)
+5. [LifeOS agent ingest](#lifeos-agent-ingest)
+6. [Claude Code ingest](#claude-code-ingest)
+7. [Status inference (Claude Code)](#status-inference-claude-code)
+8. [Live process detection](#live-process-detection)
+9. [Cross-machine CLI session registration](#cross-machine-cli-session-registration)
+10. [Snapshot caching](#snapshot-caching)
+11. [D3 force-graph](#d3-force-graph)
+12. [Side-panel SSE](#side-panel-sse)
+13. [Operator kill](#operator-kill)
+14. [Claude Code resume + Go To](#claude-code-resume--go-to)
+15. [Worker resilience](#worker-resilience)
+16. [Security boundaries](#security-boundaries)
+17. [Related Documents](#related-documents)
 
 ---
 
@@ -32,8 +34,11 @@ Engineering view of the `/agents` page — endpoint shapes, ingest paths, status
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
-│                          web/agents.html                                  │
-│   D3 force-simulation graph, SSE consumer, side panel, kill/resume UI     │
+│  web/agents.html (shell + tabs)                                           │
+│    web/agents/board.js  — Kanban board, drag/drop, drawer                 │
+│    web/agents/graph.js  — D3 force-simulation graph (Graph tab, lazy-init)│
+│    web/agents/panel.js  — shared session-detail panel (both tabs)         │
+│    web/agents/assignment.js — model/effort/host pickers (board drawer)    │
 └─────────────────────────────┬────────────────────────────────────────────┘
                               │ HTTP + SSE
                               ▼
@@ -41,6 +46,8 @@ Engineering view of the `/agents` page — endpoint shapes, ingest paths, status
 │                       api/routes/agents.py                                │
 │   /api/agents/snapshot · /stream · /sessions/{id}/events · /stream       │
 │                       · /kill · /resume                                   │
+│   /api/agents/board · /board/stream · /board/cards/{id}/lane · /accept   │
+│   /api/agents/pending-questions · /pending-questions/{id}/answer         │
 └────┬───────────────────────────────────┬─────────────────────────────────┘
      │ LifeOS agent worker               │ Claude Code CLI
      ▼                                   ▼
@@ -54,13 +61,18 @@ Engineering view of the `/agents` page — endpoint shapes, ingest paths, status
 └─────────────────────────┘    └──────────────────────────────────────────┘
 ```
 
+The board joins two more read paths not pictured above: `TaskManager` (the
+vault task store, `api/services/task_manager.py`) and `SchedulerStore`
+(`api/services/scheduler_store.py`) — both already-owned singletons the
+board route reads from directly, same pattern as `SessionStore`/`TranscriptStore`.
+
 The route file imports the worker's `SessionStore` and `TranscriptStore` directly (read-only) and unions their output with the Claude Code adapter's normalized shape. No second worker process; the API server reads the same SQLite + JSONL files the worker writes.
 
 ---
 
 ## Endpoints
 
-All under `/api/agents`. Local-network only — the kill and resume endpoints must not be exposed via the public MCP HTTP transport.
+All under `/api/agents`. Local-network only, with one deliberate exception: `POST /cli-sessions/events` (#849) is meant to be reachable over Tailscale, gated by a bearer token instead of an IP check — see [Security boundaries](#security-boundaries). The kill, resume, focus, and pane-bind endpoints must not be exposed via the public MCP HTTP transport.
 
 | Method + Path | Purpose |
 |---|---|
@@ -70,11 +82,57 @@ All under `/api/agents`. Local-network only — the kill and resume endpoints mu
 | `GET /sessions/{id}/stream?backfill=N` | Per-session SSE: backfill last N events (default 50, max 500), then live-tail. Closes cleanly when the session reaches terminal status (LifeOS) or after 5 min idle (Claude Code). |
 | `POST /sessions/{id}/kill` | Operator kill — body `{reason: ""}`. LifeOS sessions only. Cascades to descendants in the subtree. |
 | `PUT /sessions/{id}/label` | Set or clear an operator-pinned manual label — body `{label: ""}`. Non-empty pins a custom node name that overrides the auto-derived label and AI summary label everywhere it's shown; empty clears it. Durable in `data/agent_viz_label_overrides.db` (in-process cache, lazy-loaded). Works for both LifeOS and `cc:` sessions. |
-| `POST /sessions/{id}/resume` | Resume a Claude Code session — body `{extra_env: {}}`. `cc:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED`. Spawns a WezTerm tab via `wezterm cli spawn`, captures the pane id from stdout, and stores `session_id → pane_id` in `data/cc_wezterm.db` so Focus can target it later. |
-| `POST /sessions/{id}/focus` | Activate the WezTerm pane for this session (Go To). `cc:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED`. Resolves the pane id from the cached mapping first, then falls back to an FD probe (lsof + /proc + wezterm cli list) so it works for sessions never opened via Resume. 404 only when both the cache *and* the probe come up empty; 410 when the pane existed but is gone and no replacement is found. |
+| `POST /sessions/{id}/resume` | Resume a Claude Code session — body `{extra_env: {}}`. `cc:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED`. Spawns a WezTerm tab via `wezterm cli spawn`, captures the pane id from stdout, and stores `session_id → pane_id` in `data/cc_wezterm.db` so Focus can target it later. 409 if the `cli_sessions` row for this id records a `host` other than this API's own (see [Cross-machine CLI session registration](#cross-machine-cli-session-registration)). |
+| `POST /sessions/{id}/focus` | Activate the WezTerm pane for this session (Go To). `cc:`-prefixed ids only. Gated on `LIFEOS_CC_RESUME_ENABLED`. Resolves the pane id from the cached mapping first, then falls back to an FD probe (lsof + /proc + wezterm cli list) so it works for sessions never opened via Resume. 404 only when both the cache *and* the probe come up empty; 410 when the pane existed but is gone and no replacement is found. Same 409-for-remote-host rule as `/resume`. |
 | `POST /cc-pane-bind` | Localhost-only endpoint called by the Claude Code SessionStart hook. Body `{session_id, pane_id, cwd}`. Upserts the mapping in `cc_wezterm.db` so Go To can target newly-started `claude` invocations without a probe. 403 from non-loopback callers. |
+| `POST /cx-pane-bind` | Codex sibling of `/cc-pane-bind`. Same body shape and localhost-only gate; keys `cx:`-prefixed rows in the same store. |
+| `POST /cli-sessions/events` | Cross-machine session registration (#849) — see [Cross-machine CLI session registration](#cross-machine-cli-session-registration). Bearer-token gated, reachable from any host. Body `{engine, event, session_id, host, cwd?, transcript_path?, branch?, model?, prompt_preview?, task_id?, pane_id?, wezterm_pid?}`. |
 
 Heartbeats: per-session SSE emits a `:heartbeat\n\n` comment every 15s when there's no new event, so dropped connections surface quickly through the browser's `EventSource` retry.
+
+`GET /sessions/{id}/stream` dispatches by prefix: `cc:` to the Claude Code ingest path, `cx:` to the Codex ingest path (`_stream_codex_session`, mirroring `_stream_claude_code_session` — same 1s poll loop, same 5-minute idle close, no DB status to read), everything else to the LifeOS transcript store. Before this the `cx:` branch was missing and fell through to the LifeOS path, which 400'd on the prefix — opening a Codex session's panel never streamed.
+
+---
+
+## Kanban board
+
+`api/services/agent_board.py` holds every pure decision the board makes — lane derivation, lane-move planning, and the scheduler-entry Scheduled/Done split — with no I/O. `api/routes/agents.py` does the reading and writing; it never re-derives a rule the service module already owns. Unit tests in `tests/test_agent_board.py` cover one case per row of the lane table plus the priority-ordering edge cases (e.g. an `agent-completed` tag beats a terminal status, so a worker-finished task still surfaces in Review instead of silently landing in Done).
+
+### Endpoints
+
+| Method + Path | Purpose |
+|---|---|
+| `GET /board` | Full view model, always built fresh — `run_in_threadpool(_build_board)` on every call, never served from the stream's cache (see below). `_build_board()` reads `TaskManager.list_tasks()`, joins each task's linked session (matched by `task_id` against the same `_build_snapshot()` sessions list `/snapshot` returns) and any open pending question (matched by `task_id`), derives its lane via `agent_board.derive_lane`, and separately buckets every `SchedulerStore` entry into `scheduled` or `done` via `agent_board.is_schedule_active`. |
+| `GET /board/stream` | SSE. Ticks every `_BOARD_STREAM_INTERVAL = 0.5s`, reads the board through the shared `_board_cache` (TTL `_BOARD_CACHE_TTL = 0.25s`), and only emits a `board` event when a JSON-serialized signature of `lanes` differs from the last sent tick — an idle board doesn't push empty ticks to a connected client. |
+| `PUT /board/cards/{id}/lane` | Body `{lane, assignee?}`. Reads the task, calls `agent_board.plan_lane_move`, and applies the resulting `status`/`tags` patch via one `TaskManager.update` call (or raises the planned error and writes nothing). 400 for an unknown or undroppable (`review`/`scheduled`) lane; 409 for a worker-owned card (`agent-running`/`agent-blocked` tag present) dropped on `in_progress` or `done`; 409 for an agent-engine-assigned-but-unclaimed card dropped on `in_progress`; 409 for a pending Review card (`agent-completed` without `accepted`) dropped on `in_progress` or `human_queue` (dropping it on `done` still doubles as accept — see below). A 200 response's `lane` is the card's actual landed lane, which for the tags-only `assigned`/`unassigned` targets may differ from the requested lane if a higher-priority signal (e.g. Human queue) still applies — the frontend toasts when this happens (see [Frontend module split](#frontend-module-split)). |
+| `POST /board/cards/{id}/accept` | Adds the `accepted` tag (see `ACCEPTED_TAG`) and sets `status="done"` if either isn't already true; a no-op write-wise (no `TaskManager.update` call at all) when both already hold, so the endpoint is genuinely idempotent — not just safe to call twice. |
+| `GET /pending-questions` | `session_store.list_open_questions()` — unanswered, unprocessed, not-timed-out `pending_questions` rows whose `kind` is `clarification` or `goal_approval`; `followup` (completion notices) and `status_anchor` (routing plumbing) rows are excluded so a Review card never renders a fake pending-question badge. |
+| `POST /pending-questions/{id}/answer` | `session_store.deposit_answer_by_id(question_id, answer)` — writes `answer`/`answered_at` on that exact row id, then invalidates `_board_cache` so the stream's next tick reflects it immediately. |
+
+### Why the board SSE isn't event-driven
+
+The issue's target is "reflects an external vault edit within ~3 seconds," and the task watcher's own debounce (`api/services/task_watcher.py`, `_DEBOUNCE_SECONDS = 2.0`) already spends most of that budget before `TaskManager`'s in-memory index even updates. Wiring a real push (an `asyncio.Event` set from the watcher's background thread via `loop.call_soon_threadsafe`, fanned out to every open SSE connection) would work but adds real cross-thread state for a three-second target that a fast poll already meets comfortably: both `TaskManager` and `SchedulerStore` serve `list_tasks()`/`list_all()` from an in-memory dict, so rebuilding the board costs a dict walk, not disk or DB I/O. `tests/test_agents_board_watch.py` proves the actual (not sped-up) production debounce lands well inside 3 seconds by starting a real `TaskWatcher` against a temp vault, writing an external edit, and polling the stream's own cached read (`_get_board_cached()`) until the change shows up.
+
+### Board cache
+
+`_board_cache` is a module-level `(built_at, board)` tuple used ONLY by `GET /board/stream`'s own tick — never by `GET /board`, which always calls `_build_board()` fresh. The cache exists to de-duplicate simultaneous stream connections within the same instant (multiple open board tabs shouldn't each pay the full build cost on every tick), not to skip rebuilds between ticks: its TTL (`_BOARD_CACHE_TTL = 0.25s`) is far shorter than the tick interval (`_BOARD_STREAM_INTERVAL = 0.5s`). `_invalidate_board_cache()` drops it immediately after every board write — lane-move, accept, and pending-question answer — so a stream tick right after a write never serves pre-write data. Worst-case latency from an external vault edit to every open board tab reflecting it is the sum of three independent legs: the task watcher's debounce (2.0s) + the cache TTL (0.25s, only matters if a tick lands mid-window) + the stream's own tick interval (0.5s) = 2.75s, inside the 3s budget. A direct `GET /board` skips the last two legs entirely since it never reads the cache.
+
+### Pending-question answer path
+
+`SessionStore.deposit_answer_by_id` (new in #850, alongside the pre-existing `deposit_answer` keyed by Telegram message id and `deposit_answer_by_session_id` keyed by session) sets exactly the columns `deposit_answer` sets — `answer` and `answered_at` on the matched `pending_questions` row, gated on `answered_at IS NULL AND timed_out = 0 AND kind != 'status_anchor'`. `worker.py::_process_clarification_answers` drains any row with `answered_at IS NOT NULL AND processed = 0` on its next tick regardless of which `deposit_answer*` method wrote it — the board's answer endpoint needed no change to `worker.py`.
+
+### Frontend module split
+
+`web/agents.html` used to be one 2,600-line file (inline CSS + a single IIFE covering the graph, side panel, filters, and search). It's now a shell (CSS + tab markup) plus four ES modules under `web/agents/`, served the same way `web/chat/`'s split (#360) is — `<script type="module">` tags resolving against the existing `/static` mount, no bundler:
+
+- **`panel.js`** — the shared session-detail panel: header render, inline label edit, backfill + live SSE transcript tail, LLM summary fetch, and the kill/resume/focus actions, plus the small cross-cutting helpers (`routingLabel`, `escapeHtml`, `showToast`, `prettyPayload`, …) both other modules import. Exports a `SessionPanel` class constructed with a `container` element rather than hardcoded ids, so the Graph tab's side panel and the Board tab's drawer can each hold an independent instance without DOM id collisions (both tabs' markup stays mounted; only one is visible via `[hidden]`).
+- **`graph.js`** — the D3 force-simulation graph, filters, chips, and search, moved with the rendering/simulation/interaction code unchanged; only the panel-specific calls were swapped for a `SessionPanel` instance. Exports `initGraph()`, called once, lazily, the first time the operator opens the Graph tab — so loading the board (the default view) doesn't also open a second SSE connection (`/api/agents/stream`) nobody is watching.
+- **`board.js`** — the Kanban board: fetch + SSE, lane rendering, filters, and the drawer. Exports `initBoard()`, called immediately on page load.
+- **`assignment.js`** — the card-assignment pickers (engine/model/effort/host) that `board.js` mounts into the drawer; writes `model`/`effort`/`host` (+ `assigned_by`) through `PUT /api/tasks/{id}` and reads `GET /api/agents/models` for the model options. Standalone module from #851, wired in by #859.
+
+**Drag and drop is pointer-based, not the native HTML5 Drag and Drop API.** `draggable="true"` + `dragstart`/`dragover`/`drop` only fires through the browser's OS-level drag gesture — synthetic mouse events (Playwright's included) can't reliably trigger it, which would have made the server-free browser test (`tests/test_agents_board_ui_browser.py`) unable to drive a drag at all. `board.js` instead tracks `mousedown` → `mousemove` (past a 4px threshold, to distinguish a drag from a click) → `mouseup`, rendering a floating ghost card and using `document.elementFromPoint` to resolve the lane under the cursor. The trailing `click` event that a `mouseup` also fires is suppressed via a `suppressNextClick` flag set only when a real drag happened, so the same gesture never both moves a card and opens its drawer.
+
+A successful drop always re-fetches the board (`fetchBoard()`) rather than mutating the DOM optimistically — the server is the single source of truth for a card's lane, and a rejected move (400/409/500) leaves the card exactly where the last successful fetch put it, with a toast surfacing the server's error text.
 
 ---
 
@@ -112,10 +170,13 @@ One session row, unified shape (both sources):
 | `model_label` | str | Short badge — `Local` / `Haiku` / `Sonnet` / `Opus` / `Claude Code`. |
 | `last_event_kind` | str | Most recent transcript event kind — drives the side-panel "last" tooltip. |
 | `tool_call_count`, `error_count` | int | Summed across the transcript tail (last 100 events). |
-| `source` | str | `lifeos_agent` or `claude_code`. Frontend uses this to pick the shape. |
-| `status_inferred` | bool | Claude Code only. `false` means status came from a confirmed live process. |
+| `source` | str | `lifeos_agent`, `claude_code`, or `codex`. Frontend uses this to pick the shape. |
+| `status_inferred` | bool | `false` means status came from a confirmed live process or from a `cli_sessions` registration event; `true` means it was guessed from transcript mtime. |
 | `project_key`, `decoded_cwd` | str | Claude Code only. `project_key` is the dir name under `~/.claude/projects/`; `decoded_cwd` is the original cwd. |
 | `is_subagent` | bool | True for synthetic Task/Agent tool-use children. |
+| `host` | str | The machine this session is running on (#849). Always present — LifeOS and locally-scanned CLI rows get the API's own host (`api_host_name()`); a row that also has (or only has) a `cli_sessions` registration gets that row's `host` instead. |
+| `branch` | str \| null | Git branch of the session's cwd, from the most recent registration event. Only present on a session with at least one `cli_sessions` row. |
+| `prompt_preview` | str \| null | Most recent user prompt, truncated to 200 chars, from the most recent `user_prompt_submit` registration event. Only present on a session with at least one `cli_sessions` row. |
 
 ---
 
@@ -126,7 +187,7 @@ Read paths in `api/routes/agents.py`:
 - `_session_to_dict(s, transcript)` — projects a `Session` row to the snapshot shape. Defends against the optional `total_cache_*_tokens` attrs being absent on old rows.
 - `_label_for_session(s, events)` — walks the first five transcript events looking for `description` / `task_description` / `prompt`; falls back to the session id. Result cached per session id (capped at 500 entries).
 - `_summarize_events(events)` — counts tool calls and errors across the last 100 events. `_is_error_kind` matches the literal set `{failed, managed_failed, child_failed_internal, killed, cascade_killed}` plus any kind ending in `_failed` or `_error` (future-proof).
-- `_model_label_for_routing(routing)` — derives the model badge from `settings.agent_managed_model`. Falls back to `Claude` if the model name doesn't match any known family.
+- `_model_label_for_routing(routing)` — `local` → `Local`, `remote` → `Remote`, `hermes` → `Hermes` (fixed in #850 — previously fell through to the Claude-model-name guess below and was mislabeled `Claude`), otherwise derives the badge from `settings.agent_managed_model`. Falls back to `Claude` if the model name doesn't match any known family.
 
 Per snapshot tick the route calls `session_store.list_sessions(limit=200)` (newest-first) and emits one edge per session with a `parent_session_id`. Subagents that exist only inside the transcript (no SessionStore row) do not appear in this path — they show up via the Claude Code ingest below.
 
@@ -168,6 +229,11 @@ Subagent spawns are detected when an assistant message contains a `tool_use` blo
 | Older + last event was an error | `failed` | `True` |
 | Older + pending tool in flight | `inactive` | `True` |
 | Otherwise | `completed` | `True` |
+| `cli_sessions` row present, latest event `session_start` or `stop` | `idle` | `False` |
+| `cli_sessions` row present, latest event `user_prompt_submit` | `running` | `False` |
+| `cli_sessions` row present, latest event `session_end` | `ended` | `False` |
+
+When a session has a `cli_sessions` registration (see [Cross-machine CLI session registration](#cross-machine-cli-session-registration)), that row's event-driven status replaces this file-age inference entirely — `status_inferred` is `False` regardless of what the mtime-based signals above would have guessed.
 
 The 10-minute `running` window is wider than the wall-clock-precise definition because Claude Code appends in bursts during a single turn and a tight 60-second threshold flipped sessions to `inactive` mid-pause. The `(inferred)` hint in the side panel lets the operator distinguish authoritative from heuristic status reads.
 
@@ -186,6 +252,57 @@ Failure modes degrade gracefully — `psutil` missing or a transient `AccessDeni
 The scan result is cached per-process for 5 seconds so one snapshot tick across many sessions enumerates `/proc` once, not once per session.
 
 In `build_snapshot`, the second pass uses this map to **per-cwd promote the top-N most-recently-modified sessions to authoritative `running`** — where N is the live process count for that cwd. This is the key fix for the earlier bug where one live session in a project flipped every historical jsonl in that project to `running`.
+
+---
+
+## Cross-machine CLI session registration
+
+Local process detection and the transcript scan both stop at this machine's filesystem — they cannot see a Claude Code or Codex session running on a laptop or a second box. Issue #849 adds an independent, push-based path for that: `scripts/lifeos-agent-hook.sh` posts a lifecycle event from wherever the CLI is running to `POST /api/agents/cli-sessions/events`, and the API keeps a small per-session record that the snapshot builder unions onto whatever the transcript scan already found.
+
+### Storage: `cli_sessions`
+
+Table lives in the same SQLite file `SessionStore` already owns (`api/services/agent_worker/session_store.py`, `CREATE TABLE IF NOT EXISTS` — no migration needed, it's a new table). One row per session, keyed the same way the snapshot union already keys transcript-derived rows:
+
+| Column | Notes |
+|---|---|
+| `session_id` | PK. `cc:<uuid>` or `cx:<uuid>` — `CLI_ENGINE_PREFIXES = {"claude_code": "cc", "codex": "cx"}` maps the event's `engine` field to the prefix. |
+| `engine` | `claude_code` or `codex`. |
+| `host` | Hostname the hook posted from, verbatim (no validation against a known-hosts list). |
+| `cwd`, `transcript_path`, `branch`, `model` | Optional; a `None` on an incoming event leaves the stored value alone rather than blanking it — a `stop` event with no `branch` field doesn't erase what `session_start` recorded. |
+| `status` | `idle` \| `running` \| `ended` — see the status machine below. |
+| `prompt_preview` | Truncated to `CLI_PROMPT_PREVIEW_MAX = 200` chars, set only by `user_prompt_submit` events. |
+| `task_id` | Opaque string from the CLI's `$LIFEOS_TASK_ID` env var. Stored and exposed verbatim — **never validated against the task store** (issue #853, built in parallel; this issue takes no dependency on its schema or code). |
+| `pane_id`, `wezterm_pid` | Only meaningful when the hook ran inside a WezTerm pane; `None` otherwise. |
+| `started_at`, `last_event_at`, `ended_at` | Unix epoch seconds. `ended_at` is set on `session_end` and cleared on a subsequent `session_start` (a resumed session sends `session_start` again — see below). |
+
+`SessionStore.record_cli_session_event(engine, event, session_id, host, ...)` applies one event: **status machine** — `session_start` → `idle`, `user_prompt_submit` → `running` (+ prompt preview), `stop` → `idle`, `session_end` → `ended`. A row is created on whichever event is first seen for a session id — not necessarily `session_start` — so a hook installed mid-session, or a lost `session_start` post, still registers the session rather than silently never appearing.
+
+### Endpoint: `POST /cli-sessions/events`
+
+`_check_agent_hook_auth(request)` mirrors `hermes_proxy._check_hermes_inbound_auth`: empty `LIFEOS_AGENT_HOOK_TOKEN` → 503 (endpoint disabled by default — a fresh clone accepts no unauthenticated writes from the tailnet); missing/wrong bearer → 401; `hmac.compare_digest` for the comparison. `engine` not in `CLI_ENGINE_PREFIXES` or `event` not in `CLI_SESSION_EVENTS` → 422.
+
+On a successful call, if the event's `host` equals this API's own host (`api_host_name()`) **and** it carries a `pane_id`, the handler also upserts into `CCWezTermStore` — the same table `/cc-pane-bind` and `/cx-pane-bind` write to — so Go To keeps working for a session registered this way instead of via the pane-bind hook specifically. A remote host's `pane_id` has nowhere local to activate, so it's stored on the `cli_sessions` row only, never mirrored into the pane store.
+
+### Snapshot union
+
+`_build_snapshot()` reads every `cli_sessions` row into a dict keyed by `session_id` before running the Claude Code and Codex transcript scans. Each transcript-derived row `.pop()`s its match out of that dict:
+
+- **Match found** (`_apply_cli_session_to_dict`) — the transcript row's `status`/`status_inferred` are overwritten from the registration (event-driven status always wins over the transcript's file-age guess); `host`, `branch`, `prompt_preview` are copied in; `task_id` is copied in only if the event supplied one. Token/dollar fields are left as the transcript computed them — the hook posts no usage data.
+- **No match** (`_cli_session_to_dict`) — a fully synthetic row: `host`/`branch`/`prompt_preview`/`task_id` from the `cli_sessions` row, `source` = the engine name, `status_inferred = False` always (there's no inference here, only events), zero token/dollar fields, `decoded_cwd` from the row's `cwd`.
+
+Whatever's left in the dict after both scans ran — a remote host, or (rarely) a local hook post that raced ahead of the transcript scan's 30s cache — is bounded to the same recency window each engine's transcript scan already applies (`claude_code_lookback_days` / `codex_lookback_days`) before becoming a synthetic row, so a stale registration doesn't linger in the snapshot forever.
+
+Worker (`lifeos_agent`) rows always get `host = api_host_name()` directly in `_session_to_dict` — there's no cross-host worker dispatch, so they never need a `cli_sessions` lookup.
+
+### Focus / Resume and remote hosts
+
+`_check_session_host_or_409(session_id)` looks up the id's `cli_sessions` row. A session with no row at all (never registered, or registered before this feature existed) is unaffected — it falls through to the pre-existing cache/probe resolution unchanged. When a row exists and its `host` differs from `api_host_name()` (#851): a host name present in `settings.agent_hosts` resolves to its ssh target, which both `/focus` and `/resume` then use instead of 409ing — see [Card assignment](agent-worker.md#card-assignment-851) for the mechanism (ssh-wrapped launcher, cwd sourced from the `cli_sessions` row since a remote session's transcript file isn't on this host's filesystem, and `/focus`'s fallback to running the same launcher `/resume` does, since there's no cross-host pane registry to activate an existing pane against). A host name NOT in `settings.agent_hosts` still 409s, with the recorded host in `detail` — the honest answer for an operator-config gap, not a silent no-op or a misleading 404.
+
+### Hook script and installer
+
+`scripts/lifeos-agent-hook.sh` is a single portable script (bash 3.2-compatible for macOS) that serves every hook event — engine and event name are passed as argv (`lifeos-agent-hook.sh claude_code session_start`). It reads the hook's JSON stdin payload via `jq`, adds the hostname (`hostname` with any domain suffix stripped), the cwd's git branch (`git -C "$cwd" rev-parse --abbrev-ref HEAD`), and `$LIFEOS_TASK_ID`, and POSTs to `/cli-sessions/events` with `curl --max-time 2`. It sources a small env file (`~/.config/lifeos/agent-hook.env`, override via `$LIFEOS_AGENT_HOOK_ENV`) for `LIFEOS_API_URL` / `LIFEOS_AGENT_HOOK_TOKEN` — values already in the environment take precedence over the file. Every non-fatal condition (missing `jq`/`curl`, empty stdin, no token configured, API unreachable) exits 0 silently and writes nothing to stdout, so it can never block or corrupt the CLI's own hook processing. Pane fields are included only when `$WEZTERM_PANE` is set — unlike `claude-session-pane.sh`, running outside WezTerm is a normal case, not a silent no-op, since registration doesn't depend on a pane to exist.
+
+`scripts/install-agent-hooks.sh` appends one entry per event to `~/.claude/settings.json` and `~/.codex/hooks.json` (overridable via `LIFEOS_CLAUDE_SETTINGS` / `LIFEOS_CODEX_HOOKS` for testing), identifying a prior install by the substring `lifeos-agent-hook.sh` in an existing entry's `command` so re-running it is a no-op. Every other tool's entries — Orca, atuin, a legacy `claude-session-pane.sh` / `codex-session-pane.sh` entry — are left untouched. Writes via temp file + `mv`. The installed command wraps the absolute path of the script in *this* checkout so a moved or deleted checkout degrades to a no-op instead of an error: `bash -c 's="<path>"; [ -x "$s" ] && exec "$s" <engine> <event>; exit 0'`. It never writes the token itself — it prints setup instructions for the operator.
 
 ---
 
@@ -271,6 +388,7 @@ POST /api/agents/sessions/{id}/kill   body: {"reason": "..."}
    - Emit `operator_killed` (target) or `cascade_killed` (descendants) to the transcript.
    - Call `api.services.agent_worker.inter_agent.teardown_session(...)` to actually mark the session terminal in the store and tear down the managed remote if one exists.
 4. Managed-Agents teardown uses a `ManagedAgentsDriver` instance constructed lazily from `settings.anthropic_api_key`. If the key isn't set, kill degrades to local-only and the worker's next managed poll reconciles the remote side.
+5. (#851) For a session whose `host` is set, `teardown_session` signals the process over ssh (`ssh <target> kill -- -<pgid>`, the `<pgid>` recorded from the remote executor's spawn — see [Card assignment](agent-worker.md#card-assignment-851)) instead of the local `os.killpg` path. A missing `remote_pgid` or an unregistered host degrades to a DB-only kill, the same as a missing local pid event does.
 
 Response: `{killed: [session_ids], failures: [{session_id, error}], reason: <input>}`.
 
@@ -286,7 +404,7 @@ POST /api/agents/sessions/{id}/focus    body: (none)
 POST /api/agents/cc-pane-bind           body: {session_id, pane_id, cwd}   (localhost only)
 ```
 
-All three opt-in via `LIFEOS_CC_RESUME_ENABLED` (except `/cc-pane-bind`, which is gated by client IP only — `127.0.0.1` / `::1`). Resume spawns a new WezTerm tab and records the new pane id; Go To (`/focus`) revisits the pane for a session, falling back to an FD probe when no mapping is cached; `/cc-pane-bind` is the SessionStart hook entry point that pre-populates the mapping at `claude` startup.
+All three opt-in via `LIFEOS_CC_RESUME_ENABLED` (except `/cc-pane-bind`, which is gated by client IP only — `127.0.0.1` / `::1`). Resume spawns a new WezTerm tab and records the new pane id; Go To (`/focus`) revisits the pane for a session, falling back to an FD probe when no mapping is cached; `/cc-pane-bind` is the SessionStart hook entry point that pre-populates the mapping at `claude` startup. Both Resume and Go To also check `_check_session_host_or_409` first (#849) — a session whose `cli_sessions` row names a different host than this API's own 409s immediately, before any local wezterm work runs; see [Cross-machine CLI session registration](#cross-machine-cli-session-registration).
 
 ### Resume
 
@@ -355,7 +473,7 @@ RestartSec=10
 
 ## Security boundaries
 
-The threat model: the LifeOS MCP HTTP transport is publicly accessible via Tailscale Funnel and is the obvious place an external agent or compromised credential could hit LifeOS endpoints. `/kill`, `/resume`, and `/focus`:
+The threat model: the LifeOS MCP HTTP transport is publicly accessible via Tailscale Funnel and is the obvious place an external agent or compromised credential could hit LifeOS endpoints. `/cli-sessions/events` is the one endpoint in this file deliberately reachable over Tailscale rather than local-network-only — it's gated by `LIFEOS_AGENT_HOOK_TOKEN` instead of an IP check, disabled entirely (503) until an operator sets one, and `hmac.compare_digest` avoids a timing side-channel on the comparison. It carries no more authority than "register a session and its metadata" — it cannot kill, resume, or focus anything, and the `host` field it accepts is trusted as-given rather than verified: a bearer-token holder can name any host, so a fabricated session can appear to run somewhere it doesn't. The one place this matters is the pane-store mirror: `pane_id`/`wezterm_pid` are written into `cc_wezterm_store` — the table `/focus` reads to pick a real WezTerm pane — only when the reported `host` matches this API's own AND the request itself arrived from loopback (the same IP check `/cc-pane-bind` and `/cx-pane-bind` use). A remote or spoofed-host event still records its metadata and status on the `cli_sessions` row, but never touches the shared pane store, so it cannot redirect Go To for a real local session. `/kill`, `/resume`, `/focus`, and the board's own write surface — `PUT /board/cards/{id}/lane`, `POST /board/cards/{id}/accept`, and `POST /pending-questions/{id}/answer` — sit on the same footing:
 
 - Live under `/api/agents/*` — the MCP transport never proxies this prefix.
 - Are not registered as MCP tools — so they cannot be invoked through the MCP layer even if an attacker has a bearer token.
@@ -363,6 +481,7 @@ The threat model: the LifeOS MCP HTTP transport is publicly accessible via Tails
 - Resume runs a configured launcher via `shlex.split` only — no `shell=True`. Template substitutions are URL-encoded where they go into URI strings. The rendered `{inner_command}` is split into individual argv tokens before reaching the launcher, so a malicious inner command cannot smuggle shell metacharacters.
 - Focus calls `wezterm cli activate-pane` with a fixed argv (no template) using the pane id from the local SQLite mapping. The store is only writeable from the same process (no cross-machine exposure), and pane ids are integers — there is no path for an external caller to inject arbitrary argv. The FD-probe fallback never reads attacker-controlled data: `lsof` is invoked with the transcript path that LifeOS itself derived from `discover_sessions`, and `/proc/<pid>/fd/0` is read as a symlink target whose filtering keeps only `/dev/pts/N` paths.
 - `/cc-pane-bind` is bound to loopback by IP check (`127.0.0.1` / `::1`); the public MCP transport runs on the same host but a different prefix and would never route to it. The accepted body is constrained: `session_id` runs through `validate_session_id` (rejects path traversal), `pane_id` must be a non-negative int, `cwd` is opaque text.
+- `/pending-questions/{id}/answer` deliberately drops the `bot` scoping `deposit_answer` has (`session_store.py::deposit_answer_by_id`, above). Bot scoping exists to disambiguate Telegram's multi-bot inbound channel — which reply belongs to which persona's chat — not because the operator lacks authority over a question; the board is a single local surface with strictly less authority than the pre-existing, equally ungated `POST /spawn` and `POST /threads/{id}/reply`, so an unscoped write here adds no new exposure.
 
 Per-source guarantees:
 
@@ -375,8 +494,11 @@ Per-source guarantees:
 ## Related Documents
 
 - [ADR-011: External Agent Ingest](../../adr/011-external-agent-ingest.md) — Read-only adapter pattern this spec implements
-- [Agent Viz — Product](../product/agent-viz.md) — Consumer view: filters, chips, status semantics, operator controls
+- [Agent Viz — Product](../product/agent-viz.md) — Consumer view: filters, chips, status semantics, operator controls, the board's lanes and drawer
 - [Agent Worker — Technical](agent-worker.md) — Sessions, transcripts, kill primitives, inter-agent coordination
 - [Agent Worker — Product](../product/agent-worker.md) — `#agent` task lifecycle, Telegram interactions
+- [API Reference](../product/api-reference.md) — `POST /api/agents/cli-sessions/events` and other agent endpoint contracts
 - [Architecture](architecture.md) — Where the route + adapter fit in the broader code structure
 - [Observability](observability.md) — Adjacent traces / health surfaces
+- [Task Management — Technical](task-management.md) — `TaskManager`, the store the board's cards are read from
+- [Scheduler — Technical](scheduler.md) — `SchedulerStore`, the store the Scheduled column is read from

--- a/docs/specs/technical/agent-worker.md
+++ b/docs/specs/technical/agent-worker.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Agent Worker
-> **Last Updated:** 2026-08-26
+> **Last Updated:** 2026-09-03
 
 Engineering view of the agent worker — the stand-alone process that consumes `#agent`-tagged tasks and runs them on either a local LLM or Anthropic Managed Agents. For consumer-facing behavior, see [product/agent-worker.md](../product/agent-worker.md). For operator setup, see [guides/agent-worker-setup.md](../../guides/agent-worker-setup.md).
 
@@ -18,15 +18,16 @@ Engineering view of the agent worker — the stand-alone process that consumes `
 6. [Preflight](#preflight)
 7. [Local executor (Gemma path)](#local-executor-gemma-path)
 8. [Managed executor (Claude path)](#managed-executor-claude-path)
-9. [System prompts](#system-prompts)
-10. [Inter-agent coordination](#inter-agent-coordination)
-11. [Budget enforcement](#budget-enforcement)
-12. [Restart resumability](#restart-resumability)
-13. [Telegram clarification flow](#telegram-clarification-flow)
-14. [Transcripts](#transcripts)
-15. [Agent Output notes](#agent-output-notes)
-16. [Configuration surface](#configuration-surface)
-17. [Related Documents](#related-documents)
+9. [Card assignment (#851)](#card-assignment-851)
+10. [System prompts](#system-prompts)
+11. [Inter-agent coordination](#inter-agent-coordination)
+12. [Budget enforcement](#budget-enforcement)
+13. [Restart resumability](#restart-resumability)
+14. [Telegram clarification flow](#telegram-clarification-flow)
+15. [Transcripts](#transcripts)
+16. [Agent Output notes](#agent-output-notes)
+17. [Configuration surface](#configuration-surface)
+18. [Related Documents](#related-documents)
 
 ---
 
@@ -91,7 +92,7 @@ External boundaries:
 
 ## Session store schema
 
-`session_store.py` creates seven tables (SQLite, `data/agent_sessions.db` by default). The schema is deliberately permissive — new columns and tables have been added issue-by-issue rather than designed up front — so this list is read directly off the table-creation code (`_SCHEMA` in `session_store.py`) rather than written from memory; re-check the source if it looks stale.
+`session_store.py` creates eight tables (SQLite, `data/agent_sessions.db` by default). The schema is deliberately permissive — new columns and tables have been added issue-by-issue rather than designed up front — so this list is read directly off the table-creation code (`_SCHEMA` in `session_store.py`) rather than written from memory; re-check the source if it looks stale.
 
 ### `sessions`
 
@@ -102,7 +103,7 @@ One row per agent session (1:1 with a claimed task, or a root-spawned operator s
 | `task_id` (PK) | The `#agent` task this session was claimed from (or a synthetic id for operator sessions). |
 | `session_id` (UNIQUE) | Internal session identifier used for inter-agent addressing, transcripts, etc. |
 | `status` | One of `claimed`, `running`, `yielded`, `completed`, `failed`, `budget_exceeded`, `blocked`. |
-| `routing` | `local`, `claude`, `claude_code`, `codex`, or `ask` — which executor runs the session. |
+| `routing` | `local`, `claude`, `claude_code`, `codex`, `hermes`, or `ask` — which executor runs the session. |
 | `budget_json` | JSON-encoded budget (dollars / wall-clock / tokens) set at preflight. |
 | `started_at`, `last_activity_at` | Unix epoch seconds. |
 | `total_input_tokens`, `total_output_tokens` | Accumulated token counts. |
@@ -119,6 +120,10 @@ One row per agent session (1:1 with a claimed task, or a root-spawned operator s
 | `claude_code_model` | Claude tier for `routing="claude_code"` (`haiku`/`sonnet`/`opus`); NULL falls back to the CLI's own default (`opus`). |
 | `bot` | Telegram bot that owns this session's notices; NULL = primary bot (#348). |
 | `unpriced` | Sticky flag: set once any turn was priced against a model `pricing.py` doesn't recognize, so a reader can tell "$0.00 total" apart from "some turns couldn't be priced" (#669). |
+| `host` | Board-assigned host name from `settings.agent_hosts` (#851); NULL/`""` = this API host. Read by the `claude_code`/`codex` executors to decide whether to spawn locally or wrap the argv in `ssh`. |
+| `model`, `effort` | Board-assigned model id and effort level (`low`/`medium`/`high`/`max`, #851), threaded into the executor's argv — see [Card assignment](#card-assignment-851) below. Distinct from `claude_code_model`, which predates this and is set by `lifeos_agent_spawn`'s `tier` argument, not the board. |
+| `conversation_id` | Hermes conversation id (#851, `routing="hermes"` only) — set by `HermesExecutor` once the turn's `conversation_id` SSE event arrives, and what a card's `session.open_url` points `/chat?conversation=` at. |
+| `remote_pgid` | Process-group id a remote-spawned subprocess echoed back on its first stdout line (#851) — see [Host registry and ssh spawn](#host-registry-and-ssh-spawn-851). Used by the operator kill endpoint to reach the process over ssh; NULL for a local session. |
 
 Indexed on `status`, `parent_session_id`, `root_session_id`, and (partial index) `status = 'yielded'`.
 
@@ -195,12 +200,19 @@ Polling bookkeeping for Managed Agents sessions, one row per `task_id`.
 | `final_text` | Most recent `agent.message` text seen across polls — cached because the final message and the terminal `session.status_idle` event can land on different polls, and a Telegram completion summary would otherwise have no text to show. |
 | `tool_loop_signature`, `tool_loop_count`, `tool_calls_since_message` | Runaway-loop detection counters (#139 §5), persisted so cross-poll signals survive worker restarts mid-session. |
 
+### `cli_sessions`
+
+One row per Claude Code / Codex CLI session registered from any host via `POST /api/agents/cli-sessions/events` (#849), keyed `cc:<uuid>` / `cx:<uuid>` and carrying event-driven status (`idle` / `running` / `ended`) instead of a file-age guess. See [Cross-machine CLI session registration](agent-viz.md#cross-machine-cli-session-registration) for the column table and status machine.
+
 ---
 
 ## Lifecycle of a task
 
 ```
-poll → spend tracker check (`can_start_task(default_budget)`)
+poll → resolve Human-queue cards whose done_when now passes (throttled by
+        LIFEOS_HUMAN_QUEUE_POLL_SECONDS; runs before the spend guard — it
+        never spends)
+     → spend tracker check (`can_start_task(default_budget)`)
      → wake sleeping sessions whose timer expired
      → poll managed sessions for state advancement
      → resume yielded-for-children sessions if children done
@@ -365,6 +377,53 @@ The Managed Agents API emits `session.error` events at session-start for any MCP
 ### Empty-final-text carry-forward
 
 `agent.message` events with the agent's final text can arrive in an earlier poll batch than the `session.status_idle` event. The driver's per-batch `_extract_final_text` would return `None` on the idle-only batch. The executor mitigates this by caching `final_text` to `managed_cursor.final_text` on every poll where the driver returns a non-None value, and reading it back at finalize.
+
+---
+
+## Card assignment (#851)
+
+A Kanban card assigns a task to an engine (an assignee tag — `#claude`, `#codex`, `#local`, `#hermes`), a model, an effort level, and a host, written as `[key:: value]` inline fields (`model`, `effort`, `host`, `assigned_by` — round-tripped verbatim by `Task.fields`, see [task-management.md](task-management.md)). `assignment.py`'s `extract_assignment()` reads those four fields; `worker.py`'s `_dispatch()` calls it right after preflight and records `host`/`model`/`effort` onto the session row before any executor runs (`SessionStore.set_assignment`) — the same place `claude_code_model` has always been set. `assigned_by` is recorded for bookkeeping only — it plays no role in routing. The preflight bypass that lets a card's assignee tag skip route corroboration comes from the tag itself: `_apply_tag_overrides` returns as soon as it matches a routing tag, before `_apply_route_corroboration` ever runs (`worker.py`'s comment at the assignment-persist call site notes the same thing).
+
+### Effort mapping
+
+The board's own effort vocabulary is exactly `low | medium | high | max`. Each engine speaks a different vocabulary — `assignment.py`'s `map_effort_for_engine()` translates once, in one place:
+
+| Board effort | Claude Code (`--effort`) | Codex (`-c model_reasoning_effort=`) | Local Gemma | Hermes |
+|---|---|---|---|---|
+| `low` | `low` | `low` | thinking off | no override |
+| `medium` | `medium` | `medium` | thinking off | no override |
+| `high` | `high` | `high` | thinking on | no override |
+| `max` | `max` | `xhigh` | thinking on | no override |
+| unset | CLI default | CLI's own config | `settings.local_agent_enable_thinking` | Hermes reports its own model |
+
+Local Gemma's thinking toggle is a per-SESSION override (`local_executor.py`'s `_call_llm(session_id, effort=...)`), not a mutation of the global `settings.local_agent_enable_thinking` — concurrent sessions with different assigned efforts would otherwise race each other over one process-wide flag. It only ever reaches a real `LocalLLMClient` on the local (not #809 remote-forced) route, mirroring `run_agent_loop`'s identical `isinstance(...) and not force_remote` gate — the remote OpenAI-compatible provider doesn't understand llama-server's `chat_template_kwargs` switch.
+
+### Host registry and ssh spawn (#851)
+
+`LIFEOS_AGENT_HOSTS` (`{name: ssh_target}`, e.g. `{"laptop": "user@laptop.example"}`) maps a board-facing host name to an ssh target. `remote_spawn.py` is the shared mechanism:
+
+- `resolve_host_target(host, api_host_name)` — empty/unset `host`, or a match on this API's own hostname, means local (returns `None`, the existing `spawn_fn` seam runs unchanged). Anything else must be a registry key or `resolve_host_target` raises `HostResolutionError` — the executor fails the task closed (`#agent-failed`, reason naming the host) **without ever calling `spawn_fn`**.
+- `build_remote_argv(argv, target, unset_env_names)` — wraps the exact local argv into `ssh -o BatchMode=yes -o ConnectTimeout=<setting> <target> -- <remote command>`. The remote command unsets every credential name `_clean_env` strips locally (mirrored via `env_names_matching_prefixes`, applied to the remote command's `env -u` prefix instead of the local Popen `env=` kwarg), then wraps the whole thing in `setsid bash -c 'echo "PGID:$$"; exec "$@"' _ …` so the remote process group id is captured as the very first stdout line. The executor strips that line (`read_remote_pgid_line`) before the normal event-stream parsing begins, and persists it via `SessionStore.set_remote_pgid`.
+- The Popen call site itself is untouched by any of this — only `cmd` (built beforehand) and the local `_clean_env()`-sourced `env=` differ between the local and remote branches, which is what keeps the injection seam (`spawn_fn`/`binary_resolver`) a pure test seam rather than something remote spawn has to special-case.
+- Reading that `PGID:` line back is bounded on its own clock (`remote_spawn.read_line_with_deadline`, `settings.agent_ssh_connect_timeout + 5` seconds), separate from and ahead of each executor's usual wall-clock watchdog — `ssh -o ConnectTimeout` only bounds the TCP handshake, not a stall during auth or a host that accepts the connection but never answers. A timeout here fails the task with `host <name> did not answer within <n>s`, distinct from the ordinary execution-timeout failure.
+- Kill: `POST /sessions/{id}/kill` on a session whose `host` is set runs `ssh <target> kill -- -<pgid>` through an injectable runner (`remote_spawn.kill_remote_process_group`) instead of the local `os.killpg` — see `inter_agent.py`'s `_kill_remote_subprocess`. An unregistered host degrades to a DB-only kill, the same way a missing local pid event does.
+- Resume/focus (`api/routes/agents.py`): a session whose `cli_sessions.host` names a registered host runs the same rendered launcher template over ssh (`remote_spawn.build_remote_launcher_argv` — no pgid capture, no credential stripping; a launcher is a short-lived terminal spawner, not the long-running CLI session). Its cwd comes from the `cli_sessions` row (populated by the remote host's own hook post, #849) rather than a local transcript-file scan, which a remote session's files were never going to satisfy. `/focus` has no cross-host pane registry to activate an existing pane against (the `cc_wezterm_store` mapping is only ever written for a session that ran on THIS API host), so for a remote session it runs the same launcher `/resume` does and returns `/focus`'s response shape.
+
+**macOS FDA limitation (documented, not solved):** Apple-data tasks (iMessage, Photos, Contacts) require Full Disk Access, which is granted per-app to the process that launched a session — not something an ssh-spawned remote process can inherit. Assigning an Apple-data task to a remote macOS host over this mechanism will not have FDA; the Apple Data Agent's own export/import pipeline ([operations.md](../../guides/operations.md)) remains the supported path for cross-machine Apple data.
+
+### Hermes route
+
+`ROUTE_HERMES = "hermes"` (`preflight.py`) is a new tag-only route — like `claude_code`/`codex`, preflight's own classifier JSON schema never emits it; `#hermes` in `_apply_tag_overrides` sets it. `HermesExecutor` (`hermes_executor.py`) reuses `hermes_proxy._build_envelope` (persona/turn-context resolution) and `_HermesTurnPersister` (conversation + usage persistence) so a board-assigned Hermes turn's rows are indistinguishable from one that came through `/chat` — three small read accessors (`conversation_id`, `content_text`, `done_seen`) were added to that class for this reuse. Runs synchronously on the worker's tick thread (a bounded HTTP round trip, not a long-lived subprocess — unlike the CLI routes, which run off-tick through the CLI dispatch pool). The card's prompt is `task["description"]` plus `task["notes"]`, if any. On completion the session row stores `conversation_id`; the card's `session.open_url` becomes `/chat?conversation=<id>` — `web/chat/main.js` reads that query param on boot (after the backend restore settles) and opens the thread, purely additive to the SSE contract in [client-surfaces.md](client-surfaces.md).
+
+### Board open (#851)
+
+`POST /api/agents/board/cards/{id}/open` (`api/routes/agent_assignment.py` — a new router sharing the `/api/agents` prefix with `agents.py` rather than appending to that file, so this issue and the concurrent Kanban board UI issue touch different files) requires the card to be in Assigned state: `status == "todo"`, a recognized assignee tag, and no running session (worker-dispatched or a prior interactive open) already against it. `claude`/`codex` spawn the interactive CLI in a terminal — reusing the `cc_resume_cmd`/`codex_resume_cmd` launcher templates, with `{inner_command}` rendered as a fresh `env LIFEOS_TASK_ID=<id> claude|codex "<prompt>"` invocation rather than a `--resume <id>`. `scripts/lifeos-agent-hook.sh` already forwards `$LIFEOS_TASK_ID` as `task_id` on every lifecycle event it posts (#849); `POST /cli-sessions/events` now moves a `task_id`-bearing `session_start`'s card from `todo` to `in_progress` — the one piece #849 didn't need, since nothing produced a task-linked interactive session until this endpoint did. `hermes` has no terminal to spawn — returns `{open_url: "/chat?conversation=<id>"}` once the card has one, else 409.
+
+Two more 409s beyond the Assigned-state/tag/already-running checks: `_OPENING_GRACE_SECONDS` (30s) holds a card claimed-but-not-yet-registered so a double-click can't spawn twice before the first spawn's session shows up (`card open is already in progress`); and a card's `host` field naming a value absent from `settings.agent_hosts` fails closed (`host '<name>' is not configured in LIFEOS_AGENT_HOSTS`) rather than silently falling back to local.
+
+### Model catalog (#851)
+
+`GET /api/agents/models` (`model_catalog.py`) returns `{engines: {claude, codex, local, hermes}, refreshed_at, stale}`, each engine's list merged with `pricing.PRICING`. Sources: Anthropic via the SDK's own `models.list()` (never a hand-maintained table — that's exactly what went stale in `pricing.py` before #655/#656); Codex via its own `~/.codex/models_cache.json`, falling back to a live OpenAI models list only when `LIFEOS_OPENAI_API_KEY` is set; local via the running llama-server's `/v1/models` (`model_readout._probe_live_model`); Hermes via the last observed turn's model (`model_readout.get_hermes_models`) — never probed, since Hermes can serve a different model per turn. Cached for `LIFEOS_AGENT_MODEL_CATALOG_TTL_SECONDS` (default 24h); a refresh failure (any single engine's fetch raising) falls back to the last successful catalog with `stale: true` rather than 500ing the picker.
 
 ---
 
@@ -543,6 +602,7 @@ Full reference in [`agent-worker-setup.md`](../../guides/agent-worker-setup.md).
 | MCP HTTP transport | `LIFEOS_MCP_HTTP_URL`, `LIFEOS_MCP_BEARER_TOKEN`, `LIFEOS_MCP_HTTP_HOST`, `LIFEOS_MCP_HTTP_PORT` |
 | Inter-agent caps | `LIFEOS_AGENT_MAX_SPAWN_DEPTH`, `LIFEOS_AGENT_MAX_DESCENDANTS_PER_ROOT`, `LIFEOS_AGENT_MAX_CONCURRENT_LOCAL`, `LIFEOS_AGENT_MAX_CONCURRENT_MANAGED` |
 | Telegram clarifications | `LIFEOS_AGENT_CLARIFICATION_TIMEOUT_HOURS` |
+| Card assignment (#851) | `LIFEOS_AGENT_HOSTS`, `LIFEOS_AGENT_SSH_CONNECT_TIMEOUT`, `LIFEOS_AGENT_MODEL_CATALOG_TTL_SECONDS`, `LIFEOS_CODEX_MODELS_CACHE_PATH`, `LIFEOS_OPENAI_API_KEY` |
 
 ---
 
@@ -553,8 +613,11 @@ Full reference in [`agent-worker-setup.md`](../../guides/agent-worker-setup.md).
 - [Agent Worker — Product](../product/agent-worker.md) — What `#agent` does, consumer view
 - [Agent Worker — Setup](../../guides/agent-worker-setup.md) — Operator setup walkthrough
 - [Agent Viz — Technical](agent-viz.md) — `/agents` page that reads SessionStore + TranscriptStore here
+- [Agent Viz — Product](../product/agent-viz.md) — Board drawer pickers and Open action that write the card-assignment fields read here
 - [Task Management](../product/task-management.md) — How `#agent` tasks sit alongside regular tasks
+- [Human Queue](../../guides/human-queue.md) — Cards the worker's poll tick auto-resolves via `done_when`
 - [MCP Tools](../product/mcp-tools.md) — Standard MCP catalog including `lifeos_agent_*` family
 - [API Reference](../product/api-reference.md) — Task endpoints the worker uses (`/api/tasks/{id}/swap-tag`, `/api/tasks/{id}/complete`)
 - [Architecture](architecture.md) — Where the worker fits in the broader code structure
 - [Observability](observability.md) — Tracing, perf, and logging patterns the worker uses
+- [Client Surfaces](client-surfaces.md) — The `/chat` SSE contract the `?conversation=` deep link (#851) is additive to

--- a/docs/specs/technical/architecture.md
+++ b/docs/specs/technical/architecture.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Platform
-> **Last Updated:** 2026-08-21
+> **Last Updated:** 2026-09-03
 
 Codebase organization and module structure for efficient navigation.
 
@@ -111,6 +111,7 @@ Per-backend capabilities (personas, handoff, history ownership, usage capture) a
 
 **Task Management:**
 - `task_manager.py` - Task CRUD, markdown I/O, index persistence, fuzzy query
+- `atomic_write.py` - Shared temp-file + fsync + rename helper for atomic vault/index writes (task files, task index, scheduler store)
 
 **Background Jobs:**
 - `job_queue.py` - SQLite-backed job queue with worker thread (reindex, sync)

--- a/docs/specs/technical/client-surfaces.md
+++ b/docs/specs/technical/client-surfaces.md
@@ -441,6 +441,7 @@ The sidebar shows a conversation's persona as a subtitle suffix (`· <Persona La
 - [Chat UI](../product/chat-ui.md) — Web chat product behavior
 - [Architecture](architecture.md) — Code layout for chat routes and services
 - [Testing Standards](../standards/testing-standards.md) — Contract regression tests
+- [Agent Worker — Technical](agent-worker.md) — The `?conversation=<id>` deep link a board-assigned Hermes card's open action lands on (#851), additive to this doc's SSE contract
 
 ### Operational
 - [Voice Setup](../../guides/voice-setup.md) — Operator-facing voice mode setup, including the Hermes/Agent backend contract this doc specifies

--- a/docs/specs/technical/data-and-sync.md
+++ b/docs/specs/technical/data-and-sync.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Data Pipeline
-> **Last Updated:** 2026-08-26
+> **Last Updated:** 2026-09-03
 
 How LifeOS ingests and stores data from multiple sources.
 
@@ -170,6 +170,10 @@ The 7-phase structure ensures correct data flow:
 ### Failure Notifications
 
 Configure `LIFEOS_ALERT_EMAIL` in `.env` to receive notifications when sync steps fail.
+
+The run also files a [Human queue](../../guides/human-queue.md) card keyed
+`sync:<source>` for each genuinely failed source (not a clean skip),
+auto-resolved by the next successful run of that source.
 
 ---
 

--- a/docs/specs/technical/scheduler.md
+++ b/docs/specs/technical/scheduler.md
@@ -2,7 +2,7 @@
 
 > **Status:** Complete
 > **Owner:** Scheduler
-> **Last Updated:** 2026-05-29
+> **Last Updated:** 2026-09-03
 
 Engineering view of the Scheduler — how a trigger bound to an action is stored,
 reindexed, and fired. For the trigger/action model, line schema, and operator
@@ -78,12 +78,14 @@ short snippet in `last_result` for the dashboard.
 ## Related Documents
 
 ### Specifications
+- [Task Management — Technical](task-management.md) — Task store that mirrors this store's id-addressed block rewrite, `>` body, and merge-forward patterns
 - [Scheduler Guide](../../guides/scheduler.md) — Operator how-to, line schema, trigger/action model (the consumer-facing counterpart to this spec)
 - [API Reference](../product/api-reference.md#scheduler--telegram-endpoints) — `/api/scheduler` contracts
 - [MCP Tools](../product/mcp-tools.md) — `lifeos_schedule_*` tool contracts
 - [Architecture](architecture.md) — Where the scheduler modules sit in the code structure
 - [Agent Worker — Product](../product/agent-worker.md) — Runs the `#agent` tasks the `agent` action writes
 - [Data & Sync](data-and-sync.md) — Scheduler storage in the data-locations table
+- [Agent Viz — Technical](agent-viz.md) — The `/agents` board's Scheduled/Done split, reading `list_all()` via `agent_board.is_schedule_active`
 
 ### Code References
 - [scheduler_store.py](../../../api/services/scheduler_store.py) — Store, round-trip, scheduler

--- a/docs/specs/technical/task-management.md
+++ b/docs/specs/technical/task-management.md
@@ -1,0 +1,358 @@
+# Task Management — Technical
+
+> **Status:** Complete
+> **Owner:** Task Management
+> **Last Updated:** 2026-09-03
+
+Engineering view of the task store — how a task is located, written, and
+reindexed. For the product-facing feature description, statuses, and API
+usage examples, see [product/task-management.md](../product/task-management.md);
+for endpoint contracts see
+[api-reference.md](../product/api-reference.md#task-endpoints). This spec
+does not restate those.
+
+## Modules
+
+| File | Role |
+|------|------|
+| `api/services/task_manager.py` | `Task`, `TaskManager` (CRUD + markdown round-trip + index cache + dashboard), module-level parse/format helpers |
+| `api/services/task_watcher.py` | `TaskWatcher` — watchdog observer that reindexes on external edits |
+| `api/services/atomic_write.py` | `atomic_write_text`/`atomic_write_lines` — shared temp-file-plus-rename helper, also used by `scheduler_store.py` |
+| `api/routes/tasks.py` | `/api/tasks` HTTP surface |
+
+`api/main.py` (lifespan, `api/main.py:185-192`) rebuilds the index from the
+vault on startup, then starts the watcher.
+
+## Source of truth + cache
+
+The vault markdown is authoritative; `data/task_index.json` is a rebuildable
+cache — deleting it just costs one `rebuild_index()` pass. Nothing about task
+identity or content lives only in the cache except `reminder_id` (see
+"Cache-only field merge-forward" below).
+
+- **Source:** `LifeOS/Tasks/{Context}.md` — one checkbox line per task, with
+  an optional indented `> ` notes body directly beneath it, exactly like a
+  scheduler entry's `message_content` body
+  ([scheduler.md](scheduler.md#source-of-truth--cache)). `_format_task_line`/
+  `_parse_task_line` (`task_manager.py:1224`, `:1272`) are inverse for a task
+  written by the API. A hand-authored line need not be — see "Parsing" below.
+- **Cache:** `data/task_index.json` — the full `Task` (dataclass at
+  `task_manager.py:129`), including fields with no markdown representation
+  (`reminder_id`). `rebuild_index` (`:671`) regenerates it from the vault.
+
+## Parsing
+
+A task line is any `- [.] ...` checkbox line — `_CHECKBOX_RE` (`:1188`) does
+**not** require the literal `TODO` keyword. This is deliberate: it lets a
+task typed by hand in Obsidian (`- [ ] Buy milk`) be recognized without the
+operator learning LifeOS's own convention. `_format_task_line` still always
+emits `TODO` on any line it writes, so the Obsidian Tasks dashboard queries
+in `Dashboard.md` (which match on the checkbox status, not the word `TODO`)
+and the existing convention both keep working unchanged.
+
+Inline fields with a dedicated `Task` attribute (`due`, `priority`,
+`created`, `done`, `cancelled`, `updated`) are parsed into that attribute;
+every other `[key:: value]` — operator fields (`host`, `effort`, `model`,
+`key`) and anything a later feature invents — lands in `Task.fields` (a
+plain `dict[str, str]`) and round-trips through any rewrite untouched,
+because `_format_task_line` re-emits `Task.fields` verbatim in the order it
+holds them (`:1224-1258`). No parser change is needed to add a new field.
+
+A checkbox line inside a fenced (` ``` ` or `~~~`) code block is never
+parsed as a task, even though `_CHECKBOX_RE` would otherwise match it — a
+line like `- [ ] example` in a documentation snippet is example text, not a
+real task. `_iter_lines_with_fence_state` toggles fence state on any line
+whose stripped text starts with a fence marker; every scanner that walks
+task lines (`_reparse_lines`, `_cas_insert_at_top`, `_find_task_block_span`,
+`_reposition_file`) skips a line it marks as fenced before handing it to
+`_match_task_block`.
+
+**Duplicate ids.** Two lines sharing the same `<!-- id:xxxx -->` comment
+(most often a hand-copied line) are not left to fight over that id forever.
+`_reparse_lines` keeps the first occurrence's id as-is; a later occurrence
+in the same file carrying an id already claimed earlier in the same parse
+is treated exactly like a line with no id comment at all — its
+stale/duplicated comment is replaced with a freshly minted one on that
+pass, and both lines are indexed under distinct ids from then on.
+
+A duplicate that spans two *different* files is resolved only on the next
+full `rebuild_index`, not by a single-file `reindex_file` call: `rebuild_index`
+threads one `seen_ids` set across every file it parses, so a task whose id
+was already claimed by an earlier file in the same rebuild is treated the
+same way as a same-file duplicate. `reindex_file` deliberately does not do
+this — it has no way to distinguish a genuine cross-file duplicate from an
+operator cutting a task line out of one file and pasting it into another,
+so it keeps ids intact on an external cross-file move and leaves any true
+cross-file duplicate for the next full rebuild to resolve.
+
+## Id write-back
+
+A checkbox line with no `<!-- id:xxxx -->` comment gets one minted
+(`uuid4().hex[:8]`, same scheme as before) the first time it's parsed. On the
+next reindex, `_reparse_lines` (`:713`) appends that id comment to the raw
+line — and changes nothing else about it: no reformatting, no inserted
+`TODO`, no field reordering. Every other line in the file, task or not, is
+copied through byte-for-byte. This matters because the parser no longer
+requires `TODO`: on the first reindex after this feature ships, every
+existing hand-written `- [ ]` checklist item in `LifeOS/Tasks/*.md` gets an
+id comment appended, once, and is indexed as a task from then on. That is
+the intended migration, not a bug.
+
+## Input validation
+
+`description`, `notes`, and `fields` are validated by
+`_validate_text_fields` before `create`/`update` do anything else, because
+they're interpolated directly into the checkbox line's text rather than
+going through a serializer that could escape them. Rejected (`ValueError`,
+mapped to HTTP 422 by `api/routes/tasks.py`) rather than silently
+sanitized, since truncating or stripping would save something other than
+what the caller sent:
+
+- A newline (`\n` or `\r`) in `description` or a `fields` value would split
+  the single checkbox line into two.
+- A `]` in `description` or a `fields` value would truncate an inline
+  field's closing bracket and leak the rest of the value into the
+  description (or the next field).
+- An HTML comment opener (`<!--`) anywhere in `description`, a `fields`
+  value, or a `notes` line could forge a new `<!-- id:.. -->`, hijacking
+  another task's id on the next reindex.
+- `notes` lines are allowed to be multi-line — that's their whole point —
+  but not `\r` (would desync the `\n`-joined body from what
+  `Task.notes.split("\n")` expects) or `<!--`.
+- A `fields` key must be a bare word (`^\w+$`), because `_format_task_line`
+  interpolates it directly as `[key:: value]`.
+- A `fields` key may not shadow a reserved key: any inline field with a
+  dedicated `Task` attribute (`due`, `priority`, `created`, `done`,
+  `cancelled`, `updated`) or `id` itself. Accepting one through the
+  free-form `fields` dict would let a caller write a second, conflicting
+  `[key:: value]` onto the line, or forge the id comment outright —
+  `fields={"updated": "SPOOFED"}` would otherwise write two `[updated::]`
+  fields and, after the next reindex re-parses the line, `updated_at` would
+  read back as `"SPOOFED"`.
+
+`status` is validated the same way, against `VALID_STATUSES` — an
+unrecognized status previously wrote a blank checkbox (the symbol lookup
+falls back to `todo`'s `" "`) and round-tripped as the invalid string until
+the next reindex silently flipped it back to `todo`.
+
+## Id-addressed, compare-and-swap writes
+
+Every write locates its task's line by id — `_find_task_block_span`
+(`:1356`) scans for the block whose id comment matches, the same mechanism
+`SchedulerStore._find_block_span` uses. A cached `line_number` is never used
+to address a write; it is refreshed after every write purely as read-side
+bookkeeping (`_reposition_file`, `:917`) so `GET` responses stay accurate.
+This is what lets a `PUT` succeed correctly even when an external edit (via
+Obsidian, delivered by Syncthing) has inserted lines above the task before
+the watcher's 2s debounce catches up.
+
+Each write goes through `_cas_rewrite` (`:802`) or `_cas_insert_at_top`
+(`:881`): read the file's mtime, read and locate the block, compute the new
+content, then re-check the mtime immediately before writing. A mismatch
+means a concurrent external writer touched the file in between, so the
+manager calls `reindex_file` (absorbing that change into `self._tasks`) and
+retries — up to `_CAS_MAX_RETRIES` (`:70`, currently 3) times — before
+raising `TaskConflictError`, which `api/routes/tasks.py` maps to HTTP 409.
+The retry re-invokes the caller's `compute()` closure against the
+just-refreshed `self._tasks[task_id]`, so an `update()` retry re-applies the
+operator's requested changes on top of the latest known state rather than
+blindly overwriting it with stale data — the same "recompute, don't just
+retry the same bytes" discipline CAS requires anywhere. `compute()` always
+builds a *new* `Task` from a copy of the current one rather than mutating it
+in place, so a losing attempt's edits are never visible through `get()` —
+`self._tasks[task_id]` is rebound only once a write actually succeeds.
+
+`_cas_rewrite` also checks, before calling `compute()`, whether the on-disk
+block already reflects an edit `reindex_file` hasn't absorbed yet — the raw
+line text no longer matches the last line the API wrote or saw for this id,
+or the on-disk notes body no longer matches the in-memory task's. This is
+the *normal* case for an edit that just landed, not a rare race: the
+watcher's 2s debounce means a `PUT` can easily arrive after an external
+edit has hit disk but before `reindex_file` has run. Without this check,
+`compute()` would build its replacement from the stale in-memory task and
+silently revert the edit — an operator retitling a task and adding a body
+line, followed a moment later by an unrelated `PUT` that only changes
+`priority`, would otherwise lose the retitle and the added line. On a
+mismatch the manager absorbs it via `reindex_file` and retries (counting
+toward `_CAS_MAX_RETRIES`), the same as an mtime conflict.
+
+`self._lock` is a `threading.RLock`, not a plain `Lock`: a CAS retry inside
+a lock-held mutating call re-enters `reindex_file`, which also takes the
+lock. A plain `Lock` would self-deadlock on the very first retry.
+
+**Context-change moves.** `update(..., context=...)` moves a task's block
+between files via `_move_task_between_files`. The destination insert
+happens *before* the source removal: if the destination's CAS insert
+raises, the source is untouched — the task never disappears. If the source
+removal then fails (a conflict there, after the destination insert already
+succeeded), the manager best-effort removes the just-inserted destination
+block before re-raising, rather than leaving the task duplicated in both
+files. If the task's block is no longer present in the source at all (an
+external delete raced the move), the move is treated like any other
+externally-deleted task — reconciled out of the index — rather than raising
+a conflict.
+
+## Atomic writes
+
+All file writes — task files, `data/task_index.json`, `Dashboard.md`, a
+freshly created context file's template — go through
+`atomic_write.atomic_write_text`/`atomic_write_lines`: write a temp file in
+the same directory, `fsync`, then `os.replace` into place. A reader never
+observes a partial file, because the destination path is never opened for
+writing directly — only the temp file is, and the swap is one atomic
+rename. `scheduler_store.py` shares this same helper (its own writes had the
+same non-atomic gap; fixing it was a trivial swap with no behavior change,
+verified by the unchanged scheduler test suite).
+
+A task-file rewrite preserves the file's original line terminator (`\r\n`
+vs. `\n`) and whether it ended with a trailing terminator, rather than
+normalizing wholesale to `\n`-joined-plus-trailing-newline. Every call site
+that reads a task file for a possible rewrite (`reindex_file`,
+`rebuild_index`, `_cas_rewrite`, `_cas_insert_at_top`) uses
+`_read_lines_with_terminator`, which reads raw bytes (not `Path.read_text`,
+whose universal-newline translation would silently turn CRLF into LF before
+the terminator could even be inspected) and detects both properties; the
+matching write passes them through as `atomic_write_lines`'s `newline=`/
+`trailing_newline=` keyword arguments. `scheduler_store.py` never calls
+`atomic_write_lines` (it writes whole files via `atomic_write_text`), so
+these defaults don't change its behavior.
+
+## Notes body
+
+`Task.notes` is a multi-line string stored as `_BODY_INDENT` (four spaces)
+plus `> ` per line, directly beneath the task's checkbox line —
+`_format_task_block` (`:1261`) emits it, `_match_task_block` (`:1331`) parses
+it back, both mirroring the scheduler entry body pattern exactly
+(`scheduler.md`'s `_format_entry_block`/`_iter_entry_blocks`). Deleting or
+moving a task carries its body with it, because every write operates on the
+whole block (main line plus body lines), never the main line alone.
+
+## Cache-only field merge-forward
+
+`reminder_id` has no markdown representation — it never appears in a
+`[key:: value]` field, so a plain reindex would silently lose it (the
+markdown, re-parsed, says nothing about it). `_reparse_lines` merges it
+forward from `self._tasks` (the prior in-memory state, itself loaded from
+the JSON cache) by id, the same pattern as `SchedulerStore._merge_prior` for
+`message_content`/`endpoint_config`.
+
+## External-edit detection
+
+Whether a task's line changed externally since the API last wrote it is
+decided by exact-string comparison, not by reformatting the prior `Task` and
+hoping it matches. `TaskManager._last_written_line` (`dict[id, str]`, never
+persisted) holds the literal text last written or observed for each task
+this process's lifetime. `_reparse_lines` compares the current raw line
+against that entry: a mismatch means an external edit — the parsed values
+win (they already do, unconditionally) and the line is rewritten with a
+fresh `[updated::]` stamp, scoped to that one task's line only; a match, or
+no prior entry at all (first time this process has seen the id), leaves the
+line untouched.
+
+Reformatting the prior `Task` instead of storing the exact string was tried
+first and rejected: it broke on any line the API didn't canonically format
+— most notably a line that just had an id minted onto otherwise
+hand-written text (no `TODO`, no `created` field). Reformatting that prior
+`Task` via `_format_task_line` always re-inserts `TODO` and an (empty)
+`created` field, so the comparison found a "difference" on every single
+reindex and rewrote the line every time, defeating idempotency.
+
+**Why no `data/kanban.db` sidecar.** A small sidecar database was one option
+for this bookkeeping — `task_index.json` is rewritten whole on every
+mutation, so it's the wrong place for it — but wasn't needed: `reminder_id`
+merge-forward already works from the existing JSON-cache-backed
+`self._tasks`, and external-edit detection only needs to hold up within a
+single running process — after a restart, whatever's on disk simply becomes
+the new baseline for comparison, and the in-memory `Task` always reflects
+the file's actual current content regardless of whether that reset happened.
+The cost of not persisting is usually cosmetic: one skipped `[updated::]`
+restamp immediately after a restart, for a task that was genuinely edited
+while the server was down. It is a correctness gap in one specific,
+narrow case — a task's block is inside a fenced code block, or shares a
+duplicate id with another block, at the moment of a restart — where the
+in-memory bookkeeping that would otherwise have resolved it cleanly is
+reset along with everything else in `self._tasks`; the next parse simply
+treats it as a fresh id with no history, same as it would for any other
+process-lifetime-only piece of state. That's an accepted, bounded cost, not
+a claim that no correctness gap exists at all.
+
+`reindex_file`'s own write-back (minting an id, restamping an external
+edit) is itself CAS-protected on the file's mtime, the same discipline as
+`_cas_rewrite`: it re-reads and re-parses (bounded to `_CAS_MAX_RETRIES`
+attempts) if the file changed between its read and its write, rather than
+blindly overwriting whatever landed in between. On persistent conflict it
+logs a warning and skips the write for that pass instead of raising —
+`reindex_file` has no caller to hand a `TaskConflictError` to that would do
+anything useful with it, and the watcher will fire again for whatever
+caused the conflict. That skip is total, not partial: on a persistent
+conflict `reindex_file` returns without merging the abandoned attempt's
+parse into `self._tasks` or touching the index file or dashboard, since
+that parse may have minted ids that never reached disk.
+
+## Compare-and-swap retry vs. field-level merge
+
+A CAS retry re-applies the caller's requested field changes on top of the
+freshly reindexed task, but it does not attempt a field-level three-way
+merge against a concurrent, unrelated edit to the *same* task (e.g. the
+operator renames a task in Obsidian in the same instant the API is changing
+its due date). The later writer's full requested change wins outright for
+that task — an accepted simplification for a single-user vault, and a
+narrower race window than the previous cached-line-number addressing had
+for the sibling-line case this issue set out to fix.
+
+## Conflict files
+
+Syncthing conflict copies (`*.sync-conflict-YYYYMMDD-HHMMSS...`) and
+in-progress temp files (`.syncthing.*`) are recognized by `is_conflict_file`
+(`:209`) and skipped everywhere: `rebuild_index`'s glob, `reindex_file`
+(early return, never indexed, never triggers a write), and `TaskWatcher`'s
+event handler. `TaskManager.list_conflicts` (`:555`) surfaces them (name +
+mtime) via `GET /api/tasks/conflicts`, registered before `GET
+/{task_id}` in `api/routes/tasks.py` so FastAPI doesn't capture `"conflicts"`
+as a task id. Resolving a conflict file is a manual, out-of-band operation
+(Obsidian, or deleting the losing copy) — nothing here does it automatically.
+
+## Reindex on edit
+
+`TaskWatcher` (`task_watcher.py`) runs a watchdog `Observer` over the tasks
+directory (non-recursive). `_TaskFileHandler` coalesces rapid events per path
+behind a 2s debounce and calls `TaskManager.reindex_file`. `Dashboard.md` and
+conflict/temp files are skipped so regenerating the dashboard, or a Syncthing
+sync artifact landing mid-transfer, never triggers a feedback loop or a spurious
+reindex.
+
+## Privacy Considerations
+
+Task descriptions, notes, and operator fields live entirely in the local
+vault and `data/`; nothing here has an outbound path of its own (see
+[security-privacy.md](security-privacy.md) for the surfaces, like Telegram
+delivery, that do). `data/task_index.json` and the vault markdown carry the
+same content — deleting one and rebuilding from the other never loses or
+duplicates personal data, by construction.
+
+## Human queue
+
+The Human queue (`api/services/human_queue.py`) is a thin layer on top of
+this store, not a separate one: a card is a task with tag `human` and status
+`blocked`, using the `fields` free-form dict (`key`, `source_host`,
+`source_cwd`, `source_session`, `done_when`) documented above — no new
+persistence, no schema change. See the
+[Human Queue guide](../../guides/human-queue.md) for the tool/endpoint
+contract and the `done_when` reference.
+
+## Related Documents
+
+### Specifications
+- [Task Management — Product](../product/task-management.md) — Feature description, statuses, API usage examples (the consumer-facing counterpart to this spec)
+- [API Reference](../product/api-reference.md#task-endpoints) — `/api/tasks` contracts
+- [Human Queue guide](../../guides/human-queue.md) — Fire-and-forget operator cards built on this store
+- [Scheduler — Technical](scheduler.md) — The id-addressed block rewrite, notes-style body, and merge-forward patterns this store mirrors
+- [Agent Worker — Product](../product/agent-worker.md#tag-lifecycle) — `POST /{id}/swap-tag` contract this store preserves unchanged
+- [Architecture](architecture.md) — Where the task modules sit in the code structure
+- [Agent Viz — Technical](agent-viz.md) — The `/agents` board's `GET /board`, reading `list_tasks()` and writing via `update()`
+
+### Code References
+- [task_manager.py](../../../api/services/task_manager.py) — Store, round-trip, CAS writes
+- [task_watcher.py](../../../api/services/task_watcher.py) — File watcher
+- [atomic_write.py](../../../api/services/atomic_write.py) — Shared atomic-write helper
+- [tests/test_task_manager.py](../../../tests/test_task_manager.py) · [test_task_watcher.py](../../../tests/test_task_watcher.py) · [test_atomic_write.py](../../../tests/test_atomic_write.py) — Coverage

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -302,7 +302,7 @@ CURATED_ENDPOINTS = {
     },
     "/api/tasks:POST": {
         "name": "lifeos_task_create",
-        "description": "Create a task (Obsidian markdown). Supports context, priority, due_date, tags. With dry_run=true + #agent tag, returns preflight routing + cost estimate instead of creating.",
+        "description": "Create a task (Obsidian markdown). Supports context, status, priority, due_date, tags, notes, fields. With dry_run=true + #agent tag, returns preflight routing + cost estimate instead of creating.",
         "method": "POST",
         "path": "/api/tasks"
     },
@@ -314,7 +314,7 @@ CURATED_ENDPOINTS = {
     },
     "/api/tasks/{task_id}:PUT": {
         "name": "lifeos_task_update",
-        "description": "Update a task's description, status, context, priority, due_date, or tags. Use lifeos_task_list first to find the task ID.",
+        "description": "Update a task's description, status, context, priority, due_date, tags, notes, or fields. Use lifeos_task_list first to find the task ID.",
         "method": "PUT",
         "path": "/api/tasks/{task_id}"
     },
@@ -329,6 +329,24 @@ CURATED_ENDPOINTS = {
         "description": "Delete a task by ID. Removes it from the vault markdown file and index.",
         "method": "DELETE",
         "path": "/api/tasks/{task_id}"
+    },
+    "/api/tasks/human-queue:POST": {
+        "name": "lifeos_human_queue_add",
+        "description": "File a card for something only the operator can do (e.g. re-authenticate an expired login). Fire-and-forget; dedupes on key (letters/digits/./:/- only). done_when path must start with '/'.",
+        "method": "POST",
+        "path": "/api/tasks/human-queue"
+    },
+    "/api/tasks/human-queue:GET": {
+        "name": "lifeos_human_queue_list",
+        "description": "List open Human-queue cards waiting on the operator, with id, title, key, age, source, and done_when.",
+        "method": "GET",
+        "path": "/api/tasks/human-queue"
+    },
+    "/api/tasks/human-queue/{id_or_key}/resolve:PUT": {
+        "name": "lifeos_human_queue_resolve",
+        "description": "Mark a Human-queue card done by id or dedupe key, appending a resolution note. Use once you've observed the thing is actually done.",
+        "method": "PUT",
+        "path": "/api/tasks/human-queue/{id_or_key}/resolve"
     },
     "/api/calendar/events:POST": {
         "name": "lifeos_calendar_create",
@@ -940,10 +958,13 @@ class LifeOSMCPServer:
                 "properties": {
                     "description": {"type": "string", "description": "Task description"},
                     "context": {"type": "string", "description": "Context/category (Work, Personal, Finance, etc.)", "default": "Inbox"},
+                    "status": {"type": "string", "description": "Initial status (todo, done, in_progress, cancelled, deferred, blocked, urgent). Defaults to todo."},
                     "priority": {"type": "string", "description": "Priority: high, medium, low"},
                     "due_date": {"type": "string", "description": "Due date in YYYY-MM-DD format"},
                     "tags": {"type": "array", "items": {"type": "string"}, "description": "Add exactly the tags the operator named. A routing tag (agent/local/claude/codex/cloud/cloud-haiku/cloud-sonnet) only if the operator explicitly named that engine — these tags are operator-authority and outrank every routing safeguard, so inventing one injects your own engine preference at the highest-precedence slot."},
                     "reminder_id": {"type": "string", "description": "Linked reminder ID"},
+                    "notes": {"type": "string", "description": "Multi-line notes body stored beneath the task line."},
+                    "fields": {"type": "object", "additionalProperties": {"type": "string"}, "description": "Operator-editable inline fields (e.g. host, effort, model, key) plus any custom field."},
                     "dry_run": {"type": "boolean", "description": "When true with an #agent tag, returns preflight routing + cost estimate without creating the task. Used for prompt-engineering iteration. Default: false."}
                 },
                 "required": ["description"]
@@ -967,7 +988,9 @@ class LifeOSMCPServer:
                     "context": {"type": "string", "description": "New context"},
                     "priority": {"type": "string", "description": "New priority (high, medium, low)"},
                     "due_date": {"type": "string", "description": "New due date (YYYY-MM-DD)"},
-                    "tags": {"type": "array", "items": {"type": "string"}, "description": "New tags (replaces existing). Add exactly the tags the operator named — a routing tag (agent/local/claude/codex/cloud/cloud-haiku/cloud-sonnet) only if the operator explicitly named that engine; these tags are operator-authority and outrank every routing safeguard."}
+                    "tags": {"type": "array", "items": {"type": "string"}, "description": "New tags (replaces existing). Add exactly the tags the operator named — a routing tag (agent/local/claude/codex/cloud/cloud-haiku/cloud-sonnet) only if the operator explicitly named that engine; these tags are operator-authority and outrank every routing safeguard."},
+                    "notes": {"type": "string", "description": "Replaces the notes body."},
+                    "fields": {"type": "object", "additionalProperties": {"type": ["string", "null"]}, "description": "Merged into operator/unknown fields, not replaced: a string sets a field, null removes it."}
                 },
                 "required": ["task_id"]
             },
@@ -984,6 +1007,31 @@ class LifeOSMCPServer:
                     "task_id": {"type": "string", "description": "Task ID to delete"}
                 },
                 "required": ["task_id"]
+            },
+            "lifeos_human_queue_add": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string", "description": "Card title, e.g. 'Re-authenticate the example-service session'."},
+                    "notes": {"type": "string", "description": "Notes body — what needs doing and why."},
+                    "key": {"type": "string", "description": "Dedupe key, e.g. 'example-service-reauth'. Letters, digits, '.', ':', '-', '_' only. Filing again with an existing open key updates its notes instead of duplicating it."},
+                    "done_when": {"type": "object", "description": "Optional auto-resolve check: {type: 'endpoint', path, pointer, equals} or {type: 'file_exists', path}. For 'endpoint', path must start with '/' (not '//')."},
+                    "source_host": {"type": "string", "description": "Filing session's hostname, if known."},
+                    "source_cwd": {"type": "string", "description": "Filing session's working directory, if known."},
+                    "source_session": {"type": "string", "description": "Filing session's id, if known."}
+                },
+                "required": ["title"]
+            },
+            "lifeos_human_queue_list": {
+                "type": "object",
+                "properties": {}
+            },
+            "lifeos_human_queue_resolve": {
+                "type": "object",
+                "properties": {
+                    "id_or_key": {"type": "string", "description": "Card id (from lifeos_human_queue_list) or dedupe key."},
+                    "note": {"type": "string", "description": "Resolution note, appended to the card's notes."}
+                },
+                "required": ["id_or_key"]
             },
             "lifeos_calendar_create": {
                 "type": "object",
@@ -1919,6 +1967,26 @@ class LifeOSMCPServer:
 
         elif tool_name == "lifeos_task_delete":
             return f"Task deleted (ID: {data.get('id', data.get('task_id', 'unknown'))})"
+
+        elif tool_name == "lifeos_human_queue_add":
+            return f"Human-queue card filed (ID: {data.get('id', 'unknown')})"
+
+        elif tool_name == "lifeos_human_queue_list":
+            cards = data.get("cards", [])
+            if not cards:
+                return "No open Human-queue cards."
+            text = f"Found {data.get('total', len(cards))} open Human-queue card(s):\n\n"
+            for c in cards:
+                age = c.get("age_hours")
+                age_str = f"{age:.1f}h old" if age is not None else "age unknown"
+                text += f"- **{c.get('title', '')}** ({age_str}) [id:{c.get('id', '')}]"
+                if c.get("key"):
+                    text += f" key:{c['key']}"
+                text += "\n"
+            return text
+
+        elif tool_name == "lifeos_human_queue_resolve":
+            return f"Human-queue card resolved (ID: {data.get('id', 'unknown')})"
 
         elif tool_name == "lifeos_workout_manage":
             # The endpoint already returns the same plain-text confirmation/

--- a/scripts/claude-session-pane.sh
+++ b/scripts/claude-session-pane.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Claude Code SessionStart hook → bind session_id → wezterm pane_id.
 #
+# Superseded by scripts/lifeos-agent-hook.sh (#849), which registers a
+# session from ANY machine (not just the one hosting the API) and covers
+# every hook event, not just SessionStart. Kept here unchanged for
+# existing operator configs that still point at it; new installs should
+# use scripts/install-agent-hooks.sh instead.
+#
 # Install by adding this file as a SessionStart hook in ~/.claude/settings.json:
 #
 #   "hooks": {

--- a/scripts/codex-session-pane.sh
+++ b/scripts/codex-session-pane.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Codex SessionStart hook → bind session_id → wezterm pane_id.
 #
+# Superseded by scripts/lifeos-agent-hook.sh (#849), which registers a
+# session from ANY machine (not just the one hosting the API) and covers
+# every hook event, not just SessionStart. Kept here unchanged for
+# existing operator configs that still point at it; new installs should
+# use scripts/install-agent-hooks.sh instead.
+#
 # Sibling of claude-session-pane.sh. Install by adding this file as a
 # SessionStart hook in ~/.codex/hooks.json:
 #

--- a/scripts/install-agent-hooks.sh
+++ b/scripts/install-agent-hooks.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Idempotently install scripts/lifeos-agent-hook.sh into a Claude Code
+# settings.json and a Codex hooks.json (#849), so this machine's CLI
+# sessions register themselves with LifeOS on /agents.
+#
+# Usage: scripts/install-agent-hooks.sh
+#
+# Targets (override for testing against temp copies — never point these
+# at anything but a scratch file outside a real run):
+#   LIFEOS_CLAUDE_SETTINGS   default: ~/.claude/settings.json
+#   LIFEOS_CODEX_HOOKS       default: ~/.codex/hooks.json
+#
+# What it does: for each event Claude Code and Codex support
+# (claude_code: SessionStart, UserPromptSubmit, Stop, SessionEnd; codex:
+# SessionStart, UserPromptSubmit, Stop — Codex has no SessionEnd hook),
+# appends one entry that runs lifeos-agent-hook.sh with that event's args,
+# UNLESS an entry already exists for that event whose command contains
+# "lifeos-agent-hook.sh" (identifies a prior run of this installer, so
+# running it again is a no-op). Every other tool's entries — Orca, atuin,
+# a legacy claude-session-pane.sh / codex-session-pane.sh entry — are left
+# exactly as they were. Creates the target file (and its `hooks` object)
+# if missing.
+#
+# The installed command is the absolute path of lifeos-agent-hook.sh in
+# THIS checkout, resolved from this installer's own location, wrapped so
+# a moved or deleted checkout never breaks the CLI:
+#   bash -c 's="<path>"; [ -x "$s" ] && exec "$s" <engine> <event>; exit 0'
+#
+# Does NOT write LIFEOS_AGENT_HOOK_TOKEN anywhere — prints instructions
+# for the operator to create the token/URL env file
+# scripts/lifeos-agent-hook.sh reads.
+#
+# Portable to bash 3.2 (macOS's shipped bash) as well as Linux bash. No
+# mapfile, no `${var,,}`, no associative arrays, no GNU-only flags.
+# Requires jq (same dependency as the hook script itself).
+
+set -eu
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "install-agent-hooks.sh: jq is required" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_SCRIPT="$SCRIPT_DIR/lifeos-agent-hook.sh"
+
+CLAUDE_SETTINGS="${LIFEOS_CLAUDE_SETTINGS:-$HOME/.claude/settings.json}"
+CODEX_HOOKS="${LIFEOS_CODEX_HOOKS:-$HOME/.codex/hooks.json}"
+
+# Appends one hook entry to the `.hooks` object of the JSON file at $1,
+# under hook key $2 (e.g. "SessionStart" — the CLI's own event name),
+# running lifeos-agent-hook.sh with args ($3 engine, $4 hook-script event
+# name) under matcher $5 — unless an entry already exists under that hook
+# key whose `.hooks[].command` contains "lifeos-agent-hook.sh".
+_install_event() {
+    file="$1"; hook_key="$2"; engine="$3"; hook_event="$4"; matcher="$5"
+
+    mkdir -p "$(dirname "$file")"
+    if [[ ! -f "$file" ]]; then
+        echo '{}' > "$file"
+    fi
+
+    already="$(jq --arg ev "$hook_key" '
+        ((.hooks // {})[$ev] // [])
+        | map((.hooks // []) | map(.command // "") | any(contains("lifeos-agent-hook.sh")))
+        | any
+    ' "$file")"
+
+    if [[ "$already" == "true" ]]; then
+        echo "  $engine $hook_key: already installed"
+        return 0
+    fi
+
+    cmd="bash -c 's=\"$HOOK_SCRIPT\"; [ -x \"\$s\" ] && exec \"\$s\" $engine $hook_event; exit 0'"
+
+    tmp="$(mktemp "${file}.XXXXXX")"
+    jq --arg ev "$hook_key" --arg matcher "$matcher" --arg cmd "$cmd" '
+        .hooks = (.hooks // {})
+        | .hooks[$ev] = ((.hooks[$ev] // []) + [{
+              matcher: $matcher,
+              hooks: [{type: "command", command: $cmd}]
+          }])
+    ' "$file" > "$tmp"
+    mv "$tmp" "$file"
+    echo "  $engine $hook_key: installed"
+}
+
+echo "Claude Code ($CLAUDE_SETTINGS):"
+_install_event "$CLAUDE_SETTINGS" "SessionStart" "claude_code" "session_start" "*"
+_install_event "$CLAUDE_SETTINGS" "UserPromptSubmit" "claude_code" "user_prompt_submit" "*"
+_install_event "$CLAUDE_SETTINGS" "Stop" "claude_code" "stop" "*"
+_install_event "$CLAUDE_SETTINGS" "SessionEnd" "claude_code" "session_end" "*"
+
+echo "Codex ($CODEX_HOOKS):"
+_install_event "$CODEX_HOOKS" "SessionStart" "codex" "session_start" "startup|resume"
+_install_event "$CODEX_HOOKS" "UserPromptSubmit" "codex" "user_prompt_submit" "*"
+_install_event "$CODEX_HOOKS" "Stop" "codex" "stop" "*"
+
+echo
+echo "Session registration needs a bearer token before it will post anywhere."
+echo "On the machine hosting the LifeOS API, set LIFEOS_AGENT_HOOK_TOKEN (e.g."
+echo "openssl rand -hex 32) and restart the API. Then on THIS machine, create:"
+echo
+echo "  \${LIFEOS_AGENT_HOOK_ENV:-~/.config/lifeos/agent-hook.env}"
+echo
+echo "containing:"
+echo
+echo "  LIFEOS_API_URL=http://<api-host>:8000"
+echo "  LIFEOS_AGENT_HOOK_TOKEN=<the same token>"
+echo
+echo "This file holds the token in plaintext, so create its directory and"
+echo "lock it down to your own account, e.g.:"
+echo
+echo "  mkdir -p ~/.config/lifeos && chmod 600 ~/.config/lifeos/agent-hook.env"
+echo
+echo "Until that file (or the equivalent environment variables) exists,"
+echo "lifeos-agent-hook.sh exits silently without posting anything."

--- a/scripts/lifeos-agent-hook.sh
+++ b/scripts/lifeos-agent-hook.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Cross-machine CLI session lifecycle hook (#849) — supersedes
+# claude-session-pane.sh and codex-session-pane.sh (kept in place; their
+# operator configs may still point at them, but new installs should use
+# this script instead — see scripts/install-agent-hooks.sh).
+#
+# Registers a Claude Code or Codex session with LifeOS from ANY machine —
+# not just the one hosting the API — so it shows up on /agents with its
+# host, branch, and current status. One script serves every hook event;
+# the engine and event names are passed as args:
+#
+#   lifeos-agent-hook.sh claude_code session_start
+#   lifeos-agent-hook.sh claude_code user_prompt_submit
+#   lifeos-agent-hook.sh claude_code stop
+#   lifeos-agent-hook.sh claude_code session_end
+#   lifeos-agent-hook.sh codex session_start
+#   lifeos-agent-hook.sh codex user_prompt_submit
+#   lifeos-agent-hook.sh codex stop
+#
+# What it does: reads the hook's JSON payload from stdin
+# (`{session_id, cwd, transcript_path?, source, prompt?}` — the exact
+# fields present vary by event and by engine), adds the hostname, the
+# cwd's git branch, and an optional task id from $LIFEOS_TASK_ID, and
+# POSTs the result to POST /api/agents/cli-sessions/events with a bearer
+# token. Unlike claude-session-pane.sh's /cc-pane-bind (localhost-only),
+# this endpoint is reachable over Tailscale, so $LIFEOS_API_URL normally
+# points at the box hosting the API, not localhost.
+#
+# Config: sources a small env file for LIFEOS_API_URL and
+# LIFEOS_AGENT_HOOK_TOKEN, defaulting to ~/.config/lifeos/agent-hook.env
+# (override with $LIFEOS_AGENT_HOOK_ENV). Values already set in the
+# environment take precedence over the file. This script never writes the
+# token itself — see scripts/install-agent-hooks.sh for the one-time setup
+# instructions it prints.
+#
+# Exits 0 silently in every non-fatal case: jq/curl missing, empty stdin,
+# no session_id in the payload, no token configured (env or file), API
+# unreachable. Never blocks the CLI; total wall time on the happy path is
+# one HTTP round trip capped at 2s. Never writes to stdout — a hook's
+# stdout may be interpreted by the CLI.
+#
+# WezTerm pane binding is optional, not required: pane_id/wezterm_pid are
+# included only when $WEZTERM_PANE is set. Unlike the scripts this
+# replaces, running outside WezTerm is a normal case, not a silent exit —
+# the session still registers, just without a pane to jump to.
+#
+# Portable to bash 3.2 (macOS's shipped bash) as well as Linux bash: no
+# mapfile, no `${var,,}`, no associative arrays, no GNU-only flags.
+
+set -u
+
+ENGINE="${1:-}"
+EVENT="${2:-}"
+
+if [[ -z "$ENGINE" || -z "$EVENT" ]]; then
+    exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+fi
+if ! command -v curl >/dev/null 2>&1; then
+    exit 0
+fi
+
+# Config file: LIFEOS_API_URL / LIFEOS_AGENT_HOOK_TOKEN. Capture whatever
+# the environment already set first so sourcing the file never overrides
+# an explicit env value — the file only fills in what's missing.
+_PRE_API_URL="${LIFEOS_API_URL:-}"
+_PRE_TOKEN="${LIFEOS_AGENT_HOOK_TOKEN:-}"
+ENV_FILE="${LIFEOS_AGENT_HOOK_ENV:-$HOME/.config/lifeos/agent-hook.env}"
+if [[ -f "$ENV_FILE" ]]; then
+    # shellcheck disable=SC1090
+    . "$ENV_FILE"
+fi
+if [[ -n "$_PRE_API_URL" ]]; then
+    LIFEOS_API_URL="$_PRE_API_URL"
+fi
+if [[ -n "$_PRE_TOKEN" ]]; then
+    LIFEOS_AGENT_HOOK_TOKEN="$_PRE_TOKEN"
+fi
+
+TOKEN="${LIFEOS_AGENT_HOOK_TOKEN:-}"
+if [[ -z "$TOKEN" ]]; then
+    exit 0
+fi
+
+LIFEOS_URL="${LIFEOS_API_URL:-http://localhost:8000}"
+
+# Buffer stdin once — every extraction below reads from it.
+PAYLOAD="$(cat 2>/dev/null || true)"
+if [[ -z "$PAYLOAD" ]]; then
+    exit 0
+fi
+
+SESSION_ID="$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null)"
+if [[ -z "$SESSION_ID" ]]; then
+    exit 0
+fi
+CWD="$(printf '%s' "$PAYLOAD" | jq -r '.cwd // empty' 2>/dev/null)"
+TRANSCRIPT_PATH="$(printf '%s' "$PAYLOAD" | jq -r '.transcript_path // empty' 2>/dev/null)"
+PROMPT="$(printf '%s' "$PAYLOAD" | jq -r '.prompt // empty' 2>/dev/null)"
+MODEL="$(printf '%s' "$PAYLOAD" | jq -r '.model // empty' 2>/dev/null)"
+
+# Hostname without domain suffix — never rely on `hostname -s`, which
+# isn't portable across Linux and macOS `hostname` implementations.
+HOST_NAME="$(hostname 2>/dev/null || true)"
+HOST_NAME="${HOST_NAME%%.*}"
+
+BRANCH=""
+if [[ -n "$CWD" ]]; then
+    BRANCH="$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+fi
+
+TASK_ID="${LIFEOS_TASK_ID:-}"
+
+JQ_ARGS=(
+    --arg engine "$ENGINE"
+    --arg event "$EVENT"
+    --arg session_id "$SESSION_ID"
+    --arg host "$HOST_NAME"
+    --arg cwd "$CWD"
+    --arg transcript_path "$TRANSCRIPT_PATH"
+    --arg branch "$BRANCH"
+    --arg model "$MODEL"
+    --arg prompt_preview "$PROMPT"
+    --arg task_id "$TASK_ID"
+)
+JQ_FILTER='{engine:$engine, event:$event, session_id:$session_id, host:$host, cwd:$cwd, transcript_path:$transcript_path, branch:$branch, model:$model, prompt_preview:$prompt_preview, task_id:$task_id}'
+
+# A non-numeric $WEZTERM_PANE would make `jq --argjson pane_id` fail,
+# emptying $BODY and silently dropping the whole event below — not just
+# the pane fields. Guard it the same way $pid/$mtime are guarded so a
+# malformed value just omits the pane fields instead.
+case "${WEZTERM_PANE:-}" in
+    ''|*[!0-9]*) ;;
+    *)
+    # Best-effort: the pid of the live wezterm-gui process this pane
+    # belongs to, found the same way the API's own `_current_wezterm_pid`
+    # does (newest live `gui-sock-*` socket under the wezterm runtime
+    # dir) — kept in sync deliberately so a local event's pane mapping
+    # matches what /cc-pane-bind would have written.
+    RTDIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+    SOCKDIR="$RTDIR/wezterm"
+    NEWEST_PID=""
+    NEWEST_MTIME=0
+    if [[ -d "$SOCKDIR" ]]; then
+        for f in "$SOCKDIR"/gui-sock-*; do
+            [[ -e "$f" ]] || continue
+            pid="${f##*gui-sock-}"
+            case "$pid" in
+                ''|*[!0-9]*) continue ;;
+            esac
+            kill -0 "$pid" 2>/dev/null || continue
+            mtime="$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0)"
+            case "$mtime" in
+                ''|*[!0-9]*) mtime=0 ;;
+            esac
+            if [[ "$mtime" -gt "$NEWEST_MTIME" ]]; then
+                NEWEST_MTIME="$mtime"
+                NEWEST_PID="$pid"
+            fi
+        done
+    fi
+    JQ_ARGS+=(--argjson pane_id "$WEZTERM_PANE")
+    if [[ -n "$NEWEST_PID" ]]; then
+        JQ_ARGS+=(--argjson wezterm_pid "$NEWEST_PID")
+        JQ_FILTER="$JQ_FILTER"' + {pane_id:$pane_id, wezterm_pid:$wezterm_pid}'
+    else
+        JQ_FILTER="$JQ_FILTER"' + {pane_id:$pane_id}'
+    fi
+    ;;
+esac
+
+BODY="$(jq -nc "${JQ_ARGS[@]}" "$JQ_FILTER" 2>/dev/null)"
+if [[ -z "$BODY" ]]; then
+    exit 0
+fi
+
+curl -fsS --max-time 2 \
+    -X POST "${LIFEOS_URL}/api/agents/cli-sessions/events" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -d "$BODY" \
+    >/dev/null 2>&1 || true
+
+exit 0

--- a/scripts/run_all_syncs.py
+++ b/scripts/run_all_syncs.py
@@ -64,7 +64,11 @@ from api.services.sync_health import (
     reap_orphan_sync_runs,
     detect_silent_source_entity_drift,
 )
-from api.services.log_redaction import configure_telegram_log_redaction
+from api.services.log_redaction import (
+    REDACTED_TOKEN,
+    TELEGRAM_TOKEN_PATTERN,
+    configure_telegram_log_redaction,
+)
 from config.settings import settings
 
 # =============================================================================
@@ -580,6 +584,151 @@ def log_sync_summary_to_markdown(result: dict, trigger: str = "unknown"):
 
     entry = "\n" + "\n".join(lines) + "\n"
     _write_to_markdown_log(entry)
+
+
+# ---------------------------------------------------------------------------
+# Human queue integration (#852) — files/resolves operator-only-failure
+# cards through the local HTTP API, never the in-process TaskManager (this
+# script runs as a separate process from the API server — the same rule the
+# maintenance-mode toggle above follows). Every entry point below is wrapped
+# so a filing failure never raises into the sync run itself.
+# ---------------------------------------------------------------------------
+
+_HUMAN_QUEUE_API_BASE = "http://localhost:8000"
+
+
+def _human_queue_request(method: str, path: str, payload: dict | None = None) -> dict | None:
+    """Call a human-queue endpoint. Returns the parsed JSON body, or None on
+    any failure (network, non-2xx, bad JSON) — logged, never raised."""
+    logger = logging.getLogger(__name__)
+    try:
+        data = json.dumps(payload).encode("utf-8") if payload is not None else None
+        req = urllib.request.Request(
+            f"{_HUMAN_QUEUE_API_BASE}{path}",
+            data=data,
+            headers={"Content-Type": "application/json"} if data is not None else {},
+            method=method,
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = resp.read()
+            return json.loads(body) if body else {}
+    except Exception as e:
+        logger.warning(f"human-queue: {method} {path} failed: {e}")
+        return None
+
+
+def _human_queue_file_card(
+    title: str, notes: str = "", key: str | None = None, done_when: dict | None = None
+) -> None:
+    payload: dict = {"title": title, "notes": notes}
+    if key:
+        payload["key"] = key
+    if done_when:
+        payload["done_when"] = done_when
+    _human_queue_request("POST", "/api/tasks/human-queue", payload)
+
+
+def _human_queue_resolve_key(key: str, note: str = "") -> None:
+    _human_queue_request("PUT", f"/api/tasks/human-queue/{key}/resolve", {"note": note})
+
+
+def _human_queue_open_keys() -> set[str]:
+    body = _human_queue_request("GET", "/api/tasks/human-queue")
+    if not body:
+        return set()
+    return {c.get("key") for c in body.get("cards", []) if c.get("key")}
+
+
+def _sanitize_human_queue_error_text(error_text: str) -> str:
+    """Sanitize raw sync error text before it's filed as a Human-queue
+    card's notes body.
+
+    A literal `\\r` desyncs from the task store's `\\n`-joined notes body,
+    which silently drops the whole card (`task_manager._validate_text_
+    fields`) rather than raising anything this script would see; a literal
+    `<!--` could forge a new `<!-- id:.. -->` comment on the next reindex,
+    hijacking another task's id. Also redact any Telegram bot token that
+    leaked into the error text (the same pattern `api/services/
+    log_redaction` scrubs from httpx logs) before it's ever written to the
+    vault. Truncated to the same 2000 chars as before.
+    """
+    text = error_text.replace("\r\n", "\n").replace("\r", " ")
+    text = text.replace("<!--", "<! --")
+    text = TELEGRAM_TOKEN_PATTERN.sub(REDACTED_TOKEN, text)
+    return text[:2000]
+
+
+def file_human_queue_cards_for_sync(result: dict) -> None:
+    """File a keyed Human-queue card for each source this run's summary
+    classifies as a real failure (`result['failed_sources']` — a source
+    that's disabled/unconfigured, or skipped because a dependency failed,
+    never enters that list), and resolve any previously-filed `sync:<source>`
+    card for a source that succeeded this run (#852).
+
+    Hooked from the summary path (called once after the full run, alongside
+    `send_sync_summary_telegram`) rather than instrumented into
+    `sync_health.record_sync_complete`/`record_sync_error` at each of
+    `run_sync`'s many internal call sites (retries, duration-collapse,
+    yield-collapse, ...) — a single, easily-testable seam, and
+    `failed_sources` is already exactly the classification this issue asks
+    for (the same list the Telegram/markdown summaries report). Never raises
+    into the sync run.
+    """
+    logger = logging.getLogger(__name__)
+    try:
+        open_keys = _human_queue_open_keys()
+        failed_sources = set(result.get("failed_sources", []))
+
+        for source in failed_sources:
+            stats = result.get("results", {}).get(source) or {}
+            error_text = stats.get("error") or "sync failed"
+            _human_queue_file_card(
+                title=f"Sync source '{source}' needs attention",
+                notes=_sanitize_human_queue_error_text(error_text),
+                key=f"sync:{source}",
+            )
+
+        # Resolve only a source that actually ran and succeeded this run —
+        # a source that's skipped (disabled, not due, dependency-skipped,
+        # or a mid-run skip like missing credentials) never ran, so its
+        # open card (if any) must stay open, not get marked "sync
+        # succeeded". Also skip sources without an open card at all —
+        # avoids a resolve HTTP call (and its inevitable 404) for every
+        # healthy source on every run.
+        for source, stats in result.get("results", {}).items():
+            if source in failed_sources:
+                continue
+            if not stats or not stats.get("success") or stats.get("skipped") or stats.get("dry_run"):
+                continue
+            key = f"sync:{source}"
+            if key in open_keys:
+                _human_queue_resolve_key(key, note="sync succeeded")
+    except Exception as e:
+        logger.warning(f"human-queue: sync integration failed: {e}")
+
+
+def file_human_queue_card_for_monarch(mstatus: dict) -> None:
+    """File the `monarch-reauth` card when the Monarch session is expired or
+    missing, with a `done_when` endpoint check the worker's poll tick
+    resolves automatically once re-auth succeeds (#852). A no-op for any
+    other status. Never raises."""
+    logger = logging.getLogger(__name__)
+    try:
+        if mstatus.get("status") not in ("expired", "missing"):
+            return
+        _human_queue_file_card(
+            title="Monarch session needs re-authentication",
+            notes=mstatus.get("message", ""),
+            key="monarch-reauth",
+            done_when={
+                "type": "endpoint",
+                "path": "/api/monarch/session_status",
+                "pointer": "/status",
+                "equals": "ok",
+            },
+        )
+    except Exception as e:
+        logger.warning(f"human-queue: Monarch re-auth filing failed: {e}")
 
 
 def send_sync_summary_telegram(result: dict, trigger: str = "unknown"):
@@ -1981,6 +2130,9 @@ def run_all_syncs(
             mstatus = get_session_status()
             if mstatus["status"] in ("expiring_soon", "expired", "missing"):
                 logger.warning(f"Monarch session: {mstatus['message']}")
+            # File a Human-queue card for expired/missing (not expiring_soon
+            # — that's an early warning, not yet operator-actionable) (#852).
+            file_human_queue_card_for_monarch(mstatus)
         except Exception as e:
             logger.warning(f"Monarch session-status check failed: {e}")
 
@@ -2313,6 +2465,10 @@ def run_all_syncs(
     # Send Telegram notification (skip for dry run)
     if not dry_run:
         send_sync_summary_telegram(result, trigger=trigger)
+
+    # File/resolve Human-queue cards for sources needing operator action (#852).
+    if not dry_run:
+        file_human_queue_cards_for_sync(result)
 
     # Restart server to pick up any changes and clear stale state
     if not dry_run:

--- a/scripts/seed_proactive_reminders.py
+++ b/scripts/seed_proactive_reminders.py
@@ -14,7 +14,6 @@ Each module is a standard prompt-type reminder — no new infrastructure.
 Delete any reminder via the API to disable it.
 """
 import argparse
-import json
 import os
 import sys
 from pathlib import Path
@@ -65,6 +64,11 @@ Search my calendar for today's events. For each meeting, include the time and a 
 **Tasks**
 List tasks that are due today or overdue. For each, include the task description and context. \
 If there are no due/overdue tasks, say "No urgent tasks today."
+
+**Waiting on You**
+Call manage_human_queue with action "list" to check the Human queue — things only I can do that \
+an agent has filed and is waiting on. Report only cards shown as 24h old or older, one line each \
+with the title and how long it's been waiting. Skip this section entirely if there are none.
 
 **Overnight Emails**
 Search my email for messages received since 6 PM yesterday. Highlight only emails that seem \

--- a/tests/fixtures/agent_system_prompt_golden_591.py
+++ b/tests/fixtures/agent_system_prompt_golden_591.py
@@ -128,6 +128,14 @@ STATIC_TEXT = ("You are LifeOS, Test User's personal knowledge assistant.\n"
  '**manage_reminders (action: create/list):**\n'
  'Create or list timed Telegram notification reminders.\n'
  '\n'
+ '**manage_human_queue (action: add/list/resolve):**\n'
+ 'The Human queue is a shared list of things only Test User can do — an expired login, an '
+ "approval, a decision the conversation can't finish on its own. 'add' files a card (title, notes "
+ "on what's needed, an optional dedupe `key`) without blocking the conversation — never file work "
+ 'you could do yourself. \'list\' returns open cards; use it for "what\'s waiting on me" or "what\'s '
+ 'in my Human queue". \'resolve\' marks a card done once you\'ve observed the thing is actually done. '
+ 'See docs/guides/human-queue.md for the full contract.\n'
+ '\n'
  '**search_finances (action: accounts/transactions/cashflow/budgets/investments):**\n'
  "Live financial data from Monarch Money. Use 'accounts' for current balances, 'transactions' to "
  "search recent spending (filterable by date, category, merchant), 'cashflow' for "
@@ -180,10 +188,9 @@ STATIC_TEXT = ("You are LifeOS, Test User's personal knowledge assistant.\n"
  'current events, "best X right now", latest versions, schedules, rosters, releases), ALWAYS call '
  'search_web first — even if it seems like general knowledge. Your training data is stale, so '
  'never claim from memory that you "can\'t access" live data, "can\'t browse the web," or have a '
- '"knowledge cutoff," and never assert that something "hasn\'t been released / announced / '
- 'happened yet," doesn\'t exist, or isn\'t available — call search_web and let the results decide. '
- "State that something isn't available only *after* a web search comes up empty, and say you "
- 'searched.\n'
+ '"knowledge cutoff," and never assert that something "hasn\'t been released / announced / happened '
+ 'yet," doesn\'t exist, or isn\'t available — call search_web and let the results decide. State that '
+ "something isn't available only *after* a web search comes up empty, and say you searched.\n"
  '\n'
  '**On pushback** ("do research," "you\'re wrong," "look it up"), you MUST call search_web before '
  'replying — don\'t repeat your previous claim, and never say "my research confirms" unless you '

--- a/tests/test_agent_board.py
+++ b/tests/test_agent_board.py
@@ -1,0 +1,351 @@
+"""Unit tests for api/services/agent_board.py — pure lane derivation and
+lane-move planning (#850). One test per row of the lane table in the issue,
+plus the scheduler-entry bucketing rule.
+"""
+import pytest
+
+from api.services import agent_board
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# derive_assignee
+# ---------------------------------------------------------------------------
+
+class TestDeriveAssignee:
+    def test_no_assignee_tag(self):
+        assert agent_board.derive_assignee(["docs", "writing"]) is None
+
+    def test_me(self):
+        assert agent_board.derive_assignee(["me"]) == "me"
+
+    @pytest.mark.parametrize("engine", ["claude", "codex", "hermes", "local"])
+    def test_agent_engines(self, engine):
+        assert agent_board.derive_assignee([engine]) == engine
+
+    def test_hash_prefix_and_case_insensitive(self):
+        assert agent_board.derive_assignee(["#Codex"]) == "codex"
+
+    def test_empty_tags(self):
+        assert agent_board.derive_assignee([]) is None
+
+    def test_multiple_assignee_tags_precedence_is_ASSIGNEE_TAGS_order(self):
+        # Round-1 finding 15: precedence follows ASSIGNEE_TAGS order
+        # ("me" first), not the order the tags happen to appear in the list.
+        assert agent_board.derive_assignee(["codex", "me"]) == "me"
+
+
+# ---------------------------------------------------------------------------
+# derive_lane — one test per row of the issue's lane table
+# ---------------------------------------------------------------------------
+
+class TestDeriveLaneTable:
+    def test_unassigned_open_task_no_assignee(self):
+        assert agent_board.derive_lane("todo", []) == "unassigned"
+
+    def test_assigned_me_tag_status_todo(self):
+        assert agent_board.derive_lane("todo", ["me"]) == "assigned"
+
+    def test_assigned_agent_engine_tag_not_yet_claimed(self):
+        assert agent_board.derive_lane("todo", ["codex"]) == "assigned"
+
+    def test_in_progress_status(self):
+        assert agent_board.derive_lane("in_progress", []) == "in_progress"
+
+    def test_in_progress_agent_running_tag(self):
+        # AC: tags [agent, agent-running] -> In progress, regardless of status.
+        assert agent_board.derive_lane("todo", ["agent", "agent-running"]) == "in_progress"
+
+    def test_human_queue_human_tag_and_blocked_status(self):
+        assert agent_board.derive_lane("blocked", ["human"]) == "human_queue"
+
+    def test_human_queue_agent_blocked_tag(self):
+        assert agent_board.derive_lane("todo", ["agent-blocked"]) == "human_queue"
+
+    def test_human_queue_status_blocked_alone(self):
+        assert agent_board.derive_lane("blocked", []) == "human_queue"
+
+    def test_scheduled_is_not_a_task_lane(self):
+        # Scheduled cards never come from derive_lane — they're built
+        # directly from scheduler entries in the route layer.
+        assert "scheduled" not in [
+            agent_board.derive_lane(s, t)
+            for s in ("todo", "in_progress", "blocked", "done", "cancelled")
+            for t in ([], ["me"], ["agent-completed"])
+        ]
+
+    def test_review_agent_completed_status_done_not_accepted(self):
+        assert agent_board.derive_lane("done", ["agent-completed"]) == "review"
+
+    def test_review_beats_done_once_accepted_it_moves_to_done(self):
+        assert agent_board.derive_lane("done", ["agent-completed", "accepted"]) == "done"
+
+    def test_done_status_done_no_special_tags(self):
+        assert agent_board.derive_lane("done", []) == "done"
+
+    def test_done_status_cancelled(self):
+        assert agent_board.derive_lane("cancelled", []) == "done"
+
+
+# ---------------------------------------------------------------------------
+# derive_lane — additional edge cases / priority ordering
+# ---------------------------------------------------------------------------
+
+class TestDeriveLanePriority:
+    def test_human_queue_beats_in_progress(self):
+        # agent-blocked + agent-running (worker rolled it to blocked but a
+        # stale running tag lingers) -> human queue wins.
+        assert agent_board.derive_lane("blocked", ["agent-running", "agent-blocked"]) == "human_queue"
+
+    def test_review_beats_human_queue(self):
+        assert agent_board.derive_lane("done", ["agent-completed", "human"]) == "review"
+
+    def test_assigned_status_urgent_still_assigned(self):
+        assert agent_board.derive_lane("urgent", ["local"]) == "assigned"
+
+    def test_unassigned_status_deferred_no_assignee(self):
+        assert agent_board.derive_lane("deferred", []) == "unassigned"
+
+
+# ---------------------------------------------------------------------------
+# plan_lane_move
+# ---------------------------------------------------------------------------
+
+class TestPlanLaneMove:
+    def test_unknown_lane_errors(self):
+        plan = agent_board.plan_lane_move("todo", [], "nonsense", None)
+        assert plan.error == (400, "unknown lane 'nonsense'")
+
+    def test_done_marks_task_done(self):
+        plan = agent_board.plan_lane_move("todo", ["me"], "done", None)
+        assert plan.status == "done"
+        assert plan.tags is None
+        assert plan.error is None
+
+    def test_unassigned_removes_assignee_tag(self):
+        plan = agent_board.plan_lane_move("todo", ["codex", "urgent-work"], "unassigned", None)
+        assert plan.error is None
+        assert plan.status is None
+        assert sorted(plan.tags) == ["urgent-work"]
+
+    def test_assigned_sets_codex_and_removes_other_assignee(self):
+        plan = agent_board.plan_lane_move("todo", ["me", "docs"], "assigned", "codex")
+        assert plan.error is None
+        assert plan.status is None
+        assert sorted(plan.tags) == ["codex", "docs"]
+
+    def test_assigned_without_assignee_body_errors(self):
+        plan = agent_board.plan_lane_move("todo", [], "assigned", None)
+        assert plan.error is not None
+        assert plan.error[0] == 400
+
+    def test_assigned_invalid_assignee_errors(self):
+        plan = agent_board.plan_lane_move("todo", [], "assigned", "gpt5")
+        assert plan.error is not None
+        assert plan.error[0] == 400
+
+    def test_in_progress_agent_assignee_is_409(self):
+        for engine in ("claude", "codex", "hermes", "local"):
+            plan = agent_board.plan_lane_move("todo", [engine], "in_progress", None)
+            assert plan.error == (409, "only the worker claims agent-assigned tasks"), engine
+
+    def test_in_progress_me_assignee_sets_status(self):
+        plan = agent_board.plan_lane_move("todo", ["me"], "in_progress", None)
+        assert plan.error is None
+        assert plan.status == "in_progress"
+
+    def test_in_progress_multiple_assignee_tags_uses_precedence(self):
+        # Round-1 finding 15: with both "me" and "codex" tags present,
+        # derive_assignee resolves "me" (ASSIGNEE_TAGS precedence) — since
+        # "me" isn't in AGENT_ASSIGNEES, the move succeeds instead of 409ing.
+        plan = agent_board.plan_lane_move("todo", ["me", "codex"], "in_progress", None)
+        assert plan.error is None
+        assert plan.status == "in_progress"
+
+    def test_in_progress_no_assignee_sets_status(self):
+        plan = agent_board.plan_lane_move("todo", [], "in_progress", None)
+        assert plan.error is None
+        assert plan.status == "in_progress"
+
+    def test_human_queue_sets_blocked_status(self):
+        plan = agent_board.plan_lane_move("todo", [], "human_queue", None)
+        assert plan.error is None
+        assert plan.status == "blocked"
+
+    def test_review_cannot_be_set_directly(self):
+        plan = agent_board.plan_lane_move("todo", [], "review", None)
+        assert plan.error is not None
+        assert plan.error[0] == 400
+
+    def test_scheduled_cannot_be_set_directly(self):
+        plan = agent_board.plan_lane_move("todo", [], "scheduled", None)
+        assert plan.error is not None
+        assert plan.error[0] == 400
+
+
+# ---------------------------------------------------------------------------
+# plan_lane_move — landing lane invariant (#850 round-1 finding 1, sharpened
+# by round-2 findings 1 and 2)
+#
+# Dropping a card on a settable lane must either land it there, or be
+# rejected for one of exactly three reasons derived straight from the
+# starting tags — never "any 409 passes" (round-2 finding 12/2c):
+#   * the worker owns the card (agent-running / agent-blocked present) and
+#     the target is In progress or Done (round-2 finding 1)
+#   * an agent-engine assignee tag is present (not yet claimed by the
+#     worker) and the target is In progress (round-1 finding, unchanged)
+#   * the card is a pending review (agent-completed, not yet accepted) and
+#     the target is In progress or Human queue — Done still doubles as the
+#     accept path (round-2 finding 2a)
+# Assigned/unassigned are tags-only by design (an assignee change must not
+# pull a card out of Human queue — the lane table says Human queue beats
+# Assigned), so for those two targets this only checks the assignee-tag
+# outcome and that `status` is left untouched, never landed-lane == target.
+# ---------------------------------------------------------------------------
+
+class TestPlanLaneMoveLandsInTargetLane:
+    STARTING_STATES = {
+        "unassigned": ("todo", []),
+        "assigned_me": ("todo", ["me"]),
+        "assigned_codex": ("todo", ["codex"]),
+        "in_progress_status": ("in_progress", []),
+        "in_progress_worker_running": ("todo", ["agent", "agent-running"]),
+        "human_queue_human_tag": ("todo", ["human"]),
+        "human_queue_human_tag_and_blocked_status": ("blocked", ["human"]),
+        "human_queue_agent_blocked": ("todo", ["agent", "agent-blocked"]),
+        "human_queue_blocked_status": ("blocked", []),
+        "review_agent_completed_status_todo": ("todo", ["agent-completed"]),
+        "review_agent_completed_status_done": ("done", ["agent-completed"]),
+        "review_assignee_me": ("done", ["me", "agent-completed"]),
+        "done_plain": ("done", []),
+        "done_accepted": ("done", ["codex", "accepted"]),
+        "cancelled": ("cancelled", []),
+    }
+
+    SETTABLE_TARGETS = ["unassigned", "assigned", "in_progress", "human_queue", "done"]
+
+    WORKER_OWNED_ERROR = (
+        409,
+        "the worker owns this task while it is running or waiting on an "
+        "answer — answer or kill the session first",
+    )
+    AGENT_ASSIGNEE_ERROR = (409, "only the worker claims agent-assigned tasks")
+    REVIEW_ERROR = (409, "accept the review first")
+
+    @classmethod
+    def _expected_error(cls, current_status, current_tags, target_lane):
+        """The one legitimate rejection reason for this (state, target)
+        pair, or None if the move must succeed. Derived independently of
+        `plan_lane_move` so the test can't just echo the implementation."""
+        tags_lower = {t.lstrip("#").lower() for t in current_tags}
+        worker_owned = bool(tags_lower & {"agent-running", "agent-blocked"})
+        current_assignee = agent_board.derive_assignee(current_tags)
+        is_review = "agent-completed" in tags_lower and "accepted" not in tags_lower
+
+        if target_lane in ("in_progress", "done") and worker_owned:
+            return cls.WORKER_OWNED_ERROR
+        if target_lane == "in_progress" and current_assignee in agent_board.AGENT_ASSIGNEES:
+            return cls.AGENT_ASSIGNEE_ERROR
+        if target_lane in ("in_progress", "human_queue") and is_review:
+            return cls.REVIEW_ERROR
+        return None
+
+    @pytest.mark.parametrize("target_lane", SETTABLE_TARGETS)
+    @pytest.mark.parametrize("start_name,start", list(STARTING_STATES.items()))
+    def test_matrix(self, start_name, start, target_lane):
+        current_status, current_tags = start
+        plan = agent_board.plan_lane_move(current_status, current_tags, target_lane, "me")
+        expected_error = self._expected_error(current_status, current_tags, target_lane)
+
+        if expected_error is not None:
+            assert plan.error == expected_error, (start_name, target_lane, plan.error)
+            assert plan.status is None and plan.tags is None, (start_name, target_lane)
+            return
+
+        assert plan.error is None, (start_name, target_lane, plan.error)
+
+        if target_lane in ("assigned", "unassigned"):
+            assert plan.status is None, (start_name, target_lane, plan.status)
+            landed_tags = plan.tags if plan.tags is not None else list(current_tags)
+            new_assignee = agent_board.derive_assignee(landed_tags)
+            expected_assignee = "me" if target_lane == "assigned" else None
+            assert new_assignee == expected_assignee, (start_name, target_lane, landed_tags)
+            return
+
+        final_status = plan.status if plan.status is not None else current_status
+        final_tags = plan.tags if plan.tags is not None else list(current_tags)
+        assert agent_board.derive_lane(final_status, final_tags) == target_lane, (
+            start_name, target_lane, final_status, final_tags,
+        )
+
+    def test_done_strips_human_tag(self):
+        plan = agent_board.plan_lane_move("todo", ["human"], "done", None)
+        assert plan.status == "done"
+        assert "human" not in plan.tags
+
+    def test_done_rejects_worker_owned_agent_blocked_and_agent_running(self):
+        # Round-2 finding 1: the worker owns a card carrying agent-running or
+        # agent-blocked — dropping it on Done must 409 and write nothing,
+        # not silently strip the tag out from under a live worker task.
+        plan = agent_board.plan_lane_move(
+            "blocked", ["codex", "agent", "agent-blocked", "agent-running"], "done", None,
+        )
+        assert plan.error == (
+            409,
+            "the worker owns this task while it is running or waiting on an "
+            "answer — answer or kill the session first",
+        )
+        assert plan.status is None
+        assert plan.tags is None
+
+    def test_done_appends_accepted_when_agent_completed_present(self):
+        plan = agent_board.plan_lane_move("done", ["codex", "agent-completed"], "done", None)
+        assert plan.status == "done"
+        assert set(plan.tags) == {"codex", "agent-completed", "accepted"}
+
+    def test_done_does_not_double_append_accepted(self):
+        plan = agent_board.plan_lane_move(
+            "done", ["codex", "agent-completed", "accepted"], "done", None,
+        )
+        assert plan.tags is None or plan.tags.count("accepted") == 1
+
+    def test_in_progress_strips_human(self):
+        plan = agent_board.plan_lane_move("todo", ["human"], "in_progress", None)
+        assert plan.status == "in_progress"
+        assert "human" not in plan.tags
+
+    def test_in_progress_rejects_worker_owned_agent_blocked(self):
+        # Round-2 finding 1: agent-blocked means the worker owns this card
+        # (it's waiting on an answer) — 409, not a silent strip.
+        plan = agent_board.plan_lane_move("todo", ["agent-blocked"], "in_progress", None)
+        assert plan.error == (
+            409,
+            "the worker owns this task while it is running or waiting on an "
+            "answer — answer or kill the session first",
+        )
+        assert plan.status is None
+        assert plan.tags is None
+
+
+# ---------------------------------------------------------------------------
+# is_schedule_active — scheduler-entry bucketing rules from the issue
+# ---------------------------------------------------------------------------
+
+class TestIsScheduleActive:
+    def test_enabled_cron_with_future_fire_is_active(self):
+        assert agent_board.is_schedule_active(True, "2099-01-01T00:00:00+00:00") is True
+
+    def test_disabled_recurring_is_not_active(self):
+        assert agent_board.is_schedule_active(False, None) is False
+
+    def test_disabled_but_stale_next_trigger_is_not_active(self):
+        # Defensive: SchedulerStore clears next_trigger_at on disable, but the
+        # function shouldn't trust a stale value if enabled=False anyway.
+        assert agent_board.is_schedule_active(False, "2099-01-01T00:00:00+00:00") is False
+
+    def test_fired_one_off_has_no_next_trigger(self):
+        assert agent_board.is_schedule_active(False, None) is False
+
+    def test_enabled_with_no_next_trigger_is_not_active(self):
+        assert agent_board.is_schedule_active(True, None) is False

--- a/tests/test_agent_cli_session_events.py
+++ b/tests/test_agent_cli_session_events.py
@@ -1,0 +1,236 @@
+"""Tests for POST /api/agents/cli-sessions/events (issue #849).
+
+Covers the bearer-token gate (mirrors `hermes_proxy._check_hermes_inbound_auth`)
+and the `cli_sessions` status machine driven by `scripts/lifeos-agent-hook.sh`
+lifecycle posts: session_start -> idle, user_prompt_submit -> running (+
+truncated prompt preview), stop -> idle, session_end -> ended. Uses a
+temp-dir-backed SessionStore so the real data/ directory is never touched,
+and always sets its own `agent_hook_token` via monkeypatch rather than
+reading whatever the operator's real .env has configured.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+from api.routes import agents as agents_route
+from api.services.agent_worker.session_store import SessionStore
+
+
+TOKEN = "test-hook-token-value"
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    session_store = SessionStore(db_path=tmp_path / "sessions.db")
+    monkeypatch.setattr(agents_route, "_session_store", session_store)
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hook_token", TOKEN)
+    yield session_store
+
+
+@pytest.fixture
+def client():
+    return TestClient(api_main.app)
+
+
+@pytest.fixture
+def loopback_client():
+    # Pin the client host to loopback (default TestClient uses host=
+    # "testclient", which is NOT loopback) — same approach as
+    # tests/test_agent_cc_pane_bind.py's `client` fixture. Needed for the
+    # pane-store mirror, which requires the request itself to originate
+    # from loopback, not just a matching `host` field in the body.
+    return TestClient(api_main.app, client=("127.0.0.1", 50000))
+
+
+def _post(client, body, token=TOKEN):
+    headers = {"Authorization": f"Bearer {token}"} if token is not None else {}
+    return client.post("/api/agents/cli-sessions/events", json=body, headers=headers)
+
+
+def _event(**overrides):
+    body = {
+        "engine": "claude_code",
+        "event": "session_start",
+        "session_id": "abc-123",
+        "host": "laptop-a",
+        "cwd": "/home/synthetic/Code/X",
+    }
+    body.update(overrides)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_events_503_when_token_unset(client, stores, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hook_token", "")
+    r = _post(client, _event())
+    assert r.status_code == 503
+
+
+@pytest.mark.unit
+def test_events_401_when_no_bearer_header(client, stores):
+    r = client.post("/api/agents/cli-sessions/events", json=_event())
+    assert r.status_code == 401
+
+
+@pytest.mark.unit
+def test_events_401_when_wrong_token(client, stores):
+    r = _post(client, _event(), token="wrong-token")
+    assert r.status_code == 401
+
+
+@pytest.mark.unit
+def test_events_200_with_correct_token(client, stores):
+    r = _post(client, _event())
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["registered"] is True
+    assert body["session_id"] == "cc:abc-123"
+    assert body["status"] == "idle"
+
+
+# ---------------------------------------------------------------------------
+# Status machine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_session_start_creates_idle_row(client, stores):
+    r = _post(client, _event(event="session_start", session_id="s1"))
+    assert r.status_code == 200
+    cli = stores.get_cli_session("cc:s1")
+    assert cli is not None
+    assert cli.status == "idle"
+    assert cli.host == "laptop-a"
+    assert cli.engine == "claude_code"
+
+
+@pytest.mark.unit
+def test_user_prompt_submit_sets_running_and_truncates_preview(client, stores):
+    _post(client, _event(event="session_start", session_id="s2"))
+    long_prompt = "x" * 500
+    r = _post(client, _event(event="user_prompt_submit", session_id="s2",
+                              prompt_preview=long_prompt))
+    assert r.status_code == 200
+    cli = stores.get_cli_session("cc:s2")
+    assert cli.status == "running"
+    assert cli.prompt_preview == long_prompt[:200]
+    assert len(cli.prompt_preview) == 200
+
+
+@pytest.mark.unit
+def test_stop_sets_idle(client, stores):
+    _post(client, _event(event="session_start", session_id="s3"))
+    _post(client, _event(event="user_prompt_submit", session_id="s3", prompt_preview="hi"))
+    r = _post(client, _event(event="stop", session_id="s3"))
+    assert r.status_code == 200
+    cli = stores.get_cli_session("cc:s3")
+    assert cli.status == "idle"
+
+
+@pytest.mark.unit
+def test_session_end_sets_ended(client, stores):
+    _post(client, _event(event="session_start", session_id="s4"))
+    r = _post(client, _event(event="session_end", session_id="s4"))
+    assert r.status_code == 200
+    cli = stores.get_cli_session("cc:s4")
+    assert cli.status == "ended"
+    assert cli.ended_at is not None
+
+
+@pytest.mark.unit
+def test_codex_engine_uses_cx_prefix(client, stores):
+    r = _post(client, _event(engine="codex", session_id="cx1"))
+    assert r.status_code == 200
+    assert r.json()["session_id"] == "cx:cx1"
+    assert stores.get_cli_session("cx:cx1") is not None
+
+
+@pytest.mark.unit
+def test_task_id_stored(client, stores):
+    r = _post(client, _event(session_id="s5", task_id="task-42"))
+    assert r.status_code == 200
+    cli = stores.get_cli_session("cc:s5")
+    assert cli.task_id == "task-42"
+
+
+@pytest.mark.unit
+def test_unknown_event_returns_422(client, stores):
+    r = _post(client, _event(event="not_a_real_event"))
+    assert r.status_code == 422
+
+
+@pytest.mark.unit
+def test_unknown_engine_returns_422(client, stores):
+    r = _post(client, _event(engine="not_a_real_engine"))
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Pane store mirroring (#849 trap: local host events go into cc_wezterm_store)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def wezterm_store(tmp_path: Path, monkeypatch):
+    from api.services import cc_wezterm_store as mod
+    store = mod.CCWezTermStore(db_path=tmp_path / "cc_wezterm.db")
+    monkeypatch.setattr(mod, "_default_store", store)
+    yield store
+    store.close()
+
+
+@pytest.mark.unit
+def test_pane_id_from_api_host_written_to_pane_store(loopback_client, stores, wezterm_store, monkeypatch):
+    # Both conditions must hold: body.host matches this API's own host,
+    # AND the request itself arrived from loopback.
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    r = _post(loopback_client, _event(host="this-api-host", session_id="s6",
+                                       pane_id=7, wezterm_pid=999))
+    assert r.status_code == 200, r.text
+    mapping = wezterm_store.get("cc:s6")
+    assert mapping is not None
+    assert mapping.pane_id == 7
+
+
+@pytest.mark.unit
+def test_pane_id_from_remote_host_not_written_to_pane_store(loopback_client, stores, wezterm_store, monkeypatch):
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    r = _post(loopback_client, _event(host="a-different-laptop", session_id="s7", pane_id=9))
+    assert r.status_code == 200, r.text
+    assert wezterm_store.get("cc:s7") is None
+    # Still stored on the cli_sessions row itself.
+    cli = stores.get_cli_session("cc:s7")
+    assert cli.pane_id == 9
+
+
+@pytest.mark.unit
+def test_pane_id_from_non_loopback_client_with_spoofed_host_not_written_to_pane_store(
+    client, stores, wezterm_store, monkeypatch,
+):
+    """A non-loopback, bearer-authenticated caller naming this API's own
+    hostname must NOT be able to write into the shared pane store — that
+    would let it redirect Go To for a real local session (#849 round-1
+    security finding). The default `client` fixture is non-loopback
+    (TestClient's default host is "testclient"), so this exercises exactly
+    that path: body.host matches api_host_name() but request.client.host
+    does not pass the loopback gate.
+    """
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    r = _post(client, _event(host="this-api-host", session_id="s8", pane_id=13))
+    assert r.status_code == 200, r.text
+    assert wezterm_store.get("cc:s8") is None
+    # The event and pane id are still recorded on the cli_sessions row —
+    # only the shared pane-store mirror is withheld.
+    cli = stores.get_cli_session("cc:s8")
+    assert cli.pane_id == 13

--- a/tests/test_agent_cli_session_task_link.py
+++ b/tests/test_agent_cli_session_task_link.py
@@ -1,0 +1,110 @@
+"""Tests for #851's task_id linkage on CLI session registration: a
+`session_start` event naming a `task_id` (forwarded by
+`scripts/lifeos-agent-hook.sh` from `$LIFEOS_TASK_ID` — see #849) moves that
+task from `todo` to `in_progress`. Board `POST /board/cards/{id}/open`
+(`api/routes/agent_assignment.py`) sets `LIFEOS_TASK_ID` when it spawns the
+interactive CLI, so this is what turns "opened" into "In progress" on the
+board.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+from api.routes import agents as agents_route
+from api.services.agent_worker.session_store import SessionStore
+from api.services.task_manager import TaskManager
+
+
+pytestmark = pytest.mark.unit
+
+TOKEN = "test-hook-token-value"
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    session_store = SessionStore(db_path=tmp_path / "sessions.db")
+    monkeypatch.setattr(agents_route, "_session_store", session_store)
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hook_token", TOKEN)
+    yield session_store
+
+
+@pytest.fixture
+def manager(tmp_path: Path, monkeypatch):
+    import api.services.task_manager as tm_mod
+    m = TaskManager(vault_path=tmp_path / "vault", index_path=tmp_path / "index.json")
+    monkeypatch.setattr(tm_mod, "get_task_manager", lambda: m)
+    return m
+
+
+@pytest.fixture
+def client():
+    return TestClient(api_main.app)
+
+
+def _post(client, body, token=TOKEN):
+    headers = {"Authorization": f"Bearer {token}"}
+    return client.post("/api/agents/cli-sessions/events", json=body, headers=headers)
+
+
+def test_session_start_with_task_id_moves_todo_card_to_in_progress(client, stores, manager):
+    task = manager.create(description="fix the printer", tags=["agent", "claude"])
+    assert task.status == "todo"
+
+    resp = _post(client, {
+        "engine": "claude_code", "event": "session_start", "session_id": "abc-1",
+        "host": "laptop-a", "cwd": "/home/x", "task_id": task.id,
+    })
+    assert resp.status_code == 200
+
+    refreshed = manager.get(task.id)
+    assert refreshed.status == "in_progress"
+
+
+def test_session_start_without_task_id_is_unaffected(client, stores, manager):
+    resp = _post(client, {
+        "engine": "claude_code", "event": "session_start", "session_id": "abc-2",
+        "host": "laptop-a", "cwd": "/home/x",
+    })
+    assert resp.status_code == 200  # no task_id -> nothing to link, no error
+
+
+def test_session_start_task_already_in_progress_is_left_alone(client, stores, manager):
+    task = manager.create(description="fix the printer", tags=["agent", "claude"])
+    manager.update(task.id, status="in_progress")
+
+    resp = _post(client, {
+        "engine": "claude_code", "event": "session_start", "session_id": "abc-3",
+        "host": "laptop-a", "cwd": "/home/x", "task_id": task.id,
+    })
+    assert resp.status_code == 200
+    assert manager.get(task.id).status == "in_progress"
+
+
+def test_session_start_unknown_task_id_does_not_fail_the_event(client, stores, manager):
+    resp = _post(client, {
+        "engine": "claude_code", "event": "session_start", "session_id": "abc-4",
+        "host": "laptop-a", "cwd": "/home/x", "task_id": "no-such-task",
+    })
+    assert resp.status_code == 200
+
+
+def test_user_prompt_submit_does_not_move_the_task(client, stores, manager):
+    """Only session_start links+moves the card — a later user_prompt_submit
+    on the same session must not re-trigger it (harmless either way, but
+    confirms the gate is on the event type, not just task_id presence)."""
+    task = manager.create(description="fix the printer", tags=["agent", "claude"])
+    _post(client, {
+        "engine": "claude_code", "event": "session_start", "session_id": "abc-5",
+        "host": "laptop-a", "cwd": "/home/x", "task_id": task.id,
+    })
+    manager.update(task.id, status="todo")  # simulate an operator reverting it
+    _post(client, {
+        "engine": "claude_code", "event": "user_prompt_submit", "session_id": "abc-5",
+        "host": "laptop-a", "prompt_preview": "go", "task_id": task.id,
+    })
+    assert manager.get(task.id).status == "todo"

--- a/tests/test_agent_cli_sessions_snapshot.py
+++ b/tests/test_agent_cli_sessions_snapshot.py
@@ -1,0 +1,221 @@
+"""Snapshot-union tests for cross-machine CLI sessions (issue #849).
+
+`GET /api/agents/snapshot` merges the `cli_sessions` table (posted by
+scripts/lifeos-agent-hook.sh, from any machine) with the local transcript
+scan. A session known from both sources collapses into one row with
+event-driven status; a session known only from `cli_sessions` (a remote
+host, or a hook post that raced ahead of the transcript cache) becomes a
+synthetic row. Every row, including LifeOS worker sessions, carries `host`.
+
+Fakes the transcript scan via `_claude_code_snapshot` rather than writing
+real ~/.claude/projects/ jsonl fixtures — the union logic under test only
+cares about the dict shape `to_session_dict` produces, not how it's parsed.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+from api.routes import agents as agents_route
+from api.services.agent_worker.session_store import SessionStore
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    session_store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcript_store = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    monkeypatch.setattr(agents_route, "_session_store", session_store)
+    monkeypatch.setattr(agents_route, "_transcript_store", transcript_store)
+    agents_route._label_cache.clear()
+    monkeypatch.setattr(agents_route, "_claude_code_snapshot", lambda: ([], []))
+    monkeypatch.setattr(agents_route, "_codex_snapshot", lambda: ([], []))
+    monkeypatch.setattr(agents_route, "api_host_name", lambda: "this-api-host")
+    yield session_store, transcript_store
+    agents_route._label_cache.clear()
+
+
+@pytest.fixture
+def client():
+    return TestClient(api_main.app)
+
+
+def _fake_cc_transcript_row(session_id="cc:merge-target", **overrides):
+    row = {
+        "session_id": session_id,
+        "task_id": session_id.split(":", 1)[1],
+        "status": "inactive",
+        "routing": "claude_code",
+        "parent_session_id": None,
+        "root_session_id": session_id,
+        "spawn_depth": 0,
+        "yield_waiting_for": [],
+        "managed_agent_session_id": None,
+        "started_at": 1000,
+        "last_activity_at": 2000,
+        "total_input_tokens": 111,
+        "total_output_tokens": 222,
+        "total_cache_creation_tokens": 0,
+        "total_cache_read_tokens": 0,
+        "total_dollars": 0.05,
+        "total_active_seconds": 0.0,
+        "expected_output": None,
+        "label": "merge-target",
+        "model_label": "Sonnet",
+        "last_event_kind": "assistant",
+        "tool_call_count": 1,
+        "error_count": 0,
+        "source": "claude_code",
+        "status_inferred": True,
+        "project_key": "-home-x",
+        "decoded_cwd": "/home/x",
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.mark.unit
+def test_merged_row_is_single_with_event_status_and_transcript_tokens(client, stores, monkeypatch):
+    session_store, _ = stores
+    monkeypatch.setattr(agents_route, "_claude_code_snapshot",
+                        lambda: ([_fake_cc_transcript_row()], []))
+
+    session_store.record_cli_session_event(
+        engine="claude_code", event="user_prompt_submit",
+        session_id="merge-target", host="this-api-host",
+        cwd="/home/x", prompt="do the thing",
+    )
+
+    r = client.get("/api/agents/snapshot")
+    assert r.status_code == 200
+    sessions = r.json()["sessions"]
+    matches = [s for s in sessions if s["session_id"] == "cc:merge-target"]
+    assert len(matches) == 1
+    row = matches[0]
+    # Event-driven status wins over the transcript's inferred "inactive".
+    assert row["status"] == "running"
+    assert row["status_inferred"] is False
+    # Token/dollar fields stay transcript-derived — the hook posts none.
+    assert row["total_input_tokens"] == 111
+    assert row["total_output_tokens"] == 222
+    assert row["total_dollars"] == 0.05
+    assert row["host"] == "this-api-host"
+    assert row["prompt_preview"] == "do the thing"
+
+
+@pytest.mark.unit
+def test_remote_row_with_no_local_transcript(client, stores):
+    session_store, _ = stores
+    session_store.record_cli_session_event(
+        engine="codex", event="session_start",
+        session_id="remote-only", host="a-different-laptop",
+        cwd="/home/laptop/proj", branch="feat/x",
+    )
+
+    r = client.get("/api/agents/snapshot")
+    assert r.status_code == 200
+    sessions = r.json()["sessions"]
+    matches = [s for s in sessions if s["session_id"] == "cx:remote-only"]
+    assert len(matches) == 1
+    row = matches[0]
+    assert row["host"] == "a-different-laptop"
+    assert row["source"] == "codex"
+    assert row["status_inferred"] is False
+    assert row["status"] == "idle"
+    assert row["branch"] == "feat/x"
+
+
+@pytest.mark.unit
+def test_task_id_exposed_on_merged_and_remote_rows(client, stores, monkeypatch):
+    session_store, _ = stores
+    monkeypatch.setattr(agents_route, "_claude_code_snapshot",
+                        lambda: ([_fake_cc_transcript_row(session_id="cc:with-task")], []))
+    session_store.record_cli_session_event(
+        engine="claude_code", event="session_start",
+        session_id="with-task", host="this-api-host", task_id="task-99",
+    )
+    session_store.record_cli_session_event(
+        engine="codex", event="session_start",
+        session_id="remote-task", host="other-host", task_id="task-100",
+    )
+
+    r = client.get("/api/agents/snapshot")
+    sessions = {s["session_id"]: s for s in r.json()["sessions"]}
+    assert sessions["cc:with-task"]["task_id"] == "task-99"
+    assert sessions["cx:remote-task"]["task_id"] == "task-100"
+
+
+@pytest.mark.unit
+def test_worker_and_all_rows_carry_host(client, stores):
+    session_store, _ = stores
+    session_store.create(task_id="t1", session_id="sess_worker1")
+    session_store.record_cli_session_event(
+        engine="claude_code", event="session_start",
+        session_id="hostcheck", host="a-different-laptop",
+    )
+
+    r = client.get("/api/agents/snapshot")
+    sessions = r.json()["sessions"]
+    assert len(sessions) >= 2
+    for s in sessions:
+        assert s.get("host"), f"row {s['session_id']} missing host"
+    worker_row = next(s for s in sessions if s["session_id"] == "sess_worker1")
+    assert worker_row["host"] == "this-api-host"
+
+
+@pytest.mark.unit
+def test_focus_409_for_session_on_different_host(client, stores):
+    """#849: focus isn't implemented for remote hosts yet — it should 409
+    with the host name rather than trying (and failing) a local wezterm
+    probe for a pane that was never on this machine."""
+    session_store, _ = stores
+    session_store.record_cli_session_event(
+        engine="claude_code", event="session_start",
+        session_id="remote-focus", host="a-different-laptop",
+    )
+    r = client.post("/api/agents/sessions/cc:remote-focus/focus")
+    assert r.status_code == 409
+    assert "a-different-laptop" in r.json()["detail"]
+
+
+@pytest.mark.unit
+def test_resume_409_for_session_on_different_host(client, stores):
+    session_store, _ = stores
+    session_store.record_cli_session_event(
+        engine="codex", event="session_start",
+        session_id="remote-resume", host="a-different-laptop",
+    )
+    r = client.post("/api/agents/sessions/cx:remote-resume/resume")
+    assert r.status_code == 409
+    assert "a-different-laptop" in r.json()["detail"]
+
+
+@pytest.mark.unit
+def test_focus_local_host_unaffected_when_no_cli_session_row(client, stores, monkeypatch):
+    """A session_id with no `cli_sessions` row (never registered via the
+    hook) must fall through to the existing local-only resolution — the
+    409 check should not fire just because the id is unknown."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    r = client.post("/api/agents/sessions/cc:never-registered/focus")
+    # No wezterm mapping and no cli_sessions row -> falls through to the
+    # probe, which finds nothing -> 404, not 409.
+    assert r.status_code == 404
+
+
+@pytest.mark.unit
+def test_local_transcript_row_without_cli_event_still_gets_local_host(client, stores, monkeypatch):
+    """A transcript-only row (no cli_sessions post yet) still needs a host —
+    it ran here, so it gets the API host directly rather than being left
+    without one."""
+    monkeypatch.setattr(agents_route, "_claude_code_snapshot",
+                        lambda: ([_fake_cc_transcript_row(session_id="cc:no-event-yet")], []))
+    r = client.get("/api/agents/snapshot")
+    sessions = {s["session_id"]: s for s in r.json()["sessions"]}
+    assert sessions["cc:no-event-yet"]["host"] == "this-api-host"
+    # Unmerged rows keep the transcript's own inferred status.
+    assert sessions["cc:no-event-yet"]["status_inferred"] is True

--- a/tests/test_agent_kill_remote.py
+++ b/tests/test_agent_kill_remote.py
@@ -1,0 +1,143 @@
+"""Tests for the #851 remote-kill path: `POST /sessions/{id}/kill` for a
+session whose `host` names a machine other than the API host runs
+`ssh <target> kill -- -<pgid>` through the injectable runner instead of a
+local `killpg` — and never touches the network in tests.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+from api.routes import agents as agents_route
+from api.services.agent_worker.session_store import STATUS_RUNNING, SessionStore
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    session_store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcript_store = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    monkeypatch.setattr(agents_route, "_session_store", session_store)
+    monkeypatch.setattr(agents_route, "_transcript_store", transcript_store)
+    monkeypatch.setattr(agents_route, "_maybe_managed_driver", lambda: None)
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", {"studio": "user@studio.example"}, raising=False)
+    agents_route._label_cache.clear()
+    yield session_store, transcript_store
+    agents_route._label_cache.clear()
+
+
+@pytest.fixture
+def client():
+    return TestClient(api_main.app)
+
+
+def test_kill_remote_session_calls_injected_runner(client, stores, monkeypatch):
+    session_store, transcript_store = stores
+    session = session_store.create(
+        task_id="remote-task", status=STATUS_RUNNING, routing="claude_code", host="studio",
+    )
+    session_store.set_remote_pgid("remote-task", 55555)
+    transcript_store.append(session.session_id, "claude_code_spawn", {"host": "studio", "remote": True})
+
+    calls = []
+
+    class _FakeResult:
+        returncode = 0
+
+    def _fake_runner(argv):
+        calls.append(argv)
+        return _FakeResult()
+
+    monkeypatch.setattr(agents_route, "_remote_kill_runner", _fake_runner)
+
+    resp = client.post(f"/api/agents/sessions/{session.session_id}/kill", json={"reason": "test"})
+    assert resp.status_code == 200
+    assert resp.json()["killed"] == [session.session_id]
+
+    assert len(calls) == 1
+    argv = calls[0]
+    assert argv[0] == "ssh"
+    assert "user@studio.example" in argv
+    assert argv[-3:] == ["kill", "--", "-55555"]
+
+    events = [e["kind"] for e in transcript_store.read(session.session_id)]
+    assert "remote_subprocess_kill_attempted" in events
+
+
+def test_kill_remote_session_unregistered_host_is_best_effort_noop(client, stores, monkeypatch):
+    """A session whose host isn't (or is no longer) in the registry must
+    not crash the kill endpoint — it degrades to a DB-only kill."""
+    session_store, transcript_store = stores
+    session = session_store.create(
+        task_id="remote-task-2", status=STATUS_RUNNING, routing="codex", host="vanished-host",
+    )
+    session_store.set_remote_pgid("remote-task-2", 111)
+
+    calls = []
+    monkeypatch.setattr(agents_route, "_remote_kill_runner", lambda argv: calls.append(argv))
+
+    resp = client.post(f"/api/agents/sessions/{session.session_id}/kill", json={"reason": "test"})
+    assert resp.status_code == 200
+    assert calls == []  # no ssh call — host isn't registered
+    refreshed = session_store.get("remote-task-2")
+    assert refreshed.status == "failed"
+
+
+def test_kill_remote_host_with_no_remote_pgid_falls_back_to_local_pid(client, stores, monkeypatch):
+    """Round 1, finding #3: if the executor's `PGID:` read never completed
+    (a hung ssh client stuck past TCP connect), no `remote_pgid` was ever
+    recorded — the operator kill must fall through to signalling the LOCAL
+    ssh client's own pid (from the `claude_code_pid` transcript event)
+    rather than silently no-op'ing via the remote path, which is the only
+    way a hung ssh client can ever be killed."""
+    from api.services.agent_worker import inter_agent
+
+    session_store, transcript_store = stores
+    session = session_store.create(
+        task_id="remote-task-3", status=STATUS_RUNNING, routing="claude_code", host="studio",
+    )
+    # No set_remote_pgid call — mirrors the hung-ssh-client scenario where
+    # the pgid line never arrived. The local ssh client's own pid/pgid was
+    # still recorded (ClaudeCodeExecutor._run appends this event
+    # unconditionally in the "remote": True branch, before/regardless of
+    # whether the pgid read itself succeeds).
+    transcript_store.append(session.session_id, "claude_code_pid", {
+        "pid": 7171, "pgid": 7171, "remote": True, "host": "studio",
+    })
+
+    ssh_calls = []
+    monkeypatch.setattr(agents_route, "_remote_kill_runner", lambda argv: ssh_calls.append(argv))
+
+    killpg_calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(inter_agent.os, "kill", lambda pid, sig: None)
+    monkeypatch.setattr(inter_agent.os, "killpg", lambda pgid, sig: killpg_calls.append((pgid, sig)))
+    monkeypatch.setattr(inter_agent, "_LOCAL_KILL_GRACE_S", 0.0)
+
+    resp = client.post(f"/api/agents/sessions/{session.session_id}/kill", json={"reason": "test"})
+    assert resp.status_code == 200
+    assert resp.json()["killed"] == [session.session_id]
+
+    assert ssh_calls == []  # never reached the remote ssh path — no remote_pgid to target
+    signalled_pgids = {pgid for pgid, _sig in killpg_calls}
+    assert signalled_pgids == {7171}  # the local ssh client's own pgid was signalled instead
+
+
+def test_kill_local_session_unaffected_by_remote_path(client, stores, monkeypatch):
+    """A session with no host still goes through the local killpg path,
+    never the ssh runner."""
+    session_store, transcript_store = stores
+    session = session_store.create(task_id="local-task", status=STATUS_RUNNING, routing="claude_code")
+
+    calls = []
+    monkeypatch.setattr(agents_route, "_remote_kill_runner", lambda argv: calls.append(argv))
+
+    resp = client.post(f"/api/agents/sessions/{session.session_id}/kill", json={"reason": "test"})
+    assert resp.status_code == 200
+    assert calls == []

--- a/tests/test_agent_resume_remote.py
+++ b/tests/test_agent_resume_remote.py
@@ -1,0 +1,207 @@
+"""Tests for #851's remote resume/focus: a session whose `cli_sessions.host`
+names a REGISTERED (settings.agent_hosts) machine other than this API host
+runs the configured launcher over ssh instead of a local wezterm spawn, and
+an unregistered host still 409s. No real ssh/wezterm is invoked — every
+test here mocks `subprocess.Popen` globally, the same pattern
+test_agent_resume_api.py uses.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def client():
+    return TestClient(api_main.app)
+
+
+@pytest.fixture
+def wezterm_store(tmp_path: Path, monkeypatch):
+    """Swap the default cc_wezterm store for a tmp-path-backed one so tests
+    can introspect what got persisted without touching the real DB — same
+    pattern as tests/test_agent_resume_api.py."""
+    from api.services import cc_wezterm_store as mod
+    store = mod.CCWezTermStore(db_path=tmp_path / "cc_wezterm.db")
+    monkeypatch.setattr(mod, "_default_store", store)
+    yield store
+    store.close()
+
+
+@pytest.fixture
+def remote_cc_session(tmp_path: Path, monkeypatch):
+    """Register a `cc:`-prefixed session on a remote host via the same
+    `cli_sessions` path `scripts/lifeos-agent-hook.sh` uses (#849), and
+    register that host's ssh target in the #851 registry."""
+    from config.settings import settings
+    from api.routes import agents as agents_route
+
+    monkeypatch.setattr(settings, "agent_hook_token", "test-hook-token")
+    monkeypatch.setattr(settings, "agent_hosts", {"laptop": "user@laptop.example"}, raising=False)
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "wezterm cli spawn --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "cc_resume_inner_cmd", "claude --resume {session_id}")
+    monkeypatch.setattr(settings, "codex_resume_enabled", True)
+    monkeypatch.setattr(settings, "codex_resume_cmd", "wezterm cli spawn --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "codex_resume_inner_cmd", "codex resume {session_id}")
+    monkeypatch.setattr("shutil.which", lambda name: None)
+
+    store = agents_route._get_session_store()
+    sid = "cc-uuid-on-laptop"
+    cli = store.record_cli_session_event(
+        engine="claude_code", event="session_start", session_id=sid,
+        host="laptop", cwd="/home/user/Code/project", branch="main",
+    )
+    return cli.session_id  # "cc:cc-uuid-on-laptop"
+
+
+def test_remote_resume_wraps_launcher_in_ssh(client, remote_cc_session, monkeypatch):
+    proc = MagicMock()
+    proc.communicate.return_value = (b"42\n", b"")
+    proc.returncode = 0
+    proc.pid = 9999
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(f"/api/agents/sessions/{remote_cc_session}/resume")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["spawned"] is True
+    assert body["cwd"] == "/home/user/Code/project"
+
+    argv = popen_mock.call_args.args[0]
+    assert argv[0] == "ssh"
+    assert "user@laptop.example" in argv
+    remote_command = argv[-1]
+    assert "wezterm cli spawn" in remote_command
+    assert "/home/user/Code/project" in remote_command
+    # The LOCAL ssh client must not cwd= into a path that only exists remotely.
+    assert popen_mock.call_args.kwargs["cwd"] is None
+
+    # Round 1, finding #7: an ssh round trip routinely exceeds the 1.5s
+    # local budget — the remote branch must pass the larger, connect-
+    # timeout-derived value to communicate(), not the local one.
+    from config.settings import settings
+    communicate_timeout = proc.communicate.call_args.kwargs["timeout"]
+    assert communicate_timeout == settings.agent_ssh_connect_timeout + 1.5
+    assert communicate_timeout != 1.5
+
+
+def test_remote_codex_resume_wraps_launcher_in_ssh(client, remote_cc_session, monkeypatch):
+    from api.routes import agents as agents_route
+
+    store = agents_route._get_session_store()
+    cli = store.record_cli_session_event(
+        engine="codex", event="session_start", session_id="cx-uuid-on-laptop",
+        host="laptop", cwd="/home/user/Code/other-project",
+    )
+
+    proc = MagicMock()
+    proc.communicate.return_value = (b"7\n", b"")
+    proc.returncode = 0
+    proc.pid = 8888
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(f"/api/agents/sessions/{cli.session_id}/resume")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["cwd"] == "/home/user/Code/other-project"
+
+    argv = popen_mock.call_args.args[0]
+    assert argv[0] == "ssh"
+    assert "user@laptop.example" in argv
+
+    # Round 1, finding #7 (codex sibling).
+    from config.settings import settings
+    communicate_timeout = proc.communicate.call_args.kwargs["timeout"]
+    assert communicate_timeout == settings.agent_ssh_connect_timeout + 1.5
+    assert communicate_timeout != 1.5
+
+
+def test_remote_resume_does_not_upsert_local_wezterm_store(
+    client, remote_cc_session, wezterm_store, monkeypatch,
+):
+    """Round 1, finding #10: a remote resume's pane and wezterm process
+    live on the REMOTE host — upserting the parsed pane id into the LOCAL
+    `cc_wezterm_store` (keyed by `wezterm_pid` from THIS host's own
+    `_current_wezterm_pid`) would record a host-mismatched mapping that a
+    later local `/focus` could act on against the wrong machine."""
+    proc = MagicMock()
+    proc.communicate.return_value = (b"42\n", b"")  # a parseable pane id
+    proc.returncode = 0
+    proc.pid = 9999
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(f"/api/agents/sessions/{remote_cc_session}/resume")
+    assert resp.status_code == 200
+    assert resp.json()["pane_id"] == 42  # pane id WAS parsed...
+
+    assert wezterm_store.get(remote_cc_session) is None  # ...but never upserted locally
+
+
+def test_remote_codex_resume_does_not_upsert_local_wezterm_store(
+    client, remote_cc_session, wezterm_store, monkeypatch,
+):
+    """Round 1, finding #10 (codex sibling)."""
+    from api.routes import agents as agents_route
+
+    store = agents_route._get_session_store()
+    cli = store.record_cli_session_event(
+        engine="codex", event="session_start", session_id="cx-uuid-on-laptop-2",
+        host="laptop", cwd="/home/user/Code/other-project",
+    )
+
+    proc = MagicMock()
+    proc.communicate.return_value = (b"7\n", b"")
+    proc.returncode = 0
+    proc.pid = 8888
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(f"/api/agents/sessions/{cli.session_id}/resume")
+    assert resp.status_code == 200
+    assert resp.json()["pane_id"] == 7
+
+    assert wezterm_store.get(cli.session_id) is None
+
+
+def test_unregistered_host_still_409s(client, remote_cc_session, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", {}, raising=False)  # "laptop" no longer registered
+
+    popen_mock = MagicMock()
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(f"/api/agents/sessions/{remote_cc_session}/resume")
+    assert resp.status_code == 409
+    popen_mock.assert_not_called()
+
+
+def test_remote_focus_falls_back_to_launcher_and_returns_focus_shape(client, remote_cc_session, monkeypatch):
+    """No cross-host pane registry exists, so /focus on a remote session
+    runs the same launcher as /resume and returns focus's response shape
+    (`focused`/`pane_id`/`cwd`), not resume's (`spawned`/`pid`/...)."""
+    proc = MagicMock()
+    proc.communicate.return_value = (b"13\n", b"")
+    proc.returncode = 0
+    proc.pid = 7777
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(f"/api/agents/sessions/{remote_cc_session}/focus")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"focused": True, "pane_id": 13, "cwd": "/home/user/Code/project"}
+
+    argv = popen_mock.call_args.args[0]
+    assert argv[0] == "ssh"

--- a/tests/test_agent_system_prompt.py
+++ b/tests/test_agent_system_prompt.py
@@ -279,3 +279,12 @@ def test_search_finances_prompt_advertises_investments(tm):
     text = "\n".join(_text_blocks(build_system_prompt()))
     assert "accounts/transactions/cashflow/budgets/investments" in text
     assert "'investments'" in text
+
+
+def test_prompt_describes_human_queue_tool(tm):
+    """#852: the orchestrator must know to file via manage_human_queue, use
+    'list' for "what's waiting on me", and never file work it can do itself."""
+    text = "\n".join(_text_blocks(build_system_prompt()))
+    assert "manage_human_queue" in text
+    assert "add/list/resolve" in text
+    assert "never file work" in text.lower()

--- a/tests/test_agent_tools_human_queue.py
+++ b/tests/test_agent_tools_human_queue.py
@@ -1,0 +1,70 @@
+"""
+Tests for the manage_human_queue native chat tool (#852) — the surface the
+/chat orchestrator uses when asked "what's waiting on me".
+"""
+import pytest
+
+from api.services.agent_tools import _tool_manage_human_queue, TOOL_DEFINITIONS
+from api.services.task_manager import TaskManager
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def tm(tmp_path, monkeypatch):
+    manager = TaskManager(vault_path=tmp_path / "vault", index_path=tmp_path / "task_index.json")
+    from api.services import human_queue
+    monkeypatch.setattr(human_queue, "get_task_manager", lambda: manager)
+    return manager
+
+
+class TestToolRegistration:
+    def test_registered_with_three_actions(self):
+        tool = next(t for t in TOOL_DEFINITIONS if t["name"] == "manage_human_queue")
+        assert set(tool["input_schema"]["properties"]["action"]["enum"]) == {"add", "list", "resolve"}
+
+
+class TestAdd:
+    def test_add_files_card(self, tm):
+        out = _tool_manage_human_queue({"action": "add", "title": "Re-auth example service"})
+        assert "Human-queue card filed" in out
+        cards = tm.list_tasks(tag="human", status="blocked")
+        assert len(cards) == 1
+        assert cards[0].description == "Re-auth example service"
+
+    def test_add_requires_title(self, tm):
+        out = _tool_manage_human_queue({"action": "add"})
+        assert out.startswith("Error:") and "title" in out
+
+    def test_add_invalid_done_when_returns_error(self, tm):
+        out = _tool_manage_human_queue({
+            "action": "add", "title": "X", "done_when": {"type": "shell"},
+        })
+        assert out.startswith("Error:")
+        assert tm.list_tasks(tag="human") == []
+
+
+class TestList:
+    def test_list_empty(self, tm):
+        assert _tool_manage_human_queue({"action": "list"}) == "No open Human-queue cards."
+
+    def test_list_shows_open_cards(self, tm):
+        _tool_manage_human_queue({"action": "add", "title": "Card one"})
+        out = _tool_manage_human_queue({"action": "list"})
+        assert "Card one" in out
+
+
+class TestResolve:
+    def test_resolve_requires_id_or_key(self, tm):
+        out = _tool_manage_human_queue({"action": "resolve"})
+        assert out.startswith("Error:") and "id_or_key" in out
+
+    def test_resolve_marks_card_done(self, tm):
+        _tool_manage_human_queue({"action": "add", "title": "X", "key": "k"})
+        out = _tool_manage_human_queue({"action": "resolve", "id_or_key": "k", "note": "fixed"})
+        assert "Human-queue card resolved" in out
+        assert tm.list_tasks(tag="human", status="blocked") == []
+
+    def test_resolve_unknown_returns_error(self, tm):
+        out = _tool_manage_human_queue({"action": "resolve", "id_or_key": "nope"})
+        assert out.startswith("Error:")

--- a/tests/test_agent_tools_tasks.py
+++ b/tests/test_agent_tools_tasks.py
@@ -87,11 +87,60 @@ class TestManageTasksCreate:
         assert len(tasks) == 1
         assert tasks[0].context == "Inbox"
 
+    def test_create_forwards_status_notes_fields(self, tm):
+        """#853: status/notes/fields are threaded through the chat tool too."""
+        _tool_manage_tasks({
+            "action": "create",
+            "description": "Waiting on legal",
+            "status": "blocked",
+            "notes": "chased on Monday",
+            "fields": {"host": "laptop"},
+        })
+        tasks = tm.list_tasks()
+        assert len(tasks) == 1
+        assert tasks[0].status == "blocked"
+        assert tasks[0].notes == "chased on Monday"
+        assert tasks[0].fields == {"host": "laptop"}
+
+
+class TestManageTasksUpdateNotesAndFields:
+    def test_update_notes(self, tm):
+        task = tm.create("Plan launch")
+        _tool_manage_tasks({"action": "update", "task_id": task.id, "notes": "draft outline"})
+        assert tm.get(task.id).notes == "draft outline"
+
+    def test_update_fields_merges_and_removes(self, tm):
+        task = tm.create("Plan launch", fields={"host": "laptop"})
+        _tool_manage_tasks({
+            "action": "update", "task_id": task.id,
+            "fields": {"host": None, "effort": "high"},
+        })
+        assert tm.get(task.id).fields == {"effort": "high"}
+
 
 class TestUnknownAction:
     def test_unknown_action(self, tm):
         out = _tool_manage_tasks({"action": "nope"})
         assert out.startswith("Error:")
+
+
+class TestManageTasksCreateBadStatus:
+    """#853 round 1 finding #11: `TaskManager.create` now raises `ValueError`
+    for an unrecognized `status`. Through the chat tool boundary
+    (`execute_tool`, which wraps every handler in try/except and formats an
+    exception as an "Error: ..." string) that must come back as an error
+    string, not an unhandled exception, and nothing should be written."""
+
+    async def test_bad_status_returns_error_string_nothing_written(self, tm):
+        from api.services.agent_tools import execute_tool
+
+        out = await execute_tool("manage_tasks", {
+            "action": "create",
+            "description": "Bad status task",
+            "status": "Done",
+        })
+        assert out.startswith("Error:")
+        assert tm.list_tasks() == []
 
 
 class TestManageTasksFilterDocs:

--- a/tests/test_agent_worker_assignment.py
+++ b/tests/test_agent_worker_assignment.py
@@ -1,0 +1,76 @@
+"""Tests for `api/services/agent_worker/assignment.py` (#851): the
+task-fields extractor and the per-engine effort mapping."""
+from __future__ import annotations
+
+import pytest
+
+from api.services.agent_worker.assignment import (
+    ENGINE_CLAUDE_CODE,
+    ENGINE_CODEX,
+    ENGINE_HERMES,
+    ENGINE_LOCAL,
+    extract_assignment,
+    local_thinking_for_effort,
+    map_effort_for_engine,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_extract_assignment_pulls_all_four_fields():
+    a = extract_assignment({
+        "model": "opus", "effort": "high", "host": "studio", "assigned_by": "board",
+    })
+    assert a.model == "opus"
+    assert a.effort == "high"
+    assert a.host == "studio"
+    assert a.assigned_by == "board"
+    assert a.is_board_assigned is True
+
+
+def test_extract_assignment_defaults_on_missing_fields():
+    a = extract_assignment(None)
+    assert a.model is None and a.effort is None and a.host is None
+    assert a.assigned_by is None
+    assert a.is_board_assigned is False
+
+
+def test_extract_assignment_ignores_unrecognized_effort():
+    a = extract_assignment({"effort": "extreme"})
+    assert a.effort is None
+
+
+def test_extract_assignment_strips_whitespace_to_none():
+    a = extract_assignment({"model": "  ", "host": ""})
+    assert a.model is None
+    assert a.host is None
+
+
+@pytest.mark.parametrize("effort,expected", [
+    ("low", "low"), ("medium", "medium"), ("high", "high"), ("max", "max"),
+    (None, None), ("bogus", None),
+])
+def test_claude_code_effort_map(effort, expected):
+    assert map_effort_for_engine(ENGINE_CLAUDE_CODE, effort) == expected
+
+
+@pytest.mark.parametrize("effort,expected", [
+    ("low", "low"), ("medium", "medium"), ("high", "high"), ("max", "xhigh"),
+    (None, None),
+])
+def test_codex_effort_map(effort, expected):
+    assert map_effort_for_engine(ENGINE_CODEX, effort) == expected
+
+
+def test_engines_without_effort_flags_return_none():
+    assert map_effort_for_engine(ENGINE_LOCAL, "high") is None
+    assert map_effort_for_engine(ENGINE_HERMES, "high") is None
+
+
+@pytest.mark.parametrize("effort,expected", [
+    ("high", True), ("max", True), ("low", False), ("medium", False),
+    (None, None), ("", None), ("bogus", None),
+])
+def test_local_thinking_for_effort(effort, expected):
+    assert local_thinking_for_effort(effort) is expected

--- a/tests/test_agent_worker_claude_code_assignment.py
+++ b/tests/test_agent_worker_claude_code_assignment.py
@@ -1,0 +1,439 @@
+"""Tests for card-assignment threading (#851) into ClaudeCodeExecutor:
+model/effort flags, host resolution, remote ssh wrapping + pgid capture,
+and the unknown-host failure path (no ssh call).
+"""
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+from api.services.agent_worker.claude_code_executor import ClaudeCodeExecutor
+from api.services.agent_worker.session_store import STATUS_FAILED, SessionStore
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeStdout:
+    """Iterable + `readline()`-capable stand-in for a Popen stdout pipe."""
+
+    def __init__(self, lines: list[str]):
+        self._lines = list(lines)
+        self._idx = 0
+
+    def readline(self) -> str:
+        if self._idx >= len(self._lines):
+            return ""
+        line = self._lines[self._idx]
+        self._idx += 1
+        return line
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        line = self.readline()
+        if line == "":
+            raise StopIteration
+        return line
+
+
+class _FakeStderr:
+    def read(self) -> str:
+        return ""
+
+
+class _FakeProc:
+    def __init__(self, lines: list[str], pid: int = 4242, returncode: int = 0):
+        self.stdout = _FakeStdout(lines)
+        self.stderr = _FakeStderr()
+        self.pid = pid
+        self.returncode = returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self.returncode
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        pass
+
+    def kill(self):
+        pass
+
+
+def _lines_for(events: Iterable[dict], pgid_line: str | None = None) -> list[str]:
+    lines = [json.dumps(e) + "\n" for e in events]
+    return ([pgid_line] if pgid_line else []) + lines
+
+
+_INIT_EVENT = {"type": "system", "subtype": "init", "session_id": "cli-sess-1"}
+_RESULT_EVENT = {
+    "type": "result", "session_id": "cli-sess-1", "total_cost_usd": 0.01, "result": "done",
+}
+
+
+def _build(tmp_path: Path, monkeypatch, *, spawn_calls: list, lines: list[str],
+           agent_hosts: dict | None = None):
+    db_path = tmp_path / "sessions.db"
+    store = SessionStore(db_path=db_path)
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", agent_hosts or {}, raising=False)
+
+    def _spawn_fn(cmd, **kwargs):
+        spawn_calls.append((cmd, kwargs))
+        return _FakeProc(lines)
+
+    executor = ClaudeCodeExecutor(
+        session_store=store, transcript_store=transcripts, spawn_fn=_spawn_fn,
+    )
+    return store, executor
+
+
+def test_model_and_effort_flags_in_argv(tmp_path, monkeypatch):
+    """AC1: a claude-tagged task with model/effort fields spawns with
+    `--model opus --effort high`."""
+    spawn_calls: list = []
+    lines = _lines_for([_INIT_EVENT, _RESULT_EVENT])
+    store, executor = _build(tmp_path, monkeypatch, spawn_calls=spawn_calls, lines=lines)
+    session = store.create(task_id="t1", routing="claude_code", claude_code_model="opus", effort="high")
+    outcome = executor.execute(session, {"description": "do the thing"})
+    assert outcome.status != STATUS_FAILED
+    cmd = spawn_calls[0][0]
+    assert "--model" in cmd and cmd[cmd.index("--model") + 1] == "opus"
+    assert "--effort" in cmd and cmd[cmd.index("--effort") + 1] == "high"
+
+
+def test_board_assigned_model_reaches_argv_via_set_assignment(tmp_path, monkeypatch):
+    """Round 1, finding #1: the board-assignment `model` field — written by
+    the real dispatch path (`SessionStore.create` then
+    `SessionStore.set_assignment`, exactly like `worker._dispatch` does),
+    NOT `claude_code_model` (the unrelated child-spawn escalation tier) —
+    must reach `--model`. Uses a non-"opus" value so the executor's
+    hardcoded `"opus"` fallback can't mask a regression back to reading
+    only `claude_code_model`."""
+    spawn_calls: list = []
+    lines = _lines_for([_INIT_EVENT, _RESULT_EVENT])
+    store, executor = _build(tmp_path, monkeypatch, spawn_calls=spawn_calls, lines=lines)
+    store.create(task_id="t1", routing="claude_code")
+    store.set_assignment("t1", model="sonnet", effort="high")
+    session = store.get("t1")
+    assert session.model == "sonnet"  # sanity: the write path actually landed
+    outcome = executor.execute(session, {"description": "do the thing"})
+    assert outcome.status != STATUS_FAILED
+    cmd = spawn_calls[0][0]
+    assert "--model" in cmd and cmd[cmd.index("--model") + 1] == "sonnet"
+    assert "--effort" in cmd and cmd[cmd.index("--effort") + 1] == "high"
+
+
+def test_no_effort_field_omits_flag(tmp_path, monkeypatch):
+    spawn_calls: list = []
+    lines = _lines_for([_INIT_EVENT, _RESULT_EVENT])
+    store, executor = _build(tmp_path, monkeypatch, spawn_calls=spawn_calls, lines=lines)
+    session = store.create(task_id="t1", routing="claude_code")
+    executor.execute(session, {"description": "do the thing"})
+    cmd = spawn_calls[0][0]
+    assert "--effort" not in cmd
+
+
+def test_remote_host_wraps_argv_in_ssh_and_captures_pgid(tmp_path, monkeypatch):
+    """AC5: a task with host: <name> mapped in the registry invokes ssh to
+    that target with the same argv, and the session records host + the
+    remote pgid captured from the wrapper's first stdout line."""
+    spawn_calls: list = []
+    lines = _lines_for([_INIT_EVENT, _RESULT_EVENT], pgid_line="PGID:98765\n")
+    store, executor = _build(
+        tmp_path, monkeypatch, spawn_calls=spawn_calls, lines=lines,
+        agent_hosts={"studio": "user@studio.example"},
+    )
+    session = store.create(task_id="t1", routing="claude_code", host="studio", claude_code_model="opus")
+    outcome = executor.execute(session, {"description": "do the thing"})
+    assert outcome.status != STATUS_FAILED
+    # Round 1, finding #9: prove the pgid-line strip leaves the JSON stream
+    # aligned — the `_RESULT_EVENT`'s own text must still reach `final_text`
+    # unscathed, not just status/argv/pgid.
+    assert outcome.final_text == "done"
+    cmd = spawn_calls[0][0]
+    assert cmd[0] == "ssh"
+    assert "user@studio.example" in cmd
+    assert any("--model opus" in part or ("--model" in part and "opus" in part) for part in cmd)
+    remote_command = cmd[-1]
+    assert "env -u" in remote_command
+    assert "setsid bash -c" in remote_command
+    assert "PGID:$$" in remote_command
+
+    refreshed = store.get("t1")
+    assert refreshed.remote_pgid == 98765
+
+
+def test_unknown_host_fails_without_ssh_call(tmp_path, monkeypatch):
+    """AC6: an unregistered host fails the task with a reason naming the
+    host, and spawn_fn (ssh) is never invoked."""
+    spawn_calls: list = []
+    store, executor = _build(
+        tmp_path, monkeypatch, spawn_calls=spawn_calls, lines=[],
+        agent_hosts={"studio": "user@studio.example"},
+    )
+    session = store.create(task_id="t1", routing="claude_code", host="nonexistent-box")
+    outcome = executor.execute(session, {"description": "do the thing"})
+    assert outcome.status == STATUS_FAILED
+    assert "nonexistent-box" in outcome.reason
+    assert spawn_calls == []
+
+
+class _HangingStdout:
+    """`readline()` never returns — simulates an ssh client stuck past TCP
+    connect (auth stall, or a host that accepts the connection and then
+    never answers). `ConnectTimeout` doesn't bound this."""
+
+    def readline(self) -> str:
+        import threading
+        threading.Event().wait()  # blocks forever; the test's deadline is what ends it
+        return ""  # pragma: no cover — unreachable
+
+
+class _HangingProc:
+    def __init__(self, pid: int = 9999):
+        self.stdout = _HangingStdout()
+        self.stderr = _FakeStderr()
+        self.pid = pid
+        self.returncode = None
+        self._terminated = False
+
+    def poll(self):
+        return None if not self._terminated else -15
+
+    def terminate(self):
+        self._terminated = True
+
+    def wait(self, timeout: float | None = None) -> int:
+        return -15
+
+    def kill(self):
+        self._terminated = True
+
+
+def test_remote_host_unresponsive_pgid_read_fails_within_deadline(tmp_path, monkeypatch):
+    """Round 1, finding #3: a remote ssh client whose `PGID:` line never
+    arrives (hung post-TCP-connect) must not block forever — the executor
+    fails within the configured connect-timeout-derived deadline instead."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_ssh_connect_timeout", 0, raising=False)
+
+    spawn_calls: list = []
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    monkeypatch.setattr(settings, "agent_hosts", {"studio": "user@studio.example"}, raising=False)
+
+    def _spawn_fn(cmd, **kwargs):
+        spawn_calls.append((cmd, kwargs))
+        return _HangingProc()
+
+    executor = ClaudeCodeExecutor(
+        session_store=store, transcript_store=transcripts, spawn_fn=_spawn_fn,
+    )
+    session = store.create(task_id="t1", routing="claude_code", host="studio")
+
+    import time
+    start = time.monotonic()
+    outcome = executor.execute(session, {"description": "do the thing"})
+    elapsed = time.monotonic() - start
+
+    assert outcome.status == STATUS_FAILED
+    assert "studio" in outcome.reason
+    assert elapsed < 30  # well under the test-harness timeout; proves it didn't hang
+
+
+class _UnblockableStdout:
+    """`readline()` blocks on a `threading.Event` until the test releases
+    it, then returns `line` on the next call (and `""` after that). Unlike
+    `_HangingStdout` (blocks forever), this lets a test observe executor
+    state DURING the blocked read and then let it complete."""
+
+    def __init__(self, line: str):
+        self._line = line
+        self._released = threading.Event()
+        self._returned = False
+
+    def unblock(self) -> None:
+        self._released.set()
+
+    def readline(self) -> str:
+        self._released.wait()
+        if self._returned:
+            return ""
+        self._returned = True
+        return self._line
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        line = self.readline()
+        if line == "":
+            raise StopIteration
+        return line
+
+
+class _UnblockableProc:
+    def __init__(self, stdout: "_UnblockableStdout", pid: int = 7777):
+        self.stdout = stdout
+        self.stderr = _FakeStderr()
+        self.pid = pid
+        self.returncode = 0
+        self._terminated = False
+
+    def poll(self):
+        return None if not self._terminated else self.returncode
+
+    def terminate(self):
+        self._terminated = True
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self.returncode
+
+    def kill(self):
+        self._terminated = True
+
+
+def test_remote_pid_event_recorded_before_pgid_line_arrives(tmp_path, monkeypatch):
+    """Round 2, finding #2: the `claude_code_pid` transcript event must be
+    recorded IMMEDIATELY after `Popen` — before the deadline-bounded pgid
+    read — not only once (if) the pgid line arrives. Otherwise the
+    operator-kill fallback (`inter_agent._kill_local_subprocess`) finds no
+    pid event and silently no-ops for a local ssh client stuck mid-read,
+    until the much longer wall-clock watchdog eventually fires.
+
+    Runs the REAL executor on a background thread against a stdout whose
+    `readline()` blocks until released, polls the transcript store while
+    still blocked to prove the pid event already exists, then unblocks the
+    fake so the pgid line is read and the run completes normally."""
+    import time
+
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_ssh_connect_timeout", 5, raising=False)
+    monkeypatch.setattr(settings, "agent_hosts", {"studio": "user@studio.example"}, raising=False)
+
+    stdout = _UnblockableStdout("PGID:24680\n")
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+
+    def _spawn_fn(cmd, **kwargs):
+        return _UnblockableProc(stdout, pid=7777)
+
+    executor = ClaudeCodeExecutor(
+        session_store=store, transcript_store=transcripts, spawn_fn=_spawn_fn,
+    )
+    session = store.create(task_id="t1", routing="claude_code", host="studio")
+
+    thread = threading.Thread(target=executor.execute, args=(session, {"description": "do the thing"}))
+    thread.start()
+    try:
+        # Poll for the pid event to appear WHILE the pgid read is still
+        # blocked (well inside the 5s+5s deadline) — this is the assertion
+        # that would fail before the fix, since the event used to be
+        # appended only after this read returned.
+        deadline = time.monotonic() + 3.0
+        pid_events: list[dict] = []
+        while time.monotonic() < deadline:
+            pid_events = [e for e in transcripts.read(session.session_id) if e.get("kind") == "claude_code_pid"]
+            if pid_events:
+                break
+            time.sleep(0.02)
+        assert pid_events, "claude_code_pid event was not recorded before the pgid line arrived"
+        payload = pid_events[0]["payload"]
+        assert payload["pid"] == 7777
+        assert payload["pgid"] is None
+        assert payload["remote"] is True
+
+        # Now let the blocked read complete and the executor finish.
+        stdout.unblock()
+    finally:
+        thread.join(timeout=10)
+    assert not thread.is_alive()
+
+    refreshed = store.get("t1")
+    assert refreshed.remote_pgid == 24680
+    all_pid_events = [e for e in transcripts.read(session.session_id) if e.get("kind") == "claude_code_pid"]
+    assert len(all_pid_events) == 2
+    assert all_pid_events[-1]["payload"]["pgid"] == 24680
+
+
+class _FakeStderrWithText:
+    def __init__(self, text: str):
+        self._text = text
+
+    def read(self) -> str:
+        return self._text
+
+
+class _FailingSshProc:
+    """A fast ssh connection failure — stdout is empty (ssh never even ran
+    the remote wrapper), stderr carries ssh's own error text, non-zero
+    returncode."""
+
+    def __init__(self, stderr_text: str, returncode: int = 255, pid: int = 6060):
+        self.stdout = _FakeStdout([])
+        self.stderr = _FakeStderrWithText(stderr_text)
+        self.pid = pid
+        self.returncode = returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self.returncode
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        pass
+
+    def kill(self):
+        pass
+
+
+def test_remote_ssh_failure_reason_includes_stderr(tmp_path, monkeypatch):
+    """Round 1, finding #4: an unreachable-host ssh failure's stderr must
+    land in `outcome.reason` (what `worker.py` uses verbatim for the
+    #agent-failed card), not just the transcript's `stderr_tail`."""
+    spawn_calls: list = []
+    ssh_stderr = "ssh: connect to host studio port 22: Connection refused\n"
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", {"studio": "user@studio.example"}, raising=False)
+
+    def _spawn_fn(cmd, **kwargs):
+        spawn_calls.append((cmd, kwargs))
+        return _FailingSshProc(ssh_stderr)
+
+    executor = ClaudeCodeExecutor(
+        session_store=store, transcript_store=transcripts, spawn_fn=_spawn_fn,
+    )
+    session = store.create(task_id="t1", routing="claude_code", host="studio")
+    outcome = executor.execute(session, {"description": "do the thing"})
+    assert outcome.status == STATUS_FAILED
+    assert "studio" in outcome.reason
+    assert "Connection refused" in outcome.reason
+
+
+def test_local_host_name_matches_api_host_runs_locally(tmp_path, monkeypatch):
+    """A host equal to this API's own hostname behaves like no host at
+    all — local spawn, no ssh wrapping."""
+    import socket
+    spawn_calls: list = []
+    lines = _lines_for([_INIT_EVENT, _RESULT_EVENT])
+    store, executor = _build(tmp_path, monkeypatch, spawn_calls=spawn_calls, lines=lines)
+    local_name = socket.gethostname().split(".")[0]
+    session = store.create(task_id="t1", routing="claude_code", host=local_name)
+    outcome = executor.execute(session, {"description": "do the thing"})
+    assert outcome.status != STATUS_FAILED
+    cmd = spawn_calls[0][0]
+    assert cmd[0] != "ssh"

--- a/tests/test_agent_worker_codex_assignment.py
+++ b/tests/test_agent_worker_codex_assignment.py
@@ -1,0 +1,309 @@
+"""Tests for card-assignment threading (#851) into CodexExecutor:
+model/effort flags, host resolution, remote ssh wrapping + pgid capture,
+and the unknown-host failure path (no ssh call).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+from api.services.agent_worker.codex_executor import CodexExecutor
+from api.services.agent_worker.session_store import STATUS_FAILED, SessionStore
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeStdout:
+    def __init__(self, lines: list[str]):
+        self._lines = list(lines)
+        self._idx = 0
+
+    def readline(self) -> str:
+        if self._idx >= len(self._lines):
+            return ""
+        line = self._lines[self._idx]
+        self._idx += 1
+        return line
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        line = self.readline()
+        if line == "":
+            raise StopIteration
+        return line
+
+
+class _FakeStderr:
+    def read(self) -> str:
+        return ""
+
+
+class _FakeProc:
+    def __init__(self, lines: list[str], pid: int = 5151, returncode: int = 0):
+        self.stdout = _FakeStdout(lines)
+        self.stderr = _FakeStderr()
+        self.pid = pid
+        self.returncode = returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self.returncode
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        pass
+
+    def kill(self):
+        pass
+
+
+def _lines_for(events: Iterable[dict], pgid_line: str | None = None) -> list[str]:
+    lines = [json.dumps(e) + "\n" for e in events]
+    return ([pgid_line] if pgid_line else []) + lines
+
+
+_THREAD_EVENT = {"type": "thread.started", "thread_id": "cx-thread-1"}
+_TURN_COMPLETED = {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}}
+_SESSION_COMPLETED = {"type": "session.completed"}
+_AGENT_MESSAGE_COMPLETED = {
+    "type": "item.completed",
+    "item": {"type": "agent_message", "text": "done remotely"},
+}
+
+
+def _build(tmp_path: Path, monkeypatch, *, spawn_calls: list, lines: list[str],
+           agent_hosts: dict | None = None):
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", agent_hosts or {}, raising=False)
+
+    def _spawn_fn(cmd, **kwargs):
+        spawn_calls.append((cmd, kwargs))
+        return _FakeProc(lines)
+
+    executor = CodexExecutor(
+        session_store=store, transcript_store=transcripts, spawn_fn=_spawn_fn,
+    )
+    return store, executor
+
+
+def test_model_and_effort_flags_in_argv(tmp_path, monkeypatch):
+    """AC2: a codex-tagged task with model/effort fields spawns with
+    `--model gpt-5.5` and `-c model_reasoning_effort=high`."""
+    spawn_calls: list = []
+    lines = _lines_for([_THREAD_EVENT, _TURN_COMPLETED, _SESSION_COMPLETED])
+    store, executor = _build(tmp_path, monkeypatch, spawn_calls=spawn_calls, lines=lines)
+    session = store.create(task_id="t1", routing="codex", model="gpt-5.5", effort="high")
+    outcome = executor.execute(session, {"description": "do the thing"})
+    assert outcome.status != STATUS_FAILED
+    cmd = spawn_calls[0][0]
+    assert "--model" in cmd and cmd[cmd.index("--model") + 1] == "gpt-5.5"
+    assert "-c" in cmd
+    assert "model_reasoning_effort=high" in cmd
+
+
+def test_board_assigned_model_reaches_argv_via_set_assignment(tmp_path, monkeypatch):
+    """Round 1, finding #1 (Codex mirror): drives the real dispatch write
+    path — `SessionStore.create` then `SessionStore.set_assignment`, like
+    `worker._dispatch` does — rather than passing `model=` straight to
+    `create()`, so a regression in how `CodexExecutor` reads `session.model`
+    would be caught the same way the Claude Code test catches it."""
+    spawn_calls: list = []
+    lines = _lines_for([_THREAD_EVENT, _TURN_COMPLETED, _SESSION_COMPLETED])
+    store, executor = _build(tmp_path, monkeypatch, spawn_calls=spawn_calls, lines=lines)
+    store.create(task_id="t1", routing="codex")
+    store.set_assignment("t1", model="gpt-5.5", effort="high")
+    session = store.get("t1")
+    assert session.model == "gpt-5.5"  # sanity: the write path actually landed
+    outcome = executor.execute(session, {"description": "do the thing"})
+    assert outcome.status != STATUS_FAILED
+    cmd = spawn_calls[0][0]
+    assert "--model" in cmd and cmd[cmd.index("--model") + 1] == "gpt-5.5"
+    assert "model_reasoning_effort=high" in cmd
+
+
+def test_no_model_field_omits_flag(tmp_path, monkeypatch):
+    spawn_calls: list = []
+    lines = _lines_for([_THREAD_EVENT, _TURN_COMPLETED, _SESSION_COMPLETED])
+    store, executor = _build(tmp_path, monkeypatch, spawn_calls=spawn_calls, lines=lines)
+    session = store.create(task_id="t1", routing="codex")
+    executor.execute(session, {"description": "do the thing"})
+    cmd = spawn_calls[0][0]
+    assert "--model" not in cmd
+    assert not any("model_reasoning_effort" in part for part in cmd)
+
+
+def test_max_effort_maps_to_xhigh(tmp_path, monkeypatch):
+    spawn_calls: list = []
+    lines = _lines_for([_THREAD_EVENT, _TURN_COMPLETED, _SESSION_COMPLETED])
+    store, executor = _build(tmp_path, monkeypatch, spawn_calls=spawn_calls, lines=lines)
+    session = store.create(task_id="t1", routing="codex", effort="max")
+    executor.execute(session, {"description": "do the thing"})
+    cmd = spawn_calls[0][0]
+    assert "model_reasoning_effort=xhigh" in cmd
+
+
+def test_remote_host_wraps_argv_in_ssh_and_captures_pgid(tmp_path, monkeypatch):
+    """AC5 for codex: host field maps to a registered ssh target."""
+    spawn_calls: list = []
+    lines = _lines_for(
+        [_THREAD_EVENT, _AGENT_MESSAGE_COMPLETED, _TURN_COMPLETED, _SESSION_COMPLETED],
+        pgid_line="PGID:1212\n",
+    )
+    store, executor = _build(
+        tmp_path, monkeypatch, spawn_calls=spawn_calls, lines=lines,
+        agent_hosts={"studio": "user@studio.example"},
+    )
+    session = store.create(task_id="t1", routing="codex", host="studio", model="gpt-5.5")
+    outcome = executor.execute(session, {"description": "do the thing"})
+    assert outcome.status != STATUS_FAILED
+    # Round 1, finding #9: prove the pgid-line strip leaves the JSON stream
+    # aligned for codex too — a real completion event's text must still
+    # reach `final_text`.
+    assert outcome.final_text == "done remotely"
+    cmd = spawn_calls[0][0]
+    assert cmd[0] == "ssh"
+    assert "user@studio.example" in cmd
+    remote_command = cmd[-1]
+    assert "env -u" in remote_command
+    assert "setsid bash -c" in remote_command
+
+    refreshed = store.get("t1")
+    assert refreshed.remote_pgid == 1212
+
+
+def test_unknown_host_fails_without_ssh_call(tmp_path, monkeypatch):
+    spawn_calls: list = []
+    store, executor = _build(
+        tmp_path, monkeypatch, spawn_calls=spawn_calls, lines=[],
+        agent_hosts={"studio": "user@studio.example"},
+    )
+    session = store.create(task_id="t1", routing="codex", host="nonexistent-box")
+    outcome = executor.execute(session, {"description": "do the thing"})
+    assert outcome.status == STATUS_FAILED
+    assert "nonexistent-box" in outcome.reason
+    assert spawn_calls == []
+
+
+class _FakeStderrWithText:
+    def __init__(self, text: str):
+        self._text = text
+
+    def read(self) -> str:
+        return self._text
+
+
+class _FailingSshProc:
+    def __init__(self, stderr_text: str, returncode: int = 255, pid: int = 6161):
+        self.stdout = _FakeStdout([])
+        self.stderr = _FakeStderrWithText(stderr_text)
+        self.pid = pid
+        self.returncode = returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self.returncode
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        pass
+
+    def kill(self):
+        pass
+
+
+def test_remote_ssh_failure_reason_includes_stderr(tmp_path, monkeypatch):
+    """Round 1, finding #4 (Codex mirror): an unreachable-host ssh
+    failure's stderr must land in `outcome.reason`."""
+    spawn_calls: list = []
+    ssh_stderr = "ssh: connect to host studio port 22: Connection refused\n"
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", {"studio": "user@studio.example"}, raising=False)
+
+    def _spawn_fn(cmd, **kwargs):
+        spawn_calls.append((cmd, kwargs))
+        return _FailingSshProc(ssh_stderr)
+
+    executor = CodexExecutor(
+        session_store=store, transcript_store=transcripts, spawn_fn=_spawn_fn,
+    )
+    session = store.create(task_id="t1", routing="codex", host="studio")
+    outcome = executor.execute(session, {"description": "do the thing"})
+    assert outcome.status == STATUS_FAILED
+    assert "studio" in outcome.reason
+    assert "Connection refused" in outcome.reason
+
+
+class _HangingStdout:
+    """`readline()` never returns — simulates an ssh client stuck past TCP
+    connect. `ConnectTimeout` doesn't bound this. Codex mirror of the
+    ClaudeCodeExecutor test double."""
+
+    def readline(self) -> str:
+        import threading
+        threading.Event().wait()
+        return ""  # pragma: no cover — unreachable
+
+
+class _HangingProc:
+    def __init__(self, pid: int = 8888):
+        self.stdout = _HangingStdout()
+        self.stderr = _FakeStderr()
+        self.pid = pid
+        self.returncode = None
+        self._terminated = False
+
+    def poll(self):
+        return None if not self._terminated else -15
+
+    def terminate(self):
+        self._terminated = True
+
+    def wait(self, timeout: float | None = None) -> int:
+        return -15
+
+    def kill(self):
+        self._terminated = True
+
+
+def test_remote_host_unresponsive_pgid_read_fails_within_deadline(tmp_path, monkeypatch):
+    """Round 1, finding #3 (Codex mirror): a hung ssh client whose `PGID:`
+    line never arrives must not block the executor forever."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_ssh_connect_timeout", 0, raising=False)
+
+    spawn_calls: list = []
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    monkeypatch.setattr(settings, "agent_hosts", {"studio": "user@studio.example"}, raising=False)
+
+    def _spawn_fn(cmd, **kwargs):
+        spawn_calls.append((cmd, kwargs))
+        return _HangingProc()
+
+    executor = CodexExecutor(
+        session_store=store, transcript_store=transcripts, spawn_fn=_spawn_fn,
+    )
+    session = store.create(task_id="t1", routing="codex", host="studio")
+
+    import time
+    start = time.monotonic()
+    outcome = executor.execute(session, {"description": "do the thing"})
+    elapsed = time.monotonic() - start
+
+    assert outcome.status == STATUS_FAILED
+    assert "studio" in outcome.reason
+    assert elapsed < 30

--- a/tests/test_agent_worker_dispatch_assignment.py
+++ b/tests/test_agent_worker_dispatch_assignment.py
@@ -1,0 +1,151 @@
+"""Worker `_dispatch()` wiring for card assignment (#851): a task's
+`fields` (model/effort/host) are extracted and recorded on the session row
+before the executor is invoked, and the new `#hermes` tag routes through
+`HermesExecutor`.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import httpx
+import pytest
+
+from api.services.agent_worker.local_executor import ExecutorOutcome
+from api.services.agent_worker.session_store import STATUS_COMPLETED, SessionStore
+from api.services.agent_worker.spend_tracker import SpendTracker
+from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services.agent_worker.worker import Worker, _SynchronousPool
+from api.services.conversation_store import ConversationStore
+
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class _StubExecutor:
+    outcome: ExecutorOutcome
+    calls: list = field(default_factory=list)
+
+    def execute(self, session, task):
+        self.calls.append((session.task_id, session.host, session.model, session.effort))
+        return self.outcome
+
+
+def _golden_preflight_reply(routing: str = "local", routing_reason: str = "guess") -> str:
+    return json.dumps({
+        "budget": {"wall_seconds": 3600, "max_tokens": 100000, "max_dollars": 1.0},
+        "routing": routing,
+        "routing_reason": routing_reason,
+        "routing_explicit": False,
+        "expected_output": "text",
+        "ambiguity": None,
+        "sane": True,
+        "sane_reason": "",
+    })
+
+
+def _make_worker(tmp_path: Path, *, claude_code_executor=None, hermes_executor=None):
+    transport = httpx.MockTransport(lambda _req: httpx.Response(200, json={"tasks": []}))
+    client = httpx.Client(transport=transport, base_url="http://api")
+    return Worker(
+        api_base="http://api",
+        session_store=SessionStore(db_path=tmp_path / "sessions.db"),
+        conversation_store=ConversationStore(db_path=str(tmp_path / "conversations.db")),
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        telegram_send=lambda text, chat_id=None: True,
+        telegram_send_with_id=lambda text: [1],
+        http_client=client,
+        preflight_caller=lambda prompt: _golden_preflight_reply(),
+        claude_code_executor=claude_code_executor,
+        hermes_executor=hermes_executor,
+        cli_pool=_SynchronousPool(),
+    )
+
+
+def test_dispatch_records_assignment_fields_on_session_before_cli_executor_runs(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", {}, raising=False)
+
+    stub = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="done"))
+    worker = _make_worker(tmp_path, claude_code_executor=stub)
+    worker.session_store.create(task_id="board-1", status="claimed")
+
+    task = {
+        "id": "board-1",
+        "description": "fix the printer",
+        "tags": ["agent", "claude"],
+        "fields": {"model": "opus", "effort": "high", "assigned_by": "board"},
+    }
+    worker._dispatch(task)
+
+    session = worker.session_store.get("board-1")
+    assert session.host is None
+    assert session.model == "opus"
+    assert session.effort == "high"
+    assert stub.calls == [("board-1", None, "opus", "high")]
+
+
+def test_dispatch_records_host_field_on_session(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", {"studio": "user@studio.example"}, raising=False)
+
+    stub = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="done"))
+    worker = _make_worker(tmp_path, claude_code_executor=stub)
+    worker.session_store.create(task_id="board-2", status="claimed")
+
+    task = {
+        "id": "board-2",
+        "description": "deploy the thing",
+        "tags": ["agent", "claude"],
+        "fields": {"host": "studio"},
+    }
+    worker._dispatch(task)
+
+    session = worker.session_store.get("board-2")
+    assert session.host == "studio"
+    assert stub.calls[-1] == ("board-2", "studio", None, None)
+
+
+def test_dispatch_untagged_task_has_no_assignment(tmp_path, monkeypatch):
+    """A task with no fields at all records NULL host/model/effort — the
+    #851 write is a no-op for every pre-existing task shape."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", {}, raising=False)
+
+    stub = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="done"))
+    worker = _make_worker(tmp_path, claude_code_executor=stub)
+    worker.session_store.create(task_id="plain-1", status="claimed")
+
+    task = {"id": "plain-1", "description": "reindex the vault", "tags": ["agent", "claude"]}
+    worker._dispatch(task)
+
+    session = worker.session_store.get("plain-1")
+    assert session.host is None
+    assert session.model is None
+    assert session.effort is None
+
+
+def test_hermes_tag_dispatches_through_hermes_executor(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", {}, raising=False)
+
+    stub = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="hi there"))
+    worker = _make_worker(tmp_path, hermes_executor=stub)
+    worker.session_store.create(task_id="hermes-1", status="claimed")
+
+    task = {
+        "id": "hermes-1",
+        "description": "ask hermes what's on my calendar",
+        "tags": ["agent", "hermes"],
+        "fields": {},
+    }
+    worker._dispatch(task)
+
+    session = worker.session_store.get("hermes-1")
+    assert session.routing == "hermes"
+    assert len(stub.calls) == 1
+    assert stub.calls[0][0] == "hermes-1"

--- a/tests/test_agent_worker_hermes_executor.py
+++ b/tests/test_agent_worker_hermes_executor.py
@@ -1,0 +1,170 @@
+"""Tests for HermesExecutor (#851, AC4): a board-assigned #hermes task opens
+a Hermes conversation via the configured backend, the turn's final text
+lands on the outcome (worker.py hands it to the Agent Output note the same
+way every other executor's final_text does), the session records
+routing='hermes' + the conversation id, and the card's open_url can point
+at `/chat?conversation=<id>`. Stubs the backend entirely — no network call.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from api.routes import hermes_proxy as hp
+from api.services.agent_worker.hermes_executor import HermesExecutor
+from api.services.agent_worker.session_store import STATUS_COMPLETED, STATUS_FAILED, SessionStore
+from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services.conversation_store import ConversationStore
+from api.services.usage_store import UsageStore
+
+
+pytestmark = pytest.mark.unit
+
+
+def _sse(events: list[dict]) -> bytes:
+    return b"".join(b"data: " + json.dumps(e).encode() + b"\n\n" for e in events)
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes, status_code: int = 200):
+        self._body = body
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "error", request=httpx.Request("POST", "http://backend/api/ask/stream"),
+                response=httpx.Response(self.status_code),
+            )
+
+    def iter_bytes(self):
+        yield self._body
+
+
+class _FakeStreamCM:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+
+    def __enter__(self):
+        return self._response
+
+    def __exit__(self, *args):
+        return False
+
+
+class _FakeClient:
+    def __init__(self, body: bytes, status_code: int = 200, captured: dict | None = None):
+        self._body = body
+        self._status_code = status_code
+        self.captured = captured if captured is not None else {}
+
+    def stream(self, method, url, content=None, headers=None):
+        self.captured["method"] = method
+        self.captured["url"] = url
+        self.captured["content"] = content
+        self.captured["headers"] = headers
+        return _FakeStreamCM(_FakeResponse(self._body, self._status_code))
+
+    def close(self):
+        pass
+
+
+def _build(tmp_path, monkeypatch, *, body: bytes, status_code: int = 200,
+           backend_url: str = "http://hermes-backend.example"):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "hermes_backend_url", backend_url, raising=False)
+    monkeypatch.setattr(settings, "hermes_backend_token", "test-token", raising=False)
+
+    # _HermesTurnPersister.finalize() (called via HermesExecutor, which
+    # imports it from api.routes.hermes_proxy) resolves the conversation/
+    # usage stores through THIS module's own `get_store`/`get_usage_store`
+    # names — patch them here (not on conversation_store/usage_store
+    # directly) so a real turn's persistence never touches the operator's
+    # actual data/ directory. Mirrors test_hermes_proxy.py's own pattern.
+    conv_store = ConversationStore(db_path=str(tmp_path / "conversations.db"))
+    usage_store = UsageStore(db_path=str(tmp_path / "usage.db"))
+    monkeypatch.setattr(hp, "get_store", lambda: conv_store)
+    monkeypatch.setattr(hp, "get_usage_store", lambda: usage_store)
+    monkeypatch.setattr(hp, "schedule_retitle", lambda conv_id: None)
+
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    captured: dict = {}
+    factory = lambda: _FakeClient(body, status_code, captured)  # noqa: E731
+    executor = HermesExecutor(
+        session_store=store, transcript_store=transcripts, http_client_factory=factory,
+    )
+    session = store.create(task_id="t1", routing="hermes")
+    return executor, store, session, captured
+
+
+def test_happy_path_completes_and_records_conversation_id(tmp_path, monkeypatch):
+    body = _sse([
+        {"type": "conversation_id", "conversation_id": "conv-abc123"},
+        {"type": "content", "content": "Here is your schedule."},
+        {"type": "usage", "model": "gpt-5.5", "input_tokens": 10, "output_tokens": 5, "cost_usd": 0.002},
+        {"type": "done"},
+    ])
+    executor, store, session, captured = _build(tmp_path, monkeypatch, body=body)
+    outcome = executor.execute(session, {"description": "What's on my schedule today?"})
+    assert outcome.status == STATUS_COMPLETED
+    assert outcome.final_text == "Here is your schedule."
+    refreshed = store.get("t1")
+    assert refreshed.conversation_id == "conv-abc123"
+    # Envelope + bearer token present.
+    assert captured["url"].endswith("/api/ask/stream")
+    assert captured["headers"]["Authorization"] == "Bearer test-token"
+
+
+def test_prompt_combines_title_and_notes(tmp_path, monkeypatch):
+    body = _sse([
+        {"type": "conversation_id", "conversation_id": "conv-1"},
+        {"type": "content", "content": "ack"},
+        {"type": "done"},
+    ])
+    executor, store, session, captured = _build(tmp_path, monkeypatch, body=body)
+    executor.execute(session, {"description": "Book dinner", "notes": "somewhere quiet, 7pm"})
+    sent_body = json.loads(captured["content"])
+    assert "Book dinner" in sent_body["question"]
+    assert "somewhere quiet, 7pm" in sent_body["question"]
+
+
+def test_empty_prompt_fails_without_request(tmp_path, monkeypatch):
+    executor, store, session, captured = _build(tmp_path, monkeypatch, body=b"")
+    outcome = executor.execute(session, {"description": "   "})
+    assert outcome.status == STATUS_FAILED
+    assert captured == {}  # no HTTP call made
+
+
+def test_backend_not_configured_fails_without_request(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "hermes_backend_url", "", raising=False)
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    calls = []
+    executor = HermesExecutor(
+        session_store=store, transcript_store=transcripts,
+        http_client_factory=lambda: calls.append(1) or _FakeClient(b""),
+    )
+    session = store.create(task_id="t1", routing="hermes")
+    outcome = executor.execute(session, {"description": "hello"})
+    assert outcome.status == STATUS_FAILED
+    assert "not configured" in outcome.reason
+    assert calls == []
+
+
+def test_truncated_stream_without_done_still_fails_gracefully(tmp_path, monkeypatch):
+    """No conversation_id/content at all (e.g. the connection dropped
+    immediately) -> FAILED with a clear reason, not a crash."""
+    executor, store, session, captured = _build(tmp_path, monkeypatch, body=b"")
+    outcome = executor.execute(session, {"description": "hello"})
+    assert outcome.status == STATUS_FAILED
+
+
+def test_http_error_fails_gracefully(tmp_path, monkeypatch):
+    executor, store, session, captured = _build(tmp_path, monkeypatch, body=b"", status_code=500)
+    outcome = executor.execute(session, {"description": "hello"})
+    assert outcome.status == STATUS_FAILED
+    assert "hermes request failed" in outcome.reason

--- a/tests/test_agent_worker_human_queue.py
+++ b/tests/test_agent_worker_human_queue.py
@@ -1,0 +1,259 @@
+"""Tests for the agent worker's Human-queue done_when poll tick (#852).
+
+The worker talks to the human queue over the HTTP API (never the in-process
+TaskManager), so these tests fake that surface with httpx.MockTransport,
+matching the pattern in test_agent_worker_clarifications.py.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from api.services.agent_worker.session_store import SessionStore
+from api.services.agent_worker.spend_tracker import SpendTracker
+from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services.agent_worker.worker import Worker, _resolve_json_pointer
+
+pytestmark = pytest.mark.unit
+
+
+class FakeHumanQueueApi:
+    def __init__(self, cards, endpoint_responses=None):
+        self.cards = cards
+        self.endpoint_responses = endpoint_responses or {}
+        self.resolved: list[tuple[str, str]] = []  # (id, note)
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "GET" and path == "/api/tasks/human-queue":
+            return httpx.Response(200, json={"cards": self.cards, "total": len(self.cards)})
+        if request.method == "PUT" and path.endswith("/resolve") and "/human-queue/" in path:
+            card_id = path.split("/")[-2]
+            note = json.loads(request.content or b"{}").get("note", "")
+            self.resolved.append((card_id, note))
+            return httpx.Response(200, json={"id": card_id, "status": "done"})
+        if path in self.endpoint_responses:
+            body, status = self.endpoint_responses[path]
+            return httpx.Response(status, json=body)
+        return httpx.Response(404)
+
+
+def _make_worker(tmp_path, api):
+    transport = httpx.MockTransport(api.handler)
+    client = httpx.Client(transport=transport, base_url="http://api")
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    return Worker(
+        api_base="http://api",
+        session_store=store,
+        transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
+        spend_tracker=SpendTracker(db_path=tmp_path / "sessions.db", daily_cap_dollars=100.0),
+        poll_seconds=0.01,
+        http_client=client,
+    )
+
+
+def _card(id="c1", done_when=None):
+    return {
+        "id": id, "title": "X", "key": None, "notes": None, "age_hours": 1.0,
+        "source_host": None, "source_cwd": None, "source_session": None,
+        "done_when": done_when,
+    }
+
+
+class TestJsonPointer:
+    def test_empty_pointer_returns_whole_doc(self):
+        assert _resolve_json_pointer({"a": 1}, "") == {"a": 1}
+        assert _resolve_json_pointer({"a": 1}, "/") == {"a": 1}
+
+    def test_simple_pointer(self):
+        assert _resolve_json_pointer({"status": "ok"}, "/status") == "ok"
+
+    def test_nested_pointer(self):
+        assert _resolve_json_pointer({"a": {"b": "c"}}, "/a/b") == "c"
+
+    def test_missing_key_raises(self):
+        with pytest.raises(KeyError):
+            _resolve_json_pointer({"a": 1}, "/missing")
+
+
+class TestEndpointDoneWhen:
+    def test_passing_check_resolves_with_note(self, tmp_path):
+        api = FakeHumanQueueApi(
+            cards=[_card(done_when={"type": "endpoint", "path": "/api/example/status", "pointer": "/status", "equals": "ok"})],
+            endpoint_responses={"/api/example/status": ({"status": "ok"}, 200)},
+        )
+        w = _make_worker(tmp_path, api)
+        w._process_human_queue()
+        assert len(api.resolved) == 1
+        assert api.resolved[0][0] == "c1"
+        # Tightened: the resolution note must name the exact path+pointer
+        # checked and the value it matched, not just contain the word
+        # "endpoint" (which every endpoint-type note would trivially do).
+        assert api.resolved[0][1] == "Auto-resolved: endpoint /api/example/status/status == 'ok'"
+
+    def test_failing_check_leaves_card_untouched(self, tmp_path):
+        api = FakeHumanQueueApi(
+            cards=[_card(done_when={"type": "endpoint", "path": "/api/example/status", "pointer": "/status", "equals": "ok"})],
+            endpoint_responses={"/api/example/status": ({"status": "expired"}, 200)},
+        )
+        w = _make_worker(tmp_path, api)
+        w._process_human_queue()
+        assert api.resolved == []
+
+    def test_erroring_endpoint_leaves_card_untouched(self, tmp_path):
+        api = FakeHumanQueueApi(
+            cards=[_card(done_when={"type": "endpoint", "path": "/api/example/status", "pointer": "/status", "equals": "ok"})],
+            endpoint_responses={},  # 404 on the check target
+        )
+        w = _make_worker(tmp_path, api)
+        w._process_human_queue()
+        assert api.resolved == []
+
+
+class TestFileExistsDoneWhen:
+    def test_existing_file_resolves(self, tmp_path):
+        flag = tmp_path / "flag"
+        flag.write_text("x")
+        api = FakeHumanQueueApi(cards=[_card(done_when={"type": "file_exists", "path": str(flag)})])
+        w = _make_worker(tmp_path, api)
+        w._process_human_queue()
+        assert len(api.resolved) == 1
+        assert "file_exists" in api.resolved[0][1]
+
+    def test_missing_file_leaves_card_untouched(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+        api = FakeHumanQueueApi(cards=[_card(done_when={"type": "file_exists", "path": str(missing)})])
+        w = _make_worker(tmp_path, api)
+        w._process_human_queue()
+        assert api.resolved == []
+
+
+class TestNoDoneWhen:
+    def test_card_without_done_when_is_skipped(self, tmp_path):
+        api = FakeHumanQueueApi(cards=[_card(done_when=None)])
+        w = _make_worker(tmp_path, api)
+        w._process_human_queue()
+        assert api.resolved == []
+
+
+class TestPollThrottle:
+    def test_second_call_within_interval_is_a_no_op(self, tmp_path, monkeypatch):
+        from config.settings import settings
+        # A non-default value (production default is 300) — proves
+        # _process_human_queue actually reads settings.human_queue_poll_
+        # seconds rather than a hardcoded 300 that would happen to pass
+        # the old version of this test too.
+        monkeypatch.setattr(settings, "human_queue_poll_seconds", 9999.0)
+        flag = tmp_path / "flag"
+        flag.write_text("x")
+        api = FakeHumanQueueApi(cards=[_card(id="c1", done_when={"type": "file_exists", "path": str(flag)})])
+        w = _make_worker(tmp_path, api)
+
+        w._process_human_queue()
+        assert len(api.resolved) == 1
+
+        # A second card would resolve too, but the throttle should skip the
+        # whole check within the poll interval.
+        api.cards = [_card(id="c2", done_when={"type": "file_exists", "path": str(flag)})]
+        w._process_human_queue()
+        assert len(api.resolved) == 1  # unchanged — still just c1
+
+    def test_call_after_interval_elapses_runs_again(self, tmp_path, monkeypatch):
+        from config.settings import settings
+        monkeypatch.setattr(settings, "human_queue_poll_seconds", 9999.0)
+        flag = tmp_path / "flag"
+        flag.write_text("x")
+        api = FakeHumanQueueApi(cards=[_card(id="c1", done_when={"type": "file_exists", "path": str(flag)})])
+        w = _make_worker(tmp_path, api)
+        w._process_human_queue()
+        assert len(api.resolved) == 1
+
+        # Force the throttle clock back so the interval has "elapsed".
+        w._last_human_queue_check -= 10000
+        api.cards = [_card(id="c2", done_when={"type": "file_exists", "path": str(flag)})]
+        w._process_human_queue()
+        assert len(api.resolved) == 2
+
+    def test_zero_interval_never_throttles(self, tmp_path, monkeypatch):
+        """poll_seconds=0.0 means every call is past the interval — two
+        back-to-back calls must both actually list/check cards, not just
+        the first."""
+        from config.settings import settings
+        monkeypatch.setattr(settings, "human_queue_poll_seconds", 0.0)
+        flag = tmp_path / "flag"
+        flag.write_text("x")
+        api = FakeHumanQueueApi(cards=[_card(id="c1", done_when={"type": "file_exists", "path": str(flag)})])
+        w = _make_worker(tmp_path, api)
+
+        w._process_human_queue()
+        assert len(api.resolved) == 1
+
+        api.cards = [_card(id="c2", done_when={"type": "file_exists", "path": str(flag)})]
+        w._process_human_queue()
+        assert len(api.resolved) == 2
+
+
+class TestTickInvokesHumanQueue:
+    def test_tick_calls_process_human_queue(self, tmp_path, monkeypatch):
+        """Worker.tick() must actually invoke _process_human_queue — the
+        throttle tests above call _process_human_queue directly and would
+        pass even if tick() never wired it in. Every other step tick()
+        takes is stubbed to a no-op so this test isolates just that wiring,
+        not the rest of the poll cycle."""
+        api = FakeHumanQueueApi(cards=[])
+        w = _make_worker(tmp_path, api)
+        for step in (
+            "_wake_sleeping_sessions",
+            "_poll_managed_sessions",
+            "_resume_yielded_for_children",
+            "_dispatch_spawned_sessions",
+            "_process_clarification_answers",
+            "_timeout_stale_clarifications",
+        ):
+            monkeypatch.setattr(w, step, lambda: None)
+        monkeypatch.setattr(w, "_list_agent_tasks", lambda: [])
+
+        called = []
+        monkeypatch.setattr(w, "_process_human_queue", lambda: called.append(True))
+
+        result = w.tick()
+
+        assert called == [True]
+        assert result == 0
+
+    def test_tick_calls_process_human_queue_even_at_spend_cap(self, tmp_path, monkeypatch):
+        """R2-3: tick() used to return on the spend-cap guard before ever
+        reaching _process_human_queue(), so auto-resolve silently stopped
+        while the worker was paused or near its daily cap. done_when
+        resolution never starts a new task or spends money, so it must run
+        regardless of the cap."""
+        api = FakeHumanQueueApi(cards=[])
+        w = _make_worker(tmp_path, api)
+        monkeypatch.setattr(w.spend_tracker, "can_start_task", lambda estimate: False)
+
+        called = []
+        monkeypatch.setattr(w, "_process_human_queue", lambda: called.append(True))
+
+        result = w.tick()
+
+        assert called == [True]
+        assert result == 0
+
+
+class TestMultipleCards:
+    def test_one_log_line_per_resolution(self, tmp_path, caplog):
+        flag = tmp_path / "flag"
+        flag.write_text("x")
+        api = FakeHumanQueueApi(cards=[
+            _card(id="c1", done_when={"type": "file_exists", "path": str(flag)}),
+            _card(id="c2", done_when={"type": "file_exists", "path": str(tmp_path / "missing")}),
+            _card(id="c3", done_when={"type": "file_exists", "path": str(flag)}),
+        ])
+        w = _make_worker(tmp_path, api)
+        with caplog.at_level("INFO", logger="api.services.agent_worker.worker"):
+            w._process_human_queue()
+        assert {c_id for c_id, _ in api.resolved} == {"c1", "c3"}
+        resolution_lines = [r for r in caplog.records if "human-queue: resolved" in r.message]
+        assert len(resolution_lines) == 2

--- a/tests/test_agent_worker_local_executor_thinking.py
+++ b/tests/test_agent_worker_local_executor_thinking.py
@@ -1,0 +1,99 @@
+"""Tests for the per-session local-executor thinking override (#851, AC3):
+`effort: high`/`max` requests thinking on a LocalLLMClient turn; `low`/
+`medium`/absent does not. Verifies the override never reaches a fake
+(non-LocalLLMClient) test double, so every pre-#851 local_executor test
+stays byte-identical.
+"""
+from __future__ import annotations
+
+import pytest
+
+from api.services.agent_worker.local_executor import LocalExecutor
+from api.services.agent_worker.session_store import SessionStore
+from api.services.agent_worker.transcript_store import TranscriptStore
+from api.services.llm_client import LocalLLMClient
+
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeResponse:
+    def __init__(self):
+        self.text = "done"
+        self.tool_calls = []
+        self.stop_reason = "end_turn"
+        self.usage = {"input_tokens": 1, "output_tokens": 1}
+
+
+def _build_executor(tmp_path, monkeypatch, *, effort: str | None, remote: bool = False):
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    client = LocalLLMClient(base_url="http://localhost:9999", model="local")
+    calls: list[dict] = []
+
+    def _fake_create(self, messages, *, system=None, max_tokens, tools=None, **kwargs):
+        calls.append(kwargs)
+        return _FakeResponse()
+
+    monkeypatch.setattr(LocalLLMClient, "create", _fake_create)
+    executor = LocalExecutor(
+        session_store=store, transcript_store=transcripts, llm_client=client, is_remote=remote,
+    )
+    session = store.create(task_id="t1", routing="local", effort=effort)
+    return executor, store, session, calls
+
+
+@pytest.mark.parametrize("effort", ["high", "max"])
+def test_high_or_max_effort_requests_thinking(tmp_path, monkeypatch, effort):
+    executor, store, session, calls = _build_executor(tmp_path, monkeypatch, effort=effort)
+    executor._call_llm(session.session_id, effort=effort)
+    assert calls[-1]["enable_thinking"] is True
+
+
+@pytest.mark.parametrize("effort", ["low", "medium"])
+def test_low_or_medium_effort_disables_thinking(tmp_path, monkeypatch, effort):
+    executor, store, session, calls = _build_executor(tmp_path, monkeypatch, effort=effort)
+    executor._call_llm(session.session_id, effort=effort)
+    assert calls[-1]["enable_thinking"] is False
+
+
+def test_absent_effort_falls_back_to_setting(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "local_agent_enable_thinking", True, raising=False)
+    executor, store, session, calls = _build_executor(tmp_path, monkeypatch, effort=None)
+    executor._call_llm(session.session_id, effort=None)
+    assert calls[-1]["enable_thinking"] is None  # True setting -> None (server default)
+
+    monkeypatch.setattr(settings, "local_agent_enable_thinking", False, raising=False)
+    executor._call_llm(session.session_id, effort=None)
+    assert calls[-1]["enable_thinking"] is False
+
+
+def test_remote_forced_route_never_receives_enable_thinking(tmp_path, monkeypatch):
+    """The #809 remote-forced route is also a LocalLLMClient instance but
+    must never get the local-only thinking toggle."""
+    executor, store, session, calls = _build_executor(
+        tmp_path, monkeypatch, effort="high", remote=True,
+    )
+    executor._call_llm(session.session_id, effort="high")
+    assert "enable_thinking" not in calls[-1]
+
+
+def test_non_local_llm_client_fake_never_receives_enable_thinking(tmp_path):
+    """A test-injected fake whose create() doesn't accept enable_thinking
+    must not be called with it — this is what keeps every pre-#851
+    local_executor test (which uses exactly this kind of fake) passing
+    unchanged."""
+
+    class _Fake:
+        def create(self, messages, *, system=None, max_tokens, tools=None, temperature=None):
+            return _FakeResponse()
+
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcripts = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    executor = LocalExecutor(session_store=store, transcript_store=transcripts, llm_client=_Fake())
+    session = store.create(task_id="t1", routing="local", effort="high")
+    # Would raise TypeError if enable_thinking were passed — _Fake.create()
+    # has no such parameter.
+    result = executor._call_llm(session.session_id, effort="high")
+    assert result.text == "done"

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -301,6 +301,33 @@ def test_routing_ask_lands_in_blocked_with_model_question(tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_ssh_failure_reason_reaches_agent_failed_notice(tmp_path: Path):
+    """Round 1, finding #4, dispatch-level half: `_handle_outcome` (the
+    wiring `outcome.reason` goes through on the way to the #agent-failed
+    Telegram notice) must surface the ssh failure text verbatim — the
+    executor-level tests only prove `outcome.reason` itself is correct,
+    not that the worker actually uses it for the card the operator sees."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "do the thing on studio", "status": "in_progress",
+         "tags": [RUNNING_TAG, "claude"]},
+    ])
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="claude"),
+                     local_executor=_StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED)))
+    session = w.session_store.create(task_id="t1", routing="claude_code", host="studio")
+    outcome = ExecutorOutcome(
+        status=STATUS_FAILED,
+        reason="ssh to studio failed (exit 255): ssh: connect to host studio port 22: Connection refused",
+    )
+    w._handle_outcome(session, api.tasks["t1"], outcome)
+
+    assert FAILED_TAG in api.tasks["t1"]["tags"]
+    sent = w._sent_telegram  # type: ignore[attr-defined]
+    assert any("Connection refused" in s for s in sent)
+    assert any("studio" in s for s in sent)
+
+
+@pytest.mark.unit
 def test_insane_task_lands_in_failed(tmp_path: Path):
     """A deterministically destructive title (matched by the code, not the
     model's prose) still fails closed — #747 must not weaken this guard."""

--- a/tests/test_agent_worker_model_catalog.py
+++ b/tests/test_agent_worker_model_catalog.py
@@ -1,0 +1,267 @@
+"""Tests for ModelCatalog (#851, AC11): per-engine model lists merged with
+pricing, a 24h TTL cache that calls no provider on a cache hit, and a
+provider failure falling back to the last cached list with `stale: true`.
+Every provider is a stub — no network call is ever made.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from api.services.agent_worker.model_catalog import ModelCatalog
+
+
+pytestmark = pytest.mark.unit
+
+
+class _FrozenClock:
+    def __init__(self, start: float = 0.0):
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+
+class _FakeAnthropicModel:
+    def __init__(self, id_: str, display_name: str | None = None):
+        self.id = id_
+        self.display_name = display_name
+
+
+class _FakeAnthropicPage:
+    def __init__(self, models):
+        self.data = models
+
+
+class _FakeAnthropicModelsAPI:
+    def __init__(self, models, raise_exc=None):
+        self._models = models
+        self._raise = raise_exc
+
+    def list(self):
+        if self._raise:
+            raise self._raise
+        return _FakeAnthropicPage(self._models)
+
+
+class _FakeAnthropicClient:
+    def __init__(self, models, raise_exc=None):
+        self.models = _FakeAnthropicModelsAPI(models, raise_exc)
+
+
+async def _noop_local_probe():
+    return None
+
+
+async def _noop_hermes_probe():
+    return {"hermes_chat": {"status": "unknown", "model": None}}
+
+
+def _write_codex_cache(path: Path, models: list[dict]):
+    path.write_text(json.dumps({"fetched_at": "2026-01-01T00:00:00Z", "models": models}))
+
+
+@pytest.mark.asyncio
+async def test_claude_engine_empty_when_no_api_key(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "anthropic_api_key", "", raising=False)
+    catalog = ModelCatalog(
+        codex_cache_path=str(tmp_path / "missing.json"),
+        local_probe=_noop_local_probe, hermes_probe=_noop_hermes_probe,
+        clock=_FrozenClock(),
+    )
+    result = await catalog.get(ttl_seconds=86400)
+    assert result["engines"]["claude"] == []
+    assert catalog.provider_call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_claude_models_merged_with_pricing(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "anthropic_api_key", "sk-test", raising=False)
+    fake_client = _FakeAnthropicClient([
+        _FakeAnthropicModel("claude-opus-5", "Claude Opus 5"),
+        _FakeAnthropicModel("claude-haiku-4-5", "Claude Haiku 4.5"),
+    ])
+    catalog = ModelCatalog(
+        anthropic_client_factory=lambda: fake_client,
+        codex_cache_path=str(tmp_path / "missing.json"),
+        local_probe=_noop_local_probe, hermes_probe=_noop_hermes_probe,
+        clock=_FrozenClock(),
+    )
+    result = await catalog.get(ttl_seconds=86400)
+    claude = {m["id"]: m for m in result["engines"]["claude"]}
+    assert claude["claude-opus-5"]["label"] == "Claude Opus 5"
+    assert claude["claude-opus-5"]["pricing"]["input"] > 0
+    assert claude["claude-haiku-4-5"]["pricing"] is not None
+
+
+@pytest.mark.asyncio
+async def test_codex_reads_models_cache_file(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "anthropic_api_key", "", raising=False)
+    cache_path = tmp_path / "models_cache.json"
+    _write_codex_cache(cache_path, [
+        {"slug": "gpt-5.5", "display_name": "GPT-5.5"},
+        {"slug": "gpt-5.5-codex"},
+    ])
+    catalog = ModelCatalog(
+        codex_cache_path=str(cache_path),
+        local_probe=_noop_local_probe, hermes_probe=_noop_hermes_probe,
+        clock=_FrozenClock(),
+    )
+    result = await catalog.get(ttl_seconds=86400)
+    codex_ids = {m["id"] for m in result["engines"]["codex"]}
+    assert codex_ids == {"gpt-5.5", "gpt-5.5-codex"}
+
+
+@pytest.mark.asyncio
+async def test_codex_falls_back_to_provider_list_when_cache_missing(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "anthropic_api_key", "", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "sk-openai-test", raising=False)
+
+    captured = {}
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"data": [{"id": "gpt-5.5"}, {"id": "gpt-5.5-mini"}]}
+
+    class _FakeHttpClient:
+        def get(self, url, headers=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            return _FakeResponse()
+
+        def close(self):
+            captured["closed"] = True
+
+    catalog = ModelCatalog(
+        codex_cache_path=str(tmp_path / "missing.json"),
+        openai_http_client_factory=lambda: _FakeHttpClient(),
+        local_probe=_noop_local_probe, hermes_probe=_noop_hermes_probe,
+        clock=_FrozenClock(),
+    )
+    result = await catalog.get(ttl_seconds=86400)
+    codex_ids = {m["id"] for m in result["engines"]["codex"]}
+    assert codex_ids == {"gpt-5.5", "gpt-5.5-mini"}
+    assert captured["headers"]["Authorization"] == "Bearer sk-openai-test"
+    assert captured["closed"] is True
+
+
+@pytest.mark.asyncio
+async def test_codex_empty_when_cache_missing_and_no_openai_key(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "anthropic_api_key", "", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "", raising=False)
+    catalog = ModelCatalog(
+        codex_cache_path=str(tmp_path / "missing.json"),
+        local_probe=_noop_local_probe, hermes_probe=_noop_hermes_probe,
+        clock=_FrozenClock(),
+    )
+    result = await catalog.get(ttl_seconds=86400)
+    assert result["engines"]["codex"] == []
+    assert catalog.provider_call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_local_and_hermes_from_probes(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "anthropic_api_key", "", raising=False)
+
+    async def local_probe():
+        return "local"
+
+    async def hermes_probe():
+        return {"hermes_chat": {"status": "ok", "model": "deepseek-v4"}}
+
+    catalog = ModelCatalog(
+        codex_cache_path=str(tmp_path / "missing.json"),
+        local_probe=local_probe, hermes_probe=hermes_probe,
+        clock=_FrozenClock(),
+    )
+    result = await catalog.get(ttl_seconds=86400)
+    assert result["engines"]["local"] == [{"id": "local", "label": "local", "pricing": {"input": 0.0, "output": 0.0}}]
+    assert result["engines"]["hermes"][0]["id"] == "deepseek-v4"
+
+
+@pytest.mark.asyncio
+async def test_second_call_within_ttl_calls_no_provider(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "anthropic_api_key", "sk-test", raising=False)
+    fake_client = _FakeAnthropicClient([_FakeAnthropicModel("claude-opus-5")])
+    clock = _FrozenClock()
+    catalog = ModelCatalog(
+        anthropic_client_factory=lambda: fake_client,
+        codex_cache_path=str(tmp_path / "missing.json"),
+        local_probe=_noop_local_probe, hermes_probe=_noop_hermes_probe,
+        clock=clock,
+    )
+    await catalog.get(ttl_seconds=86400)
+    assert catalog.provider_call_count == 1
+    clock.now += 3600  # 1 hour later, well within the 24h TTL
+    result = await catalog.get(ttl_seconds=86400)
+    assert catalog.provider_call_count == 1  # no second provider call
+    assert result["stale"] is False
+
+
+@pytest.mark.asyncio
+async def test_ttl_expiry_triggers_a_fresh_call(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "anthropic_api_key", "sk-test", raising=False)
+    fake_client = _FakeAnthropicClient([_FakeAnthropicModel("claude-opus-5")])
+    clock = _FrozenClock()
+    catalog = ModelCatalog(
+        anthropic_client_factory=lambda: fake_client,
+        codex_cache_path=str(tmp_path / "missing.json"),
+        local_probe=_noop_local_probe, hermes_probe=_noop_hermes_probe,
+        clock=clock,
+    )
+    await catalog.get(ttl_seconds=100)
+    clock.now += 101
+    await catalog.get(ttl_seconds=100)
+    assert catalog.provider_call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_provider_failure_returns_stale_cached_list(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "anthropic_api_key", "sk-test", raising=False)
+    good_client = _FakeAnthropicClient([_FakeAnthropicModel("claude-opus-5")])
+    clock = _FrozenClock()
+    catalog = ModelCatalog(
+        anthropic_client_factory=lambda: good_client,
+        codex_cache_path=str(tmp_path / "missing.json"),
+        local_probe=_noop_local_probe, hermes_probe=_noop_hermes_probe,
+        clock=clock,
+    )
+    first = await catalog.get(ttl_seconds=1)
+    assert first["stale"] is False
+    assert first["engines"]["claude"][0]["id"] == "claude-opus-5"
+
+    # Swap in a failing client and let the TTL expire.
+    catalog.anthropic_client_factory = lambda: _FakeAnthropicClient([], raise_exc=RuntimeError("provider down"))
+    clock.now += 2
+    second = await catalog.get(ttl_seconds=1)
+    assert second["stale"] is True
+    assert second["engines"]["claude"][0]["id"] == "claude-opus-5"  # last good list, unchanged
+
+
+@pytest.mark.asyncio
+async def test_first_call_provider_failure_raises_when_nothing_cached(tmp_path, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "anthropic_api_key", "sk-test", raising=False)
+    failing_client = _FakeAnthropicClient([], raise_exc=RuntimeError("provider down"))
+    catalog = ModelCatalog(
+        anthropic_client_factory=lambda: failing_client,
+        codex_cache_path=str(tmp_path / "missing.json"),
+        local_probe=_noop_local_probe, hermes_probe=_noop_hermes_probe,
+        clock=_FrozenClock(),
+    )
+    with pytest.raises(RuntimeError):
+        await catalog.get(ttl_seconds=86400)

--- a/tests/test_agent_worker_preflight_assignment.py
+++ b/tests/test_agent_worker_preflight_assignment.py
@@ -1,0 +1,107 @@
+"""Tests for #851's preflight surface: the new `#hermes` route/tag, and the
+board-assignment routing-bypass acceptance criterion — "a task carrying
+`[assigned_by:: board]` keeps its assignee tag's route".
+
+On the bypass: `_apply_route_corroboration` already no-ops for ANY
+recognized routing tag (`_has_route_override_tag`), and every tag branch in
+`_apply_tag_overrides` (`#local`/`#claude`/`#codex`/`#hermes`/`#cloud*`)
+returns immediately — nothing downstream ever re-examines a tagged route.
+So a board-assigned card, which is always tagged with its assignee engine,
+already can't be downgraded; these tests prove that invariant directly
+(with `LIFEOS_AGENT_DEFAULT_ROUTE` configured to something else and a title
+that names a DIFFERENT engine, so a corroboration bug would be caught) —
+see the two `test_*_survives_default_route_and_uncorroborating_title` cases
+below. `[assigned_by:: board]` itself never reaches `run_preflight` (it
+isn't a tag), which is exactly why nothing about it needs threading through
+preflight for the AC to hold: `worker.py` reads it from `task["fields"]`
+via `assignment.extract_assignment()` for its own bookkeeping, and the tag
+carries the routing.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from api.services.agent_worker import preflight as pf
+
+
+def _stub(reply: str):
+    return lambda prompt: reply
+
+
+def _golden_reply(**overrides) -> str:
+    base = {
+        "budget": {"wall_seconds": 14400, "max_tokens": 500000, "max_dollars": 5.0},
+        "routing": "local",
+        "routing_reason": "model's own guess",
+        "routing_explicit": False,
+        "expected_output": "text",
+        "ambiguity": None,
+        "sane": True,
+        "sane_reason": "",
+    }
+    base.update(overrides)
+    return json.dumps(base)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_hermes_tag_routes_to_hermes():
+    result = pf.run_preflight(title="ask hermes about my schedule", tags=["agent", "hermes"], caller=_stub(_golden_reply()))
+    assert result.routing == pf.ROUTE_HERMES
+    assert result.routing_explicit is True
+
+
+def test_hermes_is_a_known_route():
+    assert pf.ROUTE_HERMES in pf.KNOWN_ROUTES
+
+
+def test_claude_tag_survives_default_route_and_uncorroborating_title(monkeypatch):
+    """AC: `[assigned_by:: board]` + `#claude` -> claude_code even with a
+    title that names another engine. The default-route setting and an
+    uncorroborating title are exactly the two levers that demote an
+    LLM-guessed route (#757) — proving a `#claude`-tagged task survives
+    both proves the tag itself, not luck, is what protects it."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "codex", raising=False)
+    reply = _golden_reply(routing="local", routing_reason="model guessed local", routing_explicit=True)
+    result = pf.run_preflight(
+        title="run this with codex please",  # names a DIFFERENT engine than #claude
+        tags=["agent", "claude"],
+        caller=_stub(reply),
+    )
+    assert result.routing == pf.ROUTE_CLAUDE_CODE
+    assert result.demoted_routing is None
+
+
+def test_hermes_tag_survives_default_route_and_uncorroborating_title(monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "local", raising=False)
+    reply = _golden_reply(routing="local", routing_reason="model guessed local", routing_explicit=True)
+    result = pf.run_preflight(
+        title="use the local model for this",
+        tags=["agent", "hermes"],
+        caller=_stub(reply),
+    )
+    assert result.routing == pf.ROUTE_HERMES
+
+
+def test_cloud_tag_still_yields_remote_route():
+    """AC: `#cloud` still yields ROUTE_REMOTE — unaffected by the #851
+    additions to `_apply_tag_overrides`/`KNOWN_ROUTES`."""
+    result = pf.run_preflight(title="summarize this", tags=["agent", "cloud"], caller=_stub(_golden_reply()))
+    assert result.routing == pf.ROUTE_REMOTE
+
+
+def test_untagged_task_precedence_unchanged(monkeypatch):
+    """AC: existing routing-tag precedence for tasks WITHOUT board
+    assignment is unchanged — an untagged, uncorroborated LLM route still
+    demotes to the configured default exactly as before #851."""
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_default_route", "codex", raising=False)
+    reply = _golden_reply(routing="local", routing_reason="model guessed local", routing_explicit=True)
+    result = pf.run_preflight(title="just do the thing", tags=["agent"], caller=_stub(reply))
+    assert result.routing == pf.ROUTE_CODEX
+    assert result.demoted_routing == pf.ROUTE_LOCAL

--- a/tests/test_agent_worker_remote_spawn.py
+++ b/tests/test_agent_worker_remote_spawn.py
@@ -1,0 +1,151 @@
+"""Tests for `api/services/agent_worker/remote_spawn.py` (#851): host
+resolution, ssh argv construction, and the injectable remote kill runner."""
+from __future__ import annotations
+
+import pytest
+
+from api.services.agent_worker.remote_spawn import (
+    CANONICAL_CREDENTIAL_ENV_NAMES,
+    HostResolutionError,
+    build_remote_argv,
+    env_names_matching_prefixes,
+    kill_remote_process_group,
+    read_remote_pgid_line,
+    resolve_host_target,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_resolve_host_target_empty_host_is_local():
+    assert resolve_host_target("", "studio") is None
+    assert resolve_host_target(None, "studio") is None
+
+
+def test_resolve_host_target_matching_api_host_is_local():
+    assert resolve_host_target("studio", "studio") is None
+
+
+def test_resolve_host_target_known_host_returns_ssh_target(monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", {"laptop": "user@laptop.example"}, raising=False)
+    assert resolve_host_target("laptop", "studio") == "user@laptop.example"
+
+
+def test_resolve_host_target_unknown_host_raises(monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", {"laptop": "user@laptop.example"}, raising=False)
+    with pytest.raises(HostResolutionError):
+        resolve_host_target("nonexistent", "studio")
+
+
+def test_build_remote_argv_shape(monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_ssh_connect_timeout", 7, raising=False)
+    argv = build_remote_argv(
+        ["claude", "-p", "hello there"],
+        target="user@laptop.example",
+        unset_env_names=["ANTHROPIC_API_KEY", "CLAUDECODE"],
+    )
+    assert argv[0] == "ssh"
+    assert "-o" in argv and "BatchMode=yes" in argv
+    assert "ConnectTimeout=7" in argv
+    assert "user@laptop.example" in argv
+    assert argv[-2] == "--"
+    remote_command = argv[-1]
+    assert "env -u ANTHROPIC_API_KEY -u CLAUDECODE" in remote_command
+    assert "'hello there'" in remote_command  # shlex-quoted, spaces preserved
+    assert remote_command.startswith("setsid bash -c")
+
+
+def test_read_remote_pgid_line():
+    assert read_remote_pgid_line("PGID:12345\n") == 12345
+    assert read_remote_pgid_line("PGID:12345") == 12345
+    assert read_remote_pgid_line("not a pgid line\n") is None
+    assert read_remote_pgid_line("") is None
+
+
+def test_kill_remote_process_group_uses_injected_runner_never_touches_network():
+    calls = []
+
+    class _FakeResult:
+        returncode = 0
+
+    def _fake_runner(argv):
+        calls.append(argv)
+        return _FakeResult()
+
+    ok = kill_remote_process_group(target="user@laptop.example", pgid=999, runner=_fake_runner)
+    assert ok is True
+    assert len(calls) == 1
+    argv = calls[0]
+    assert argv[0] == "ssh"
+    assert "user@laptop.example" in argv
+    assert argv[-3:] == ["kill", "--", "-999"]
+
+
+def test_kill_remote_process_group_nonzero_exit_returns_false():
+    class _FakeResult:
+        returncode = 1
+
+    ok = kill_remote_process_group(
+        target="user@laptop.example", pgid=999, runner=lambda argv: _FakeResult(),
+    )
+    assert ok is False
+
+
+def test_kill_remote_process_group_runner_exception_returns_false():
+    def _raising_runner(argv):
+        raise OSError("network unreachable")
+
+    ok = kill_remote_process_group(
+        target="user@laptop.example", pgid=999, runner=_raising_runner,
+    )
+    assert ok is False
+
+
+def test_env_names_matching_prefixes(monkeypatch):
+    monkeypatch.setenv("CLAUDE_TEST_VAR_851", "x")
+    monkeypatch.setenv("ANTHROPIC_TEST_VAR_851", "y")
+    monkeypatch.setenv("UNRELATED_VAR_851", "z")
+    names = env_names_matching_prefixes(("ANTHROPIC_", "CLAUDE"))
+    assert "CLAUDE_TEST_VAR_851" in names
+    assert "ANTHROPIC_TEST_VAR_851" in names
+    assert "UNRELATED_VAR_851" not in names
+
+
+def test_env_names_matching_prefixes_respects_keep(monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", "/home/x/.codex")
+    monkeypatch.setenv("CODEX_TEST_851", "y")
+    names = env_names_matching_prefixes(("CODEX_",), keep=frozenset({"CODEX_HOME"}))
+    assert "CODEX_HOME" not in names
+    assert "CODEX_TEST_851" in names
+
+
+def test_env_names_matching_prefixes_unsets_canonical_names_on_clean_local_env(monkeypatch):
+    """Round 1, finding #2: a worker whose OWN process env has none of the
+    provider-credential vars set (subscription/OAuth install — the common
+    case) must still unset them remotely, since a registered host's own
+    non-interactive shell may export one. `env_names_matching_prefixes`
+    must not rely solely on scanning the local process's environment."""
+    for name in CANONICAL_CREDENTIAL_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    names = env_names_matching_prefixes(("ANTHROPIC_", "CLAUDE"))
+    assert set(CANONICAL_CREDENTIAL_ENV_NAMES).issubset(set(names))
+
+
+def test_remote_command_carries_env_unset_on_clean_local_env(monkeypatch):
+    """End-to-end version of the above: even on a clean local env, the
+    fully-built remote command (what actually reaches ssh) carries
+    `env -u ANTHROPIC_API_KEY` for the credential the AC is about."""
+    for name in CANONICAL_CREDENTIAL_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    names = env_names_matching_prefixes(("ANTHROPIC_", "CLAUDE"))
+    argv = build_remote_argv(
+        ["claude", "-p", "hello"],
+        target="user@laptop.example",
+        unset_env_names=names,
+    )
+    remote_command = argv[-1]
+    assert "-u ANTHROPIC_API_KEY" in remote_command

--- a/tests/test_agents_assignment_ui_browser.py
+++ b/tests/test_agents_assignment_ui_browser.py
@@ -1,0 +1,242 @@
+"""Browser test for web/agents/assignment.js (#851) — the isolated
+model/effort/host/engine assignment-picker module, built ahead of the
+Kanban board UI (#850) merging (see this PR's description for why it's
+standalone rather than wired into web/agents/board.js).
+
+Serves `web/` itself from an ephemeral port (same pattern as
+tests/test_voice_mic_block_ui_browser.py) rather than pointing at a running
+API — every `/api/**` call the page makes is stubbed, so this carries no
+`requires_server` marker and runs at pre-push (`browser and not
+requires_server`).
+"""
+import http.server
+import json
+import threading
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+
+
+class _WebHandler(http.server.SimpleHTTPRequestHandler):
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        return str(WEB_DIR / path.lstrip("/"))
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def web_base_url():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _WebHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+_MODEL_CATALOG = {
+    "engines": {
+        "claude": [
+            {"id": "claude-opus-5", "label": "Claude Opus 5", "pricing": {"input": 5e-6, "output": 25e-6}},
+            {"id": "claude-sonnet-5", "label": "Claude Sonnet 5", "pricing": {"input": 2e-6, "output": 10e-6}},
+        ],
+        "codex": [{"id": "gpt-5.5", "label": "GPT-5.5", "pricing": None}],
+        "local": [],
+        "hermes": [],
+    },
+    "refreshed_at": "2026-01-01T00:00:00Z",
+    "stale": False,
+}
+
+
+def _load_module(page: Page, base_url: str, *, api_handler=None):
+    """Serve a page on the target origin, stub every /api/ call, and inject
+    assignment.js as a module — exposing `window.__renderAssignmentPickers`
+    for the test to drive."""
+    def default_handler(route):
+        if "/api/agents/models" in route.request.url:
+            route.fulfill(status=200, content_type="application/json", body=json.dumps(_MODEL_CATALOG))
+        elif "/api/tasks/" in route.request.url and route.request.method == "PUT":
+            body = json.loads(route.request.post_data or "{}")
+            route.fulfill(status=200, content_type="application/json", body=json.dumps({"id": "t1", **body}))
+        else:
+            route.fulfill(status=200, content_type="application/json", body="{}")
+
+    page.route("**/api/**", api_handler or default_handler)
+    # agents.html is a real, already-served page — used purely as a host
+    # document so assignment.js's relative-to-origin import resolves; its
+    # own legacy inline scripts hit /api/** too, which the stub above
+    # already covers harmlessly.
+    page.goto(f"{base_url}/agents.html")
+    page.add_script_tag(
+        content="""
+        import { renderAssignmentPickers } from '/agents/assignment.js';
+        window.__renderAssignmentPickers = renderAssignmentPickers;
+        window.__assignmentReady = true;
+        """,
+        type="module",
+    )
+    page.wait_for_function("() => window.__assignmentReady === true")
+
+
+def _render(page: Page, card: dict):
+    page.evaluate(
+        """(card) => {
+            const container = document.createElement('div');
+            container.id = 'test-assignment-container';
+            document.body.appendChild(container);
+            window.__lastCalls = [];
+            window.__renderAssignmentPickers(container, card, {
+                putTask: (id, patch) => {
+                    window.__lastCalls.push({ id, patch });
+                    return Promise.resolve({ id, ...patch });
+                },
+            });
+        }""",
+        card,
+    )
+
+
+def test_renders_engine_model_effort_host_pickers(page: Page, web_base_url):
+    _load_module(page, web_base_url)
+    _render(page, {"id": "t1", "title": "Fix the printer", "tags": ["claude"], "assignee": "claude", "fields": {}})
+
+    container = page.locator("#test-assignment-container")
+    expect(container.locator("[data-field='assignee']")).to_be_visible()
+    expect(container.locator("[data-row='model']")).to_be_visible()
+    expect(container.locator("[data-row='effort']")).to_be_visible()
+    expect(container.locator("[data-row='host']")).to_be_visible()
+    # Model options populate asynchronously from the catalog fetch.
+    expect(container.locator("[data-field='model'] option")).to_have_count(3)  # default + 2 claude models
+
+
+def test_local_engine_hides_model_and_host_pickers(page: Page, web_base_url):
+    _load_module(page, web_base_url)
+    _render(page, {"id": "t2", "title": "Reindex the vault", "tags": ["local"], "assignee": "local", "fields": {}})
+
+    container = page.locator("#test-assignment-container")
+    expect(container.locator("[data-row='model']")).to_be_hidden()
+    expect(container.locator("[data-row='effort']")).to_be_visible()
+    expect(container.locator("[data-row='host']")).to_be_hidden()
+
+
+def test_hermes_engine_hides_model_effort_and_host_pickers(page: Page, web_base_url):
+    _load_module(page, web_base_url)
+    _render(page, {"id": "t3", "title": "Ask hermes", "tags": ["hermes"], "assignee": "hermes", "fields": {}})
+
+    container = page.locator("#test-assignment-container")
+    expect(container.locator("[data-row='model']")).to_be_hidden()
+    expect(container.locator("[data-row='effort']")).to_be_hidden()
+    expect(container.locator("[data-row='host']")).to_be_hidden()
+
+
+def test_changing_effort_saves_with_assigned_by_board(page: Page, web_base_url):
+    _load_module(page, web_base_url)
+    _render(page, {"id": "t4", "title": "Deploy the service", "tags": ["codex"], "assignee": "codex", "fields": {}})
+
+    page.locator("[data-field='effort']").select_option("high")
+    calls = page.evaluate("() => window.__lastCalls")
+    assert len(calls) == 1
+    assert calls[0]["id"] == "t4"
+    assert calls[0]["patch"]["fields"]["effort"] == "high"
+    assert calls[0]["patch"]["fields"]["assigned_by"] == "board"
+
+
+def test_changing_engine_updates_tags_and_saves(page: Page, web_base_url):
+    _load_module(page, web_base_url)
+    _render(page, {"id": "t5", "title": "Fix the printer", "tags": ["agent"], "assignee": "", "fields": {}})
+
+    page.locator("[data-field='assignee']").select_option("codex")
+    calls = page.evaluate("() => window.__lastCalls")
+    assert len(calls) == 1
+    assert calls[0]["patch"]["tags"] == ["codex", "agent"]
+    assert calls[0]["patch"]["fields"]["assigned_by"] == "board"
+
+
+def test_shows_what_actually_ran_from_session(page: Page, web_base_url):
+    _load_module(page, web_base_url)
+    _render(page, {
+        "id": "t6", "title": "Fix the printer", "tags": ["claude"], "assignee": "claude",
+        "fields": {"model": "opus", "effort": "high"},
+        "session": {"model": "opus", "effort": "high", "host": "studio"},
+    })
+    container = page.locator("#test-assignment-container")
+    ran_text = container.locator("[data-field='ran']").inner_text()
+    assert "opus" in ran_text
+    assert "high" in ran_text
+    assert "studio" in ran_text
+
+
+def test_effort_change_before_catalog_resolves_does_not_clear_model(page: Page, web_base_url):
+    """#861 regression: changing effort/host before GET /api/agents/models
+    resolves must not send `model: null` and clear a previously saved model
+    field — the model select's options (and thus its value) don't exist yet
+    on the first drawer open of a page load, so `save()` must omit the
+    `model` key entirely until the catalog has populated the select."""
+    pending = []
+
+    def api_handler(route):
+        if "/api/agents/models" in route.request.url:
+            pending.append(route)  # stashed — fulfilled later in the test
+        elif "/api/tasks/" in route.request.url and route.request.method == "PUT":
+            body = json.loads(route.request.post_data or "{}")
+            route.fulfill(status=200, content_type="application/json", body=json.dumps({"id": "t1", **body}))
+        else:
+            route.fulfill(status=200, content_type="application/json", body="{}")
+
+    _load_module(page, web_base_url, api_handler=api_handler)
+    _render(page, {
+        "id": "t8", "title": "Fix the printer", "tags": ["claude"], "assignee": "claude",
+        "fields": {"model": "claude-sonnet-5", "effort": "medium"},
+    })
+
+    # Catalog hasn't resolved yet (its route is stashed) — change effort now.
+    page.locator("[data-field='effort']").select_option("high")
+    calls = page.evaluate("() => window.__lastCalls")
+    assert len(calls) == 1
+    fields = calls[0]["patch"]["fields"]
+    assert fields["effort"] == "high"
+    assert fields["assigned_by"] == "board"
+    assert "model" not in fields  # omitted, not nulled — must not clear the saved model
+
+    # Now let the catalog resolve (fulfill every stashed models route).
+    for route in pending:
+        route.fulfill(status=200, content_type="application/json", body=json.dumps(_MODEL_CATALOG))
+    pending.clear()
+
+    container = page.locator("#test-assignment-container")
+    expect(container.locator("[data-field='model'] option")).to_have_count(3)  # default + 2 claude models
+
+    # Once the catalog is ready, effort changes carry the saved model along.
+    page.locator("[data-field='effort']").select_option("low")
+    calls = page.evaluate("() => window.__lastCalls")
+    assert len(calls) == 2
+    fields2 = calls[1]["patch"]["fields"]
+    assert fields2["model"] == "claude-sonnet-5"
+
+
+def test_put_failure_surfaces_error_without_crashing(page: Page, web_base_url):
+    _load_module(page, web_base_url)
+    page.evaluate(
+        """(card) => {
+            const container = document.createElement('div');
+            container.id = 'test-assignment-container';
+            document.body.appendChild(container);
+            window.__renderAssignmentPickers(container, card, {
+                putTask: () => Promise.reject(new Error('save failed')),
+            });
+        }""",
+        {"id": "t7", "title": "Fix the printer", "tags": ["codex"], "assignee": "codex", "fields": {}},
+    )
+    page.locator("[data-field='effort']").select_option("low")
+    error_el = page.locator("#test-assignment-container [data-field='error']")
+    expect(error_el).to_be_visible()
+    expect(error_el).to_contain_text("save failed")

--- a/tests/test_agents_board_api.py
+++ b/tests/test_agents_board_api.py
@@ -1,0 +1,728 @@
+"""API tests for the /agents Kanban board (#850).
+
+Covers GET /api/agents/board, PUT .../board/cards/{id}/lane,
+POST .../board/cards/{id}/accept, GET /api/agents/pending-questions,
+POST .../pending-questions/{id}/answer, the Hermes label fix, and the
+Codex (`cx:`) transcript stream dispatch. Uses temp-dir-backed stores via
+monkeypatch so the real vault/data directories are never touched.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+from api.routes import agents as agents_route
+import api.services.task_manager as task_manager_module
+import api.services.scheduler_store as scheduler_store_module
+from api.services.task_manager import TaskManager
+from api.services.scheduler_store import SchedulerStore
+from api.services.agent_worker.session_store import STATUS_BLOCKED, SessionStore
+from api.services.agent_worker.transcript_store import TranscriptStore
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    """Point every store the board endpoint touches at temp-dir fixtures."""
+    session_store = SessionStore(db_path=tmp_path / "sessions.db")
+    transcript_store = TranscriptStore(transcripts_dir=tmp_path / "transcripts")
+    monkeypatch.setattr(agents_route, "_session_store", session_store)
+    monkeypatch.setattr(agents_route, "_transcript_store", transcript_store)
+    agents_route._label_cache.clear()
+    # The board cache (finding #5) is module-level and TTL'd — reset it per
+    # test so a prior test's cached board can't leak into this one's stores.
+    monkeypatch.setattr(agents_route, "_board_cache", None)
+    monkeypatch.setattr(agents_route, "_claude_code_snapshot", lambda: ([], []))
+    monkeypatch.setattr(agents_route, "_codex_snapshot", lambda: ([], []))
+
+    task_manager = TaskManager(
+        vault_path=tmp_path / "vault", index_path=tmp_path / "task_index.json",
+    )
+    monkeypatch.setattr(task_manager_module, "_task_manager", task_manager)
+
+    scheduler_store = SchedulerStore(
+        vault_path=tmp_path / "vault", index_path=tmp_path / "scheduler_index.json",
+    )
+    monkeypatch.setattr(scheduler_store_module, "_scheduler_store", scheduler_store)
+
+    yield task_manager, scheduler_store, session_store, transcript_store
+    agents_route._label_cache.clear()
+
+
+@pytest.fixture
+def client():
+    return TestClient(api_main.app)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/agents/board
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestGetBoard:
+    def test_empty_board_shape(self, client, stores):
+        r = client.get("/api/agents/board")
+        assert r.status_code == 200
+        body = r.json()
+        assert set(body["lanes"].keys()) == {
+            "unassigned", "assigned", "in_progress", "human_queue",
+            "scheduled", "review", "done",
+        }
+        assert "generated_at" in body
+
+    def test_get_board_never_served_from_stream_cache(self, client, stores):
+        """Round-2 finding 6(a): GET /board must always build fresh — it
+        must never read the TTL'd cache the stream's own tick uses.
+        Poisons the cache with a snapshot missing the task and proves GET
+        ignores it rather than serving pre-write data (reproduces the
+        drawer's own `await putTask(); await fetchBoard()` staleness)."""
+        task_manager, *_ = stores
+        task = task_manager.create("Notes card", tags=["me"])
+        empty_lanes = {lane: [] for lane in (
+            "unassigned", "assigned", "in_progress", "human_queue",
+            "scheduled", "review", "done",
+        )}
+        agents_route._board_cache = (time.monotonic(), {"lanes": empty_lanes, "generated_at": 0})
+        body = client.get("/api/agents/board").json()
+        assert task.id in [c["id"] for c in body["lanes"]["assigned"]]
+
+    def test_task_lands_in_derived_lane_with_full_card_shape(self, client, stores):
+        task_manager, *_ = stores
+        task_manager.create("Ping the vendor", context="Work", tags=["me"])
+        r = client.get("/api/agents/board")
+        assert r.status_code == 200
+        assigned = r.json()["lanes"]["assigned"]
+        assert len(assigned) == 1
+        card = assigned[0]
+        for key in (
+            "id", "title", "notes", "status", "tags", "assignee", "fields",
+            "context", "updated_at", "session", "pending_question",
+        ):
+            assert key in card
+        assert card["title"] == "Ping the vendor"
+        assert card["assignee"] == "me"
+        assert card["session"] is None
+        assert card["pending_question"] is None
+
+    def test_agent_blocked_card_carries_pending_question(self, client, stores):
+        task_manager, _sched, session_store, _transcript = stores
+        task = task_manager.create("Investigate the outage", tags=["agent-blocked"], status="blocked")
+        session = session_store.create(task_id=task.id, status=STATUS_BLOCKED)
+        session_store.create_pending_question(
+            session_id=session.session_id,
+            task_id=task.id,
+            question="Which environment — staging or prod?",
+            sent_message_id=42,
+        )
+        r = client.get("/api/agents/board")
+        human_queue = r.json()["lanes"]["human_queue"]
+        assert len(human_queue) == 1
+        pq = human_queue[0]["pending_question"]
+        assert pq is not None
+        assert pq["question"] == "Which environment — staging or prod?"
+        assert pq["session_id"] == session.session_id
+
+    def test_card_carries_its_linked_session(self, client, stores):
+        """Round-1 finding 13: `_task_card`'s session join was untested —
+        every prior fixture card had `session: None`."""
+        task_manager, _sched, session_store, _transcript = stores
+        task = task_manager.create("Draft the memo", tags=["codex"])
+        session = session_store.create(task_id=task.id, status="running", routing="claude")
+        r = client.get("/api/agents/board")
+        card = r.json()["lanes"]["assigned"][0]
+        assert card["session"] is not None
+        assert card["session"]["session_id"] == session.session_id
+
+    def test_card_session_picks_most_recently_active_of_several(self, client, stores, monkeypatch):
+        """Round-1 finding 13: with two sessions on the same task, the card
+        must carry the one with the latest `last_activity_at`, not just
+        whichever the store happened to return first. `sessions` PRIMARY
+        KEYs on `task_id` (at most one LifeOS-worker session per task at a
+        time), so the second session here models the realistic case of a
+        task later resumed via a Claude Code CLI session — the union
+        `_task_card` actually has to pick between."""
+        task_manager, _sched, session_store, _transcript = stores
+        task = task_manager.create("Draft the memo", tags=["codex"])
+        older = session_store.create(task_id=task.id, status="completed", routing="claude")
+        with session_store._connect() as conn:
+            conn.execute(
+                "UPDATE sessions SET last_activity_at = ? WHERE session_id = ?",
+                (100, older.session_id),
+            )
+        newer_session_id = "cc:newer-session"
+        monkeypatch.setattr(
+            agents_route, "_claude_code_snapshot",
+            lambda: ([{
+                "session_id": newer_session_id, "task_id": task.id,
+                "status": "running", "last_activity_at": 200,
+            }], []),
+        )
+
+        r = client.get("/api/agents/board")
+        card = r.json()["lanes"]["assigned"][0]
+        assert card["session"]["session_id"] == newer_session_id
+
+    def test_review_lane_agent_completed_not_accepted(self, client, stores):
+        task_manager, *_ = stores
+        task_manager.create("Draft the memo", tags=["agent-completed"], status="done")
+        r = client.get("/api/agents/board")
+        lanes = r.json()["lanes"]
+        assert len(lanes["review"]) == 1
+        assert lanes["done"] == []
+
+    def test_scheduled_cron_entry_with_future_fire(self, client, stores):
+        _tm, scheduler_store, *_ = stores
+        scheduler_store.create(
+            name="Morning briefing", schedule_type="cron", schedule_value="0 9 * * *",
+            message_type="static", message_content="Good morning",
+        )
+        r = client.get("/api/agents/board")
+        lanes = r.json()["lanes"]
+        assert len(lanes["scheduled"]) == 1
+        card = lanes["scheduled"][0]
+        assert card["recurring"] is True
+        assert card["next_fire_at"] is not None
+        assert card["last_run"] is None
+        assert lanes["done"] == []
+
+    def test_scheduled_cron_entry_carries_last_run_after_it_fires(self, client, stores):
+        """Round-1 finding 16: a recurring entry that has already fired once
+        but is still enabled with a future next trigger stays in Scheduled —
+        its `last_run` must still be populated from the prior fire."""
+        _tm, scheduler_store, *_ = stores
+        entry = scheduler_store.create(
+            name="Morning briefing", schedule_type="cron", schedule_value="0 9 * * *",
+            message_type="static", message_content="Good morning",
+        )
+        scheduler_store.mark_triggered(entry.id)
+        scheduler_store.record_run(entry.id, "sent", "delivered the briefing")
+
+        r = client.get("/api/agents/board")
+        lanes = r.json()["lanes"]
+        assert lanes["done"] == []
+        assert len(lanes["scheduled"]) == 1
+        card = lanes["scheduled"][0]
+        assert card["last_run"] is not None
+        assert card["last_run"]["outcome"] == "sent"
+        assert card["last_run"]["snippet"] == "delivered the briefing"
+
+    def test_disabled_recurring_schedule_shows_in_done(self, client, stores):
+        _tm, scheduler_store, *_ = stores
+        entry = scheduler_store.create(
+            name="Retired job", schedule_type="cron", schedule_value="0 9 * * *",
+            message_type="static", message_content="x",
+        )
+        scheduler_store.update(entry.id, enabled=False)
+        r = client.get("/api/agents/board")
+        lanes = r.json()["lanes"]
+        assert lanes["scheduled"] == []
+        assert len(lanes["done"]) == 1
+
+    def test_fired_one_off_shows_in_done_not_scheduled(self, client, stores):
+        _tm, scheduler_store, *_ = stores
+        entry = scheduler_store.create(
+            name="One-time nudge", schedule_type="once",
+            schedule_value="2020-01-01T09:00:00+00:00",
+            message_type="static", message_content="x",
+        )
+        scheduler_store.mark_triggered(entry.id)
+        scheduler_store.record_run(entry.id, "sent", "delivered")
+        r = client.get("/api/agents/board")
+        lanes = r.json()["lanes"]
+        assert lanes["scheduled"] == []
+        assert len(lanes["done"]) == 1
+        assert lanes["done"][0]["last_run"]["outcome"] == "sent"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/agents/board/stream
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestBoardStream:
+    async def test_stream_emits_a_second_frame_after_a_task_mutation(self, stores):
+        """Round-1 finding 12(a): the SSE path itself (GET
+        /api/agents/board/stream) was never opened by any test — only
+        _build_board() was called directly. Drive the real generator
+        directly rather than through TestClient — its `_TestClientTransport`
+        fully drains an ASGI call before returning a response, and this
+        generator never completes on its own — and prove a task mutation
+        produces a second, different frame on the path the page actually
+        uses ("The board updates within three seconds of an external vault
+        edit without a page reload.")."""
+        task_manager, *_ = stores
+        task = task_manager.create("Ping the vendor")
+
+        resp = await agents_route.stream_board()
+        gen = resp.body_iterator
+        next_task = None
+        try:
+            first = await gen.__anext__()
+            assert first == ": ok\n\n"
+
+            second = await gen.__anext__()
+            assert second.startswith("event: board\n")
+            first_board = json.loads(second.split("data: ", 1)[1])
+            assert task.id in [c["id"] for c in first_board["lanes"]["unassigned"]]
+
+            # Round-2 finding 10: without a mutation, ticks must not emit —
+            # the signature-diff suppression, not "any frame that shows up".
+            # Use asyncio.wait (not wait_for) so a timeout leaves the pending
+            # __anext__() task running rather than cancelling it — cancelling
+            # an async generator's __anext__() closes the generator, which
+            # would make every subsequent __anext__() raise StopAsyncIteration.
+            next_task = asyncio.ensure_future(gen.__anext__())
+            done, _pending = await asyncio.wait(
+                {next_task}, timeout=2 * agents_route._BOARD_STREAM_INTERVAL,
+            )
+            assert next_task not in done, (
+                "stream emitted a frame despite no board mutation "
+                "(signature-diff suppression broken)"
+            )
+
+            task_manager.update(task.id, tags=["me"])
+
+            third = await next_task
+            assert third.startswith("event: board\n")
+            second_board = json.loads(third.split("data: ", 1)[1])
+            assert task.id in [c["id"] for c in second_board["lanes"]["assigned"]]
+            assert task.id not in [c["id"] for c in second_board["lanes"]["unassigned"]]
+        finally:
+            # If anything between asyncio.wait and `await next_task` raises,
+            # next_task is still pending — closing the generator while its
+            # own __anext__() is still outstanding raises "aclose(): asynchronous
+            # generator is already running" and masks the real error
+            # (#850 round-3 finding 4). Cancel it first so aclose() sees a
+            # generator that isn't mid-iteration.
+            if next_task is not None and not next_task.done():
+                next_task.cancel()
+                await asyncio.gather(next_task, return_exceptions=True)
+            await gen.aclose()
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/agents/board/cards/{id}/lane
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestMoveBoardCard:
+    def test_missing_card_is_404(self, client, stores):
+        r = client.put("/api/agents/board/cards/does-not-exist/lane", json={"lane": "done"})
+        assert r.status_code == 404
+
+    def test_done_marks_task_done(self, client, stores):
+        task_manager, *_ = stores
+        task = task_manager.create("Ship the release")
+        r = client.put(f"/api/agents/board/cards/{task.id}/lane", json={"lane": "done"})
+        assert r.status_code == 200
+        assert r.json()["lane"] == "done"
+        assert task_manager.get(task.id).status == "done"
+
+    def test_unassigned_removes_assignee_tag(self, client, stores):
+        task_manager, *_ = stores
+        task = task_manager.create("Review the PR", tags=["codex", "urgent-work"])
+        r = client.put(f"/api/agents/board/cards/{task.id}/lane", json={"lane": "unassigned"})
+        assert r.status_code == 200
+        assert r.json()["lane"] == "unassigned"
+        assert sorted(task_manager.get(task.id).tags) == ["urgent-work"]
+
+    def test_assigned_sets_codex_and_removes_other_assignee(self, client, stores):
+        task_manager, *_ = stores
+        task = task_manager.create("Fix the flaky test", tags=["me"])
+        r = client.put(
+            f"/api/agents/board/cards/{task.id}/lane",
+            json={"lane": "assigned", "assignee": "codex"},
+        )
+        assert r.status_code == 200
+        updated = task_manager.get(task.id)
+        assert sorted(updated.tags) == ["codex"]
+
+    def test_in_progress_on_agent_assigned_task_is_409(self, client, stores):
+        task_manager, *_ = stores
+        task = task_manager.create("Write the migration", tags=["codex"])
+        r = client.put(f"/api/agents/board/cards/{task.id}/lane", json={"lane": "in_progress"})
+        assert r.status_code == 409
+        # Unmodified — a rejected move must not have written anything.
+        assert task_manager.get(task.id).status == "todo"
+
+    def test_in_progress_on_me_assigned_task_succeeds(self, client, stores):
+        task_manager, *_ = stores
+        task = task_manager.create("Send the invoice", tags=["me"])
+        r = client.put(f"/api/agents/board/cards/{task.id}/lane", json={"lane": "in_progress"})
+        assert r.status_code == 200
+        assert task_manager.get(task.id).status == "in_progress"
+
+    def test_review_lane_is_not_directly_settable(self, client, stores):
+        task_manager, *_ = stores
+        task = task_manager.create("Something")
+        r = client.put(f"/api/agents/board/cards/{task.id}/lane", json={"lane": "review"})
+        assert r.status_code == 400
+
+    def test_human_queue_card_dropped_into_done_lands_in_done(self, client, stores):
+        """Round-1 finding 1: a #human + blocked card dropped into Done must
+        actually leave Human queue — the stale `human` tag used to keep it
+        there even after `status` was written to `done`."""
+        task_manager, *_ = stores
+        task = task_manager.create("Escalated to the operator", tags=["human"], status="blocked")
+        r = client.put(f"/api/agents/board/cards/{task.id}/lane", json={"lane": "done"})
+        assert r.status_code == 200
+        assert r.json()["lane"] == "done"
+        updated = task_manager.get(task.id)
+        assert updated.status == "done"
+        assert "human" not in updated.tags
+
+        board = client.get("/api/agents/board").json()
+        done_ids = [c["id"] for c in board["lanes"]["done"]]
+        human_queue_ids = [c["id"] for c in board["lanes"]["human_queue"]]
+        assert task.id in done_ids
+        assert task.id not in human_queue_ids
+
+    @pytest.mark.parametrize("worker_tag", ["agent-running", "agent-blocked"])
+    @pytest.mark.parametrize("target_lane", ["in_progress", "done"])
+    def test_worker_owned_card_cannot_be_dropped_on_in_progress_or_done(
+        self, client, stores, worker_tag, target_lane,
+    ):
+        """Round-2 finding 1: a worker-owned card (agent-running or
+        agent-blocked) must 409 for In progress and Done, with NO write at
+        all — round-1's tag-strip silently detached these from a live
+        worker task instead."""
+        task_manager, *_ = stores
+        task = task_manager.create("Being worked by the agent", tags=["agent", worker_tag])
+        inbox = task_manager.tasks_dir / "Inbox.md"
+        before = inbox.read_bytes()
+
+        r = client.put(f"/api/agents/board/cards/{task.id}/lane", json={"lane": target_lane})
+        assert r.status_code == 409
+        assert r.json()["detail"] == (
+            "the worker owns this task while it is running or waiting on an "
+            "answer — answer or kill the session first"
+        )
+        # No write at all — the vault file is byte-for-byte unchanged.
+        assert inbox.read_bytes() == before
+        updated = task_manager.get(task.id)
+        assert sorted(updated.tags) == sorted(["agent", worker_tag])
+
+    @pytest.mark.parametrize("target_lane", ["in_progress", "human_queue"])
+    def test_review_card_cannot_be_moved_to_in_progress_or_human_queue(
+        self, client, stores, target_lane,
+    ):
+        """Round-2 finding 2(a): a pending review (agent-completed, not yet
+        accepted) must 409 rather than silently writing status/tags while
+        the card stays in Review — only Done still doubles as accept."""
+        task_manager, *_ = stores
+        task = task_manager.create("Reviewed by the operator", tags=["me", "agent-completed"], status="done")
+        r = client.put(f"/api/agents/board/cards/{task.id}/lane", json={"lane": target_lane})
+        assert r.status_code == 409
+        assert r.json()["detail"] == "accept the review first"
+        updated = task_manager.get(task.id)
+        assert updated.status == "done"
+        assert sorted(updated.tags) == ["agent-completed", "me"]
+
+        board = client.get("/api/agents/board").json()
+        review_ids = [c["id"] for c in board["lanes"]["review"]]
+        assert task.id in review_ids
+
+    def test_review_card_dropped_on_done_still_accepts(self, client, stores):
+        """Done keeps acting as the accept path for a Review card — only
+        In progress and Human queue were narrowed to 409 (round-2 finding 2a)."""
+        task_manager, *_ = stores
+        task = task_manager.create("Reviewed by the operator", tags=["me", "agent-completed"], status="done")
+        r = client.put(f"/api/agents/board/cards/{task.id}/lane", json={"lane": "done"})
+        assert r.status_code == 200
+        assert r.json()["lane"] == "done"
+        updated = task_manager.get(task.id)
+        assert "accepted" in updated.tags
+        assert updated.status == "done"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/agents/board/cards/{id}/accept
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestAcceptBoardCard:
+    def test_accept_moves_review_to_done(self, client, stores):
+        task_manager, *_ = stores
+        task = task_manager.create("Refactor the parser", tags=["agent-completed"], status="done")
+        r = client.post(f"/api/agents/board/cards/{task.id}/accept")
+        assert r.status_code == 200
+        assert r.json()["lane"] == "done"
+        updated = task_manager.get(task.id)
+        assert "accepted" in updated.tags
+        assert updated.status == "done"
+
+    def test_accept_is_idempotent(self, client, stores):
+        task_manager, *_ = stores
+        task = task_manager.create("Refactor the parser", tags=["agent-completed"], status="done")
+        r1 = client.post(f"/api/agents/board/cards/{task.id}/accept")
+        updated_at_1 = task_manager.get(task.id).updated_at
+        r2 = client.post(f"/api/agents/board/cards/{task.id}/accept")
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        updated = task_manager.get(task.id)
+        assert updated.tags.count("accepted") == 1
+        # Second call is a true no-op — no write, so updated_at is unchanged.
+        assert updated.updated_at == updated_at_1
+
+    def test_accept_missing_card_is_404(self, client, stores):
+        r = client.post("/api/agents/board/cards/nope/accept")
+        assert r.status_code == 404
+
+    def test_accept_on_non_review_card_is_409(self, client, stores):
+        """Round-1 finding 6: /accept had no Review-lane guard — it would
+        happily mark any todo card done."""
+        task_manager, *_ = stores
+        task = task_manager.create("A plain todo, never touched by the worker")
+        r = client.post(f"/api/agents/board/cards/{task.id}/accept")
+        assert r.status_code == 409
+        updated = task_manager.get(task.id)
+        assert updated.status == "todo"
+        assert "accepted" not in updated.tags
+
+
+# ---------------------------------------------------------------------------
+# Pending questions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestPendingQuestions:
+    def test_answer_invalidates_the_stream_cache(self, client, stores):
+        """Round-2 finding 6(c): answering a question must invalidate
+        `_board_cache` like a lane-move/accept write does, so the stream's
+        next tick doesn't keep serving a pre-answer board for the rest of
+        the TTL."""
+        task_manager, _sched, session_store, _transcript = stores
+        task = task_manager.create("Investigate the outage", tags=["agent-blocked"], status="blocked")
+        session = session_store.create(task_id=task.id, status=STATUS_BLOCKED)
+        qid = session_store.create_pending_question(
+            session_id=session.session_id, task_id=task.id, question="Staging or prod?",
+            sent_message_id=1,
+        )
+        agents_route._board_cache = (time.monotonic(), {"stale": True})
+        r = client.post(f"/api/agents/pending-questions/{qid}/answer", json={"answer": "staging"})
+        assert r.status_code == 200
+        assert agents_route._board_cache is None
+
+    def test_list_and_answer_matches_deposit_answer_columns(self, client, stores):
+        _tm, _sched, session_store, _transcript = stores
+        session = session_store.create(task_id="t1", status=STATUS_BLOCKED)
+        qid = session_store.create_pending_question(
+            session_id=session.session_id,
+            task_id="t1",
+            question="Staging or prod?",
+            sent_message_id=99,
+        )
+
+        r = client.get("/api/agents/pending-questions")
+        assert r.status_code == 200
+        questions = r.json()["questions"]
+        assert len(questions) == 1
+        assert questions[0]["id"] == qid
+        assert questions[0]["question"] == "Staging or prod?"
+        assert questions[0]["task_id"] == "t1"
+        assert questions[0]["session_id"] == session.session_id
+
+        r2 = client.post(f"/api/agents/pending-questions/{qid}/answer", json={"answer": "staging"})
+        assert r2.status_code == 200
+
+        # The row now looks exactly like it would after a Telegram reply via
+        # deposit_answer: answer + answered_at set, nothing else touched.
+        with session_store._connect() as conn:
+            row = dict(conn.execute(
+                "SELECT * FROM pending_questions WHERE id = ?", (qid,),
+            ).fetchone())
+        assert row["answer"] == "staging"
+        assert row["answered_at"] is not None
+        assert row["processed"] == 0
+        assert row["timed_out"] == 0
+
+        # Answered questions drop off the open list.
+        r3 = client.get("/api/agents/pending-questions")
+        assert r3.json()["questions"] == []
+
+    def test_answer_matches_deposit_answer_effect_exactly(self, stores):
+        """Same row state whether answered via deposit_answer (Telegram) or
+        deposit_answer_by_id (board) — the shape worker.py consumes."""
+        _tm, _sched, session_store, _transcript = stores
+        s1 = session_store.create(task_id="t1", status=STATUS_BLOCKED)
+        s2 = session_store.create(task_id="t2", status=STATUS_BLOCKED)
+        qid1 = session_store.create_pending_question(
+            session_id=s1.session_id, task_id="t1", question="Q1", sent_message_id=1,
+        )
+        qid2 = session_store.create_pending_question(
+            session_id=s2.session_id, task_id="t2", question="Q2", sent_message_id=2,
+        )
+
+        session_store.deposit_answer(1, "via telegram")
+        session_store.deposit_answer_by_id(qid2, "via board")
+
+        with session_store._connect() as conn:
+            row1 = dict(conn.execute("SELECT * FROM pending_questions WHERE id = ?", (qid1,)).fetchone())
+            row2 = dict(conn.execute("SELECT * FROM pending_questions WHERE id = ?", (qid2,)).fetchone())
+        assert row1["answer"] == "via telegram"
+        assert row2["answer"] == "via board"
+        for row in (row1, row2):
+            assert row["answered_at"] is not None
+            assert row["processed"] == 0
+            assert row["timed_out"] == 0
+
+    def test_answer_empty_string_is_400(self, client, stores):
+        _tm, _sched, session_store, _transcript = stores
+        session = session_store.create(task_id="t1", status=STATUS_BLOCKED)
+        qid = session_store.create_pending_question(
+            session_id=session.session_id, task_id="t1", question="Q", sent_message_id=1,
+        )
+        r = client.post(f"/api/agents/pending-questions/{qid}/answer", json={"answer": "  "})
+        assert r.status_code == 400
+
+    def test_answer_unknown_question_is_404(self, client, stores):
+        r = client.post("/api/agents/pending-questions/999999/answer", json={"answer": "x"})
+        assert r.status_code == 404
+
+    def test_answer_bare_empty_string_is_400_via_min_length(self, client, stores):
+        """Round-1 finding 10: `answer` now has a min_length, so a bare empty
+        string is rejected by Pydantic validation (whitespace still 400s via
+        the handler's own strip check — see test_answer_empty_string_is_400
+        above). This app's `RequestValidationError` handler (api/main.py)
+        converts every validation failure to 400, not FastAPI's default 422
+        — matching every other `min_length` field in this codebase — so both
+        paths land on the same status code."""
+        _tm, _sched, session_store, _transcript = stores
+        session = session_store.create(task_id="t1", status=STATUS_BLOCKED)
+        qid = session_store.create_pending_question(
+            session_id=session.session_id, task_id="t1", question="Q", sent_message_id=1,
+        )
+        r = client.post(f"/api/agents/pending-questions/{qid}/answer", json={"answer": ""})
+        assert r.status_code == 400
+
+    def test_status_anchor_row_excluded_from_pending_questions(self, client, stores):
+        """Round-1 finding 14: `status_anchor` rows are routing plumbing (see
+        `add_reply_anchors`), never a real question."""
+        _tm, _sched, session_store, _transcript = stores
+        session = session_store.create(task_id="t1", status=STATUS_BLOCKED)
+        session_store.add_reply_anchors(
+            session_id=session.session_id, task_id="t1", message_ids=[5],
+        )
+        r = client.get("/api/agents/pending-questions")
+        assert r.json()["questions"] == []
+
+    def test_answering_already_answered_question_is_404(self, client, stores):
+        """Round-1 finding 14: the second answer attempt on the same
+        question must 404, not silently overwrite the first answer."""
+        _tm, _sched, session_store, _transcript = stores
+        session = session_store.create(task_id="t1", status=STATUS_BLOCKED)
+        qid = session_store.create_pending_question(
+            session_id=session.session_id, task_id="t1", question="Q", sent_message_id=1,
+        )
+        r1 = client.post(f"/api/agents/pending-questions/{qid}/answer", json={"answer": "first"})
+        assert r1.status_code == 200
+        r2 = client.post(f"/api/agents/pending-questions/{qid}/answer", json={"answer": "second"})
+        assert r2.status_code == 404
+        with session_store._connect() as conn:
+            row = dict(conn.execute(
+                "SELECT answer FROM pending_questions WHERE id = ?", (qid,),
+            ).fetchone())
+        assert row["answer"] == "first"
+
+    def test_followup_row_excluded_from_pending_questions(self, client, stores):
+        """Round-1 finding 7: `kind='followup'` rows are completion notices,
+        not real questions — they must not render a fake pending-question
+        badge on a Review card."""
+        task_manager, _sched, session_store, _transcript = stores
+        task = task_manager.create(
+            "Draft the memo", tags=["codex", "agent-completed"], status="done",
+        )
+        session = session_store.create(task_id=task.id, status="completed")
+        session_store.register_completion_followup(
+            session_id=session.session_id, task_id=task.id,
+            sent_message_ids=[7], label="Draft the memo",
+        )
+
+        r = client.get("/api/agents/pending-questions")
+        assert r.json()["questions"] == []
+
+        board = client.get("/api/agents/board").json()
+        review_cards = board["lanes"]["review"]
+        assert len(review_cards) == 1
+        assert review_cards[0]["pending_question"] is None
+
+
+# ---------------------------------------------------------------------------
+# Hermes label fix + Codex stream dispatch (#850)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestHermesLabelAndCodexStream:
+    def test_hermes_routing_labeled_hermes_not_claude(self, client, stores):
+        session_store = stores[2]
+        s = session_store.create(task_id="t1", status="running", routing="hermes")
+        r = client.get("/api/agents/snapshot")
+        assert r.status_code == 200
+        sessions = {sd["session_id"]: sd for sd in r.json()["sessions"]}
+        assert sessions[s.session_id]["model_label"] == "Hermes"
+
+    def test_codex_stream_dispatches_to_codex_ingest_not_lifeos_store(self, client, stores, monkeypatch):
+        """Before #850, /sessions/{id}/stream only special-cased `cc:` — a
+        `cx:` id fell through to the LifeOS transcript store's path-traversal
+        guard and 400'd. It must now dispatch to the Codex ingest path."""
+        called = {}
+
+        async def fake_stream_codex(session_id, backfill):
+            called["session_id"] = session_id
+            yield ": ok\n\n"
+            yield "event: transcript_event\ndata: {\"kind\": \"codex_test\"}\n\n"
+
+        monkeypatch.setattr(agents_route, "_stream_codex_session", fake_stream_codex)
+        monkeypatch.setattr(agents_route, "_codex_enabled", lambda: True)
+        monkeypatch.setattr(
+            "api.services.codex.session_ingest.validate_session_id",
+            lambda sid: sid[len("cx:"):],
+        )
+
+        with client.stream("GET", "/api/agents/sessions/cx:abc123/stream") as r:
+            assert r.status_code == 200
+            body = "".join(r.iter_text())
+        assert called["session_id"] == "cx:abc123"
+        assert "codex_test" in body
+
+    def test_codex_stream_disabled_is_404(self, client, stores, monkeypatch):
+        monkeypatch.setattr(agents_route, "_codex_enabled", lambda: False)
+        r = client.get("/api/agents/sessions/cx:abc123/stream")
+        assert r.status_code == 404
+
+    async def test_stream_codex_session_actually_reads_a_rollout_file(self, stores, monkeypatch, tmp_path):
+        """Round-1 finding 17: `_stream_codex_session` itself was never
+        executed — the dispatch test above monkeypatches the whole generator
+        away. Point `settings.codex_sessions_dir` at a synthetic rollout and
+        drive the real generator directly (not through TestClient — its
+        `_TestClientTransport` fully drains an ASGI call before returning a
+        response, and this generator only ends on a 300s idle timeout, so a
+        real HTTP round trip through it can't complete inside a unit test);
+        it should backfill the file's events unchanged."""
+        from tests.test_codex_ingest import _write_rollout, _session_meta, _agent_event_msg
+        from config.settings import settings
+
+        sessions_dir = tmp_path / "codex_sessions"
+        _write_rollout(sessions_dir, "cafe1234", [
+            _session_meta(),
+            _agent_event_msg(text="hello from a synthetic codex rollout"),
+        ])
+        monkeypatch.setattr(settings, "codex_sessions_dir", str(sessions_dir))
+
+        gen = agents_route._stream_codex_session("cx:cafe1234", 50)
+        chunks = [await gen.__anext__() for _ in range(3)]
+        await gen.aclose()
+
+        body = "".join(chunks)
+        assert chunks[0] == ": ok\n\n"
+        assert body.count("event: transcript_event") == 2
+        assert '"kind": "system_session_meta"' in body
+        assert '"kind": "assistant_message"' in body
+        assert "hello from a synthetic codex rollout" in body

--- a/tests/test_agents_board_open.py
+++ b/tests/test_agents_board_open.py
@@ -1,0 +1,282 @@
+"""Tests for POST /api/agents/board/cards/{id}/open (#851, AC9) and the
+GET /api/agents/models catalog endpoint wired through the same router.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+from api.routes import agent_assignment
+from api.services.agent_worker.session_store import SessionStore
+from api.services.task_manager import TaskManager
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def client():
+    return TestClient(api_main.app)
+
+
+@pytest.fixture
+def manager(tmp_path: Path, monkeypatch):
+    import api.services.task_manager as tm_mod
+    m = TaskManager(vault_path=tmp_path / "vault", index_path=tmp_path / "index.json")
+    monkeypatch.setattr(tm_mod, "get_task_manager", lambda: m)
+    return m
+
+
+@pytest.fixture
+def session_store(tmp_path: Path, monkeypatch):
+    store = SessionStore(db_path=tmp_path / "sessions.db")
+    monkeypatch.setattr(agent_assignment, "_session_store", store)
+    return store
+
+
+@pytest.fixture(autouse=True)
+def _clear_opening_guard():
+    """`agent_assignment._opening_card_ids` (round 1, finding #6) is
+    module-level, process-lifetime state — clear it around every test so
+    one test's card_id can't spuriously 409 a later test that reuses it."""
+    agent_assignment._opening_card_ids.clear()
+    yield
+    agent_assignment._opening_card_ids.clear()
+
+
+@pytest.fixture(autouse=True)
+def _disable_launcher_prereqs(monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "cc_resume_enabled", True)
+    monkeypatch.setattr(settings, "cc_resume_cmd", "wezterm cli spawn --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "codex_resume_enabled", True)
+    monkeypatch.setattr(settings, "codex_resume_cmd", "wezterm cli spawn --cwd {cwd} -- {inner_command}")
+    monkeypatch.setattr(settings, "agent_hosts", {}, raising=False)
+    monkeypatch.setattr("shutil.which", lambda name: None)
+
+
+def test_open_card_not_found(client, manager, session_store):
+    resp = client.post("/api/agents/board/cards/nonexistent/open")
+    assert resp.status_code == 404
+
+
+def test_open_card_no_assignee_tag(client, manager, session_store):
+    task = manager.create(description="fix the thing", tags=["agent"])
+    resp = client.post(f"/api/agents/board/cards/{task.id}/open")
+    assert resp.status_code == 409
+    assert "assignee" in resp.json()["detail"]
+
+
+def test_open_claude_card_spawns_local_launcher(client, manager, session_store, monkeypatch):
+    task = manager.create(description="fix the printer", tags=["agent", "claude"])
+
+    proc = MagicMock()
+    proc.pid = 4242
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(f"/api/agents/board/cards/{task.id}/open")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["opened"] is True
+    assert body["pid"] == 4242
+
+    argv = popen_mock.call_args.args[0]
+    inner_idx = next(i for i, a in enumerate(argv) if a == "--")
+    inner = " ".join(argv[inner_idx + 1:])
+    assert f"LIFEOS_TASK_ID={task.id}" in inner
+    assert "claude" in inner
+    assert "fix the printer" in inner
+
+
+def test_open_codex_card_spawns_local_launcher(client, manager, session_store, monkeypatch):
+    task = manager.create(description="deploy the service", tags=["agent", "codex"])
+
+    proc = MagicMock()
+    proc.pid = 5151
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(f"/api/agents/board/cards/{task.id}/open")
+    assert resp.status_code == 200
+    argv = popen_mock.call_args.args[0]
+    inner_idx = next(i for i, a in enumerate(argv) if a == "--")
+    inner = " ".join(argv[inner_idx + 1:])
+    assert "codex" in inner
+
+
+def test_open_card_not_todo_is_409(client, manager, session_store, monkeypatch):
+    task = manager.create(description="fix the printer", tags=["agent", "claude"])
+    manager.update(task.id, status="in_progress")
+    resp = client.post(f"/api/agents/board/cards/{task.id}/open")
+    assert resp.status_code == 409
+    assert "Assigned" in resp.json()["detail"]
+
+
+def test_open_card_with_running_session_is_409(client, manager, session_store):
+    task = manager.create(description="fix the printer", tags=["agent", "claude"])
+    session_store.create(task_id=task.id, status="running", routing="claude_code")
+    resp = client.post(f"/api/agents/board/cards/{task.id}/open")
+    assert resp.status_code == 409
+    assert "running session" in resp.json()["detail"]
+
+
+def test_open_card_double_click_is_serialized(client, manager, session_store, monkeypatch):
+    """Round 1, finding #6: a genuine double-click — two OS threads racing
+    the SAME check-then-spawn window — must produce exactly one spawn and
+    one 409, not two terminals opened onto the same card. A `threading.Lock`
+    alone doesn't guarantee this (neither `task.status` nor `session_store`
+    change as a side effect of a spawn, so a naive lock would just
+    serialize two SUCCESSFUL spawns) — this proves the `_opening_card_ids`
+    guard actually closes that gap."""
+    import threading as _threading
+    import time as _time
+
+    task = manager.create(description="fix the printer", tags=["agent", "claude"])
+
+    start_barrier = _threading.Barrier(2)
+    call_count = {"n": 0}
+    call_lock = _threading.Lock()
+
+    def _popen_mock(*args, **kwargs):
+        with call_lock:
+            call_count["n"] += 1
+        _time.sleep(0.1)  # widen the race window so an unlocked version would double-spawn
+        proc = MagicMock()
+        proc.pid = 4242
+        return proc
+
+    monkeypatch.setattr("subprocess.Popen", _popen_mock)
+
+    results = []
+
+    def _call():
+        start_barrier.wait()
+        resp = client.post(f"/api/agents/board/cards/{task.id}/open")
+        results.append(resp.status_code)
+
+    threads = [_threading.Thread(target=_call) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert sorted(results) == [200, 409]
+    assert call_count["n"] == 1
+
+
+def test_open_card_reopens_after_grace_period_following_success(client, manager, session_store, monkeypatch):
+    """Round 2, finding #1: `_opening_card_ids` used to be discarded ONLY on
+    a spawn failure, so a card that opened successfully stayed 409'd for
+    the rest of the process lifetime even after the session reached a
+    terminal status and the task went back to `todo`. Advancing past
+    `_OPENING_GRACE_SECONDS` must let a second, genuinely new open through."""
+    task = manager.create(description="fix the printer", tags=["agent", "claude"])
+
+    proc = MagicMock()
+    proc.pid = 4242
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    fake_time = {"t": 1_000.0}
+    monkeypatch.setattr(agent_assignment.time, "monotonic", lambda: fake_time["t"])
+
+    resp = client.post(f"/api/agents/board/cards/{task.id}/open")
+    assert resp.status_code == 200
+    assert popen_mock.call_count == 1
+
+    # A re-open immediately after (still within the grace window) stays
+    # 409'd — the card's just-claimed spot isn't cleared on success.
+    resp = client.post(f"/api/agents/board/cards/{task.id}/open")
+    assert resp.status_code == 409
+    assert popen_mock.call_count == 1
+
+    # The session the first spawn (eventually) registered reaches a
+    # terminal status, and the card goes back to `todo` for reassignment —
+    # mirroring what actually happens minutes later in production.
+    session_store.create(task_id=task.id, status="completed", routing="claude_code")
+    manager.update(task.id, status="todo")
+
+    # Still within the grace window: stays 409'd even though the task/
+    # session state now looks fully reopenable.
+    resp = client.post(f"/api/agents/board/cards/{task.id}/open")
+    assert resp.status_code == 409
+    assert popen_mock.call_count == 1
+
+    # Advance past the grace period — the stale claim expires and a fresh
+    # open is allowed to spawn again.
+    fake_time["t"] += agent_assignment._OPENING_GRACE_SECONDS + 1
+    resp = client.post(f"/api/agents/board/cards/{task.id}/open")
+    assert resp.status_code == 200
+    assert popen_mock.call_count == 2
+
+
+def test_open_card_remote_host_wraps_in_ssh(client, manager, session_store, monkeypatch):
+    from config.settings import settings
+    monkeypatch.setattr(settings, "agent_hosts", {"studio": "user@studio.example"}, raising=False)
+    task = manager.create(
+        description="fix the printer", tags=["agent", "claude"],
+        fields={"host": "studio"},
+    )
+
+    proc = MagicMock()
+    proc.pid = 6161
+    popen_mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    resp = client.post(f"/api/agents/board/cards/{task.id}/open")
+    assert resp.status_code == 200
+    argv = popen_mock.call_args.args[0]
+    assert argv[0] == "ssh"
+    assert "user@studio.example" in argv
+    assert popen_mock.call_args.kwargs["cwd"] is None
+
+
+def test_open_card_unregistered_host_is_409(client, manager, session_store, monkeypatch):
+    task = manager.create(
+        description="fix the printer", tags=["agent", "claude"],
+        fields={"host": "vanished-box"},
+    )
+    resp = client.post(f"/api/agents/board/cards/{task.id}/open")
+    assert resp.status_code == 409
+    assert "vanished-box" in resp.json()["detail"]
+
+
+def test_open_hermes_card_no_conversation_yet_is_409(client, manager, session_store):
+    task = manager.create(description="ask hermes something", tags=["agent", "hermes"])
+    resp = client.post(f"/api/agents/board/cards/{task.id}/open")
+    assert resp.status_code == 409
+
+
+def test_open_hermes_card_with_conversation_returns_open_url(client, manager, session_store):
+    task = manager.create(description="ask hermes something", tags=["agent", "hermes"])
+    session_store.create(task_id=task.id, status="completed", routing="hermes")
+    session_store.set_conversation_id(task.id, "conv-xyz")
+    resp = client.post(f"/api/agents/board/cards/{task.id}/open")
+    assert resp.status_code == 200
+    assert resp.json() == {"open_url": "/chat?conversation=conv-xyz"}
+
+
+def test_get_models_endpoint_returns_engines_shape(client, monkeypatch):
+    from api.services.agent_worker import model_catalog as mc_mod
+
+    async def _fake_get(self, ttl_seconds=None):
+        return {
+            "engines": {"claude": [], "codex": [], "local": [], "hermes": []},
+            "refreshed_at": "2026-01-01T00:00:00Z",
+            "stale": False,
+        }
+
+    monkeypatch.setattr(mc_mod.ModelCatalog, "get", _fake_get)
+    # Force a fresh singleton so the patched class method is used cleanly.
+    monkeypatch.setattr(mc_mod, "_catalog", None)
+
+    resp = client.get("/api/agents/models")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body["engines"].keys()) == {"claude", "codex", "local", "hermes"}
+    assert body["stale"] is False

--- a/tests/test_agents_board_ui_browser.py
+++ b/tests/test_agents_board_ui_browser.py
@@ -1,0 +1,1074 @@
+"""Browser test for the /agents Kanban board (#850).
+
+Serves `web/` itself from an ephemeral port (like
+`test_voice_mic_block_ui_browser.py`) rather than pointing at a running API,
+and stubs every `/api/` call the page makes — the assertions are about the
+JS in `web/agents/board.js` and `web/agents.html`, not the live backend.
+No `requires_server` marker, so this runs at pre-push
+(`browser and not requires_server`).
+
+Covers: drag between lanes (asserts the stubbed PUT lane body; asserts the
+card does NOT move and a toast shows when the stub returns 500), drawer
+notes edit + blur (asserts the stubbed PUT /api/tasks body carries `notes`),
+filters including assignee=me and lane=human_queue combined, and (#859) the
+assignment pickers mounted in the drawer — render from the model catalog,
+one save per picker, the Open action's success and 409 paths, and that
+scheduled cards render no pickers.
+"""
+import copy
+import http.server
+import json
+import re
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+
+# Obviously synthetic — same shape GET /api/agents/models returns (#851).
+_MODEL_CATALOG = {
+    "engines": {
+        "claude": [
+            {"id": "claude-opus-5", "label": "Claude Opus 5", "pricing": None},
+            {"id": "claude-sonnet-5", "label": "Claude Sonnet 5", "pricing": None},
+        ],
+        "codex": [{"id": "gpt-5.5", "label": "GPT-5.5", "pricing": None}],
+        "local": [],
+        "hermes": [],
+    },
+    "refreshed_at": "2026-01-01T00:00:00Z",
+    "stale": False,
+}
+
+# Assignee-name tags board.js's own drawer strips/re-adds on an assignee
+# change (web/agents/board.js ASSIGNEES) — used by the lane stub below to
+# mirror plan_lane_move's tag bookkeeping on a drawer-driven assign (#859
+# review round 2 finding 1).
+_ASSIGNEE_TAGS = {"me", "claude", "codex", "hermes", "local"}
+
+
+class _AgentsHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves the agents board the way api/main.py does: `/agents` is
+    agents.html and the module tree hangs off `/static/`."""
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        if path in ("/agents", "/"):
+            return str(WEB_DIR / "agents.html")
+        if path.startswith("/static/"):
+            return str(WEB_DIR / path[len("/static/"):])
+        return str(WEB_DIR / path.lstrip("/"))
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def agents_base_url():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _AgentsHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+# Obviously synthetic board fixture. Lane derivation itself is unit-tested in
+# tests/test_agent_board.py; this fixture only needs shapes the UI renders.
+def _board_fixture():
+    return {
+        "lanes": {
+            "unassigned": [
+                {
+                    "kind": "task", "id": "t1", "title": "Investigate outage",
+                    "notes": "", "status": "todo", "tags": [], "assignee": None,
+                    "fields": {}, "context": "Inbox", "updated_at": "2026-01-01T00:00:00+00:00",
+                    "session": None, "pending_question": None,
+                },
+            ],
+            "assigned": [
+                {
+                    "kind": "task", "id": "t2", "title": "Ship the release",
+                    "notes": "Draft notes", "status": "todo", "tags": ["me"], "assignee": "me",
+                    "fields": {}, "context": "Work", "updated_at": "2026-01-01T00:00:00+00:00",
+                    "session": None, "pending_question": None,
+                },
+                {
+                    # #859: assignee claude/codex (unlike t2's "me") — used
+                    # by the assignment-picker and Open-action tests.
+                    "kind": "task", "id": "t7", "title": "Deploy the release candidate",
+                    "notes": "", "status": "todo", "tags": ["claude"], "assignee": "claude",
+                    "fields": {}, "context": "Ops", "updated_at": "2026-01-01T00:00:00+00:00",
+                    "session": None, "pending_question": None,
+                },
+            ],
+            "in_progress": [],
+            "human_queue": [
+                {
+                    "kind": "task", "id": "t3", "title": "Debug prod issue",
+                    "notes": "", "status": "blocked", "tags": ["agent-blocked", "codex"], "assignee": "codex",
+                    "fields": {}, "context": "Ops", "updated_at": "2026-01-01T00:00:00+00:00",
+                    "session": None,
+                    "pending_question": {"id": 1, "session_id": "s1", "question": "Which environment?", "asked_at": 0, "bot": None},
+                },
+                {
+                    "kind": "task", "id": "t4", "title": "Ask the operator about timeline",
+                    "notes": "", "status": "blocked", "tags": ["human", "me"], "assignee": "me",
+                    "fields": {}, "context": "Inbox", "updated_at": "2026-01-01T00:00:00+00:00",
+                    "session": None, "pending_question": None,
+                },
+            ],
+            "scheduled": [
+                {
+                    "kind": "schedule", "id": "s1", "name": "Morning briefing",
+                    "message_content": "Good morning", "enabled": True,
+                    "next_fire_at": "2099-01-01T09:00:00+00:00", "recurring": True,
+                    "last_run": None,
+                },
+            ],
+            "review": [],
+            "done": [
+                {
+                    "kind": "task", "id": "t5", "title": "Archive the old runbook",
+                    "notes": "", "status": "done", "tags": [], "assignee": None,
+                    "fields": {}, "context": "Inbox", "updated_at": "2026-01-01T00:00:00+00:00",
+                    "session": None, "pending_question": None,
+                },
+                {
+                    "kind": "task", "id": "t6", "title": "Cancelled duplicate ticket",
+                    "notes": "", "status": "cancelled", "tags": [], "assignee": None,
+                    "fields": {}, "context": "Inbox", "updated_at": "2026-01-01T00:00:00+00:00",
+                    "session": None, "pending_question": None,
+                },
+            ],
+        },
+        "generated_at": 0,
+    }
+
+
+def _move_card_in_state(board_state: dict, card_id: str, target_lane: str) -> None:
+    """Mutate the stub's in-memory board the way a real PUT .../lane would,
+    so a successful move's follow-up GET /api/agents/board reflects it —
+    otherwise the client's re-fetch-after-success would silently snap the
+    card back to its original lane against a static fixture."""
+    for lane_id, cards in board_state["lanes"].items():
+        for card in list(cards):
+            if card["id"] == card_id:
+                cards.remove(card)
+                board_state["lanes"].setdefault(target_lane, []).append(card)
+                return
+
+
+def _stub_routes(page: Page, board_state: dict, lane_calls: list, task_puts: list, lane_status_code: list,
+                  schedule_puts: list, board_stream_frames: list, stream_gate: "threading.Event | None" = None,
+                  lane_response: "list | None" = None, open_calls: "list | None" = None,
+                  open_response: "dict | None" = None):
+    """Stub d3 (offline CDN) + every /api/ call the page makes.
+
+    `open_calls`: appended with each opened card id (POST
+    /api/agents/board/cards/{id}/open). `open_response`, when given, is
+    `{"status": <code>, "detail": <str>}` — the 409 failure path (#859);
+    omitted defaults to a 200 success. `GET /api/agents/models` is served
+    from `_MODEL_CATALOG`.
+
+    `board_stream_frames`: SSE frame strings (each a full
+    "event: board\\ndata: {...}\\n\\n" block), delivered one per *reconnect*
+    — the first connection gets none, the second gets frames[0], the third
+    frames[1], and so on. A `route.fulfill` response is a single static
+    body, so it always closes the EventSource immediately after delivery;
+    Chromium auto-reconnects per the SSE spec, and the `retry: 20` directive
+    below makes that reconnect fast enough for a test to wait on.
+
+    `stream_gate`: when given, every `/board/stream` connection is answered
+    with an empty keep-alive (and a short `retry:` so the client polls back
+    soon) for as long as `not stream_gate.is_set()`, checked fresh on each
+    connection — never any real frame. Once the test calls
+    `stream_gate.set()`, the next connection (at most one retry interval
+    later) gets the real frame-delivery behavior. This check is a plain
+    non-blocking `Event.is_set()`, called synchronously inside the route
+    callback: Playwright Python's sync API dispatches every route callback
+    on its one internal driver thread via a greenlet switch, so an actual
+    *block* here (`stream_gate.wait()`) — or fulfilling from a separate
+    thread to work around that — either freezes every other Playwright call
+    the test makes or raises `greenlet.error: Cannot switch to a different
+    thread` from `route.fulfill()`. Polling `is_set()` avoids both. Used to
+    prove a frame provably arrives only after a specific point in the test
+    (e.g. once a drawer is open and mid-edit) instead of racing page load on
+    a fixed timer (#850 round-2 finding 5). `board_stream_frames` (and
+    `board_state`, if the test wants the two to stay consistent) may be
+    mutated by the caller any time before calling `stream_gate.set()` — the
+    handler reads them fresh on the connection that delivers them.
+    """
+
+    def d3_handler(route):
+        route.fulfill(status=200, content_type="application/javascript", body="window.d3 = window.d3 || {};")
+
+    page.route("**/d3.v7.min.js", d3_handler)
+
+    if open_calls is None:
+        open_calls = []
+
+    stream_attempt = [0]
+
+    def api_handler(route):
+        url = route.request.url
+        method = route.request.method
+
+        if "/api/agents/board/stream" in url:
+            if stream_gate is not None and not stream_gate.is_set():
+                route.fulfill(status=200, content_type="text/event-stream", body="retry: 50\n: ok\n\n")
+                return
+            frame_idx = stream_attempt[0] - 1  # frames start on the 2nd post-gate connection
+            frame = board_stream_frames[frame_idx] if 0 <= frame_idx < len(board_stream_frames) else ""
+            stream_attempt[0] += 1
+            route.fulfill(status=200, content_type="text/event-stream", body=f"retry: 20\n: ok\n\n{frame}")
+            return
+
+        open_match = re.search(r"/api/agents/board/cards/([^/]+)/open$", url)
+        if open_match and method == "POST":
+            open_calls.append(open_match.group(1))
+            if open_response and open_response.get("status", 200) != 200:
+                route.fulfill(
+                    status=open_response["status"],
+                    content_type="application/json",
+                    body=json.dumps({"detail": open_response.get("detail", "boom")}),
+                )
+            else:
+                route.fulfill(status=200, content_type="application/json", body=json.dumps({"ok": True}))
+            return
+
+        if re.search(r"/api/agents/models$", url) and method == "GET":
+            route.fulfill(status=200, content_type="application/json", body=json.dumps(_MODEL_CATALOG))
+            return
+
+        lane_match = re.search(r"/api/agents/board/cards/([^/]+)/lane$", url)
+        if lane_match and method == "PUT":
+            try:
+                body = json.loads(route.request.post_data or "{}")
+            except ValueError:
+                body = {}
+            lane_calls.append(body)
+            code = lane_status_code[0]
+            if code == 200:
+                # `lane_response`, when given, lets a test simulate the
+                # server landing a card somewhere other than the requested
+                # lane (e.g. a human_queue card that stays put on an
+                # assign) — one popped entry per successful PUT (#850
+                # round-3 finding 2a).
+                landed = lane_response.pop(0) if lane_response else body.get("lane")
+                _move_card_in_state(board_state, lane_match.group(1), landed)
+                # Mirror plan_lane_move's assignee bookkeeping: the drawer's
+                # assignee select PUTs `assignee` alongside `lane` (#859
+                # review round 2 finding 1) — a drag move omits the key
+                # entirely, so key on `"assignee" in body`, not truthiness,
+                # and also clear on an explicit move to unassigned.
+                if "assignee" in body or body.get("lane") == "unassigned":
+                    assignee = body.get("assignee")
+                    for cards in board_state["lanes"].values():
+                        for card in cards:
+                            if card["id"] != lane_match.group(1):
+                                continue
+                            others = [t for t in card.get("tags", []) if t.lower() not in _ASSIGNEE_TAGS]
+                            card["assignee"] = assignee or None
+                            card["tags"] = ([assignee] if assignee else []) + others
+                route.fulfill(status=200, content_type="application/json", body=json.dumps({"id": lane_match.group(1), "lane": landed}))
+            else:
+                route.fulfill(status=code, content_type="application/json", body=json.dumps({"detail": "boom"}))
+            return
+
+        task_match = re.search(r"/api/tasks/([^/]+)$", url)
+        if task_match and method == "PUT":
+            try:
+                body = json.loads(route.request.post_data or "{}")
+            except ValueError:
+                body = {}
+            task_puts.append(body)
+            # Mutate the fixture card the way a real PUT would, so a test
+            # that reopens the drawer to check a saved value doesn't see
+            # the stale fixture (mirrors _move_card_in_state; #859 trap 3).
+            task_id = task_match.group(1)
+            for cards in board_state["lanes"].values():
+                for card in cards:
+                    if card["id"] != task_id:
+                        continue
+                    if "fields" in body and isinstance(body["fields"], dict):
+                        fields = card.setdefault("fields", {})
+                        for key, value in body["fields"].items():
+                            if value is None:
+                                fields.pop(key, None)
+                            else:
+                                fields[key] = value
+                    if "notes" in body:
+                        card["notes"] = body["notes"]
+                    if "tags" in body:
+                        card["tags"] = body["tags"]
+                    if "context" in body:
+                        card["context"] = body["context"]
+                    if "description" in body:
+                        card["title"] = body["description"]
+            route.fulfill(status=200, content_type="application/json", body=json.dumps({"id": task_id}))
+            return
+
+        schedule_match = re.search(r"/api/scheduler/([^/]+)$", url)
+        if schedule_match and method == "PUT":
+            try:
+                body = json.loads(route.request.post_data or "{}")
+            except ValueError:
+                body = {}
+            schedule_puts.append(body)
+            route.fulfill(status=200, content_type="application/json", body=json.dumps({"id": schedule_match.group(1)}))
+            return
+
+        if re.search(r"/api/agents/board$", url) and method == "GET":
+            route.fulfill(status=200, content_type="application/json", body=json.dumps(board_state))
+            return
+
+        # Everything else the page might touch (pending-questions answer,
+        # session focus/kill, task creation) — a harmless empty JSON body.
+        route.fulfill(status=200, content_type="application/json", body="{}")
+
+    page.route("**/api/**", api_handler)
+
+
+def _open_board(page: Page, base_url, board_state=None, lane_calls=None, task_puts=None, lane_status_code=None,
+                 schedule_puts=None, board_stream_frames=None, stream_gate=None, lane_response=None,
+                 open_calls=None, open_response=None):
+    _stub_routes(
+        page,
+        board_state if board_state is not None else _board_fixture(),
+        lane_calls if lane_calls is not None else [],
+        task_puts if task_puts is not None else [],
+        lane_status_code if lane_status_code is not None else [200],
+        schedule_puts if schedule_puts is not None else [],
+        board_stream_frames if board_stream_frames is not None else [],
+        stream_gate,
+        lane_response,
+        open_calls,
+        open_response,
+    )
+    page.goto(f"{base_url}/agents")
+    page.wait_for_selector('[data-card-id="t1"]')
+
+
+def _wait_for(predicate, page: Page, timeout_ms=5000, interval_ms=25):
+    """Poll `predicate` until it's truthy or the timeout elapses — for
+    asserting on a plain Python side effect (e.g. an appended stub call)
+    that has no DOM signal Playwright's own `expect(...)` can wait on.
+
+    `page` is required: Playwright Python's sync API only advances its
+    internal event loop — and so only delivers an already-arrived
+    intercepted request's route callback — from inside a call back into
+    Playwright, via a greenlet switch tied to the calling thread. A pure
+    `time.sleep()` poll never makes such a call, so a route callback that
+    already landed can sit undelivered for the whole timeout regardless of
+    what else is happening on the page. `page.wait_for_timeout(...)` is
+    itself a Playwright call, so using it as the poll's sleep also serves
+    as the pump — no separate `evaluate()` + `time.sleep()` pair needed."""
+    deadline = time.monotonic() + timeout_ms / 1000
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        page.wait_for_timeout(interval_ms)
+    assert predicate(), f"condition not met within {timeout_ms}ms"
+
+
+def _drag_card(page: Page, card_id: str, target_lane: str):
+    card = page.locator(f'[data-card-id="{card_id}"]')
+    card_box = card.bounding_box()
+    lane_cards = page.locator(f'.board-lane[data-lane="{target_lane}"] .board-lane-cards')
+    lane_box = lane_cards.bounding_box()
+    page.mouse.move(card_box["x"] + card_box["width"] / 2, card_box["y"] + card_box["height"] / 2)
+    page.mouse.down()
+    page.mouse.move(lane_box["x"] + lane_box["width"] / 2, lane_box["y"] + 15, steps=10)
+    page.mouse.move(lane_box["x"] + lane_box["width"] / 2, lane_box["y"] + 15, steps=1)
+    page.mouse.up()
+
+
+class TestBoardLoad:
+    def test_cards_render_in_their_derived_lanes(self, page: Page, agents_base_url):
+        _open_board(page, agents_base_url)
+        expect(page.locator('.board-lane[data-lane="unassigned"] [data-card-id="t1"]')).to_be_visible()
+        expect(page.locator('.board-lane[data-lane="assigned"] [data-card-id="t2"]')).to_be_visible()
+        expect(page.locator('.board-lane[data-lane="human_queue"] [data-card-id="t3"]')).to_be_visible()
+        expect(page.locator('.board-lane[data-lane="human_queue"] [data-card-id="t4"]')).to_be_visible()
+
+    def test_pending_question_shown_on_card(self, page: Page, agents_base_url):
+        _open_board(page, agents_base_url)
+        card = page.locator('[data-card-id="t3"]')
+        expect(card.locator(".board-card-question")).to_contain_text("Which environment?")
+
+
+class TestDragBetweenLanes:
+    def test_drag_issues_lane_put_with_expected_body(self, page: Page, agents_base_url):
+        lane_calls = []
+        _open_board(page, agents_base_url, lane_calls=lane_calls, lane_status_code=[200])
+        _drag_card(page, "t1", "in_progress")
+        # A successful move re-fetches the board; wait for the card to land
+        # in its new lane rather than asserting on a fixed delay.
+        expect(page.locator('.board-lane[data-lane="in_progress"] [data-card-id="t1"]')).to_be_visible(timeout=5000)
+        assert lane_calls == [{"lane": "in_progress"}]
+
+    def test_failed_move_does_not_move_card_and_shows_toast(self, page: Page, agents_base_url):
+        lane_calls = []
+        _open_board(page, agents_base_url, lane_calls=lane_calls, lane_status_code=[500])
+        _drag_card(page, "t1", "in_progress")
+        expect(page.locator(".toast.error")).to_be_visible(timeout=5000)
+        # Card is still where it started — the failed PUT never re-fetched
+        # the board, so nothing moved.
+        expect(page.locator('.board-lane[data-lane="unassigned"] [data-card-id="t1"]')).to_be_visible()
+        expect(page.locator('.board-lane[data-lane="in_progress"] [data-card-id="t1"]')).to_have_count(0)
+        assert lane_calls == [{"lane": "in_progress"}]
+
+    def test_dropping_on_assigned_lane_defaults_assignee_to_me(self, page: Page, agents_base_url):
+        lane_calls = []
+        _open_board(page, agents_base_url, lane_calls=lane_calls, lane_status_code=[200])
+        _drag_card(page, "t1", "assigned")
+        expect(page.locator('.board-lane[data-lane="assigned"] [data-card-id="t1"]')).to_be_visible(timeout=5000)
+        assert lane_calls == [{"lane": "assigned", "assignee": "me"}]
+
+
+class TestDrawerNotesEdit:
+    def test_editing_notes_and_blurring_saves(self, page: Page, agents_base_url):
+        task_puts = []
+        _open_board(page, agents_base_url, task_puts=task_puts)
+        page.locator('[data-card-id="t2"]').click()
+        notes = page.locator(".drawer-notes")
+        expect(notes).to_be_visible()
+        notes.fill("Updated notes from the drawer")
+        page.locator(".drawer-title").click()  # blur the notes field
+        expect(page.locator(".drawer-notes")).to_have_value("Updated notes from the drawer")
+        assert any(p.get("notes") == "Updated notes from the drawer" for p in task_puts), task_puts
+
+
+class TestDrawerTagsEdit:
+    def test_invalid_and_assignee_tokens_are_dropped(self, page: Page, agents_base_url):
+        """Round-1 finding 8: the Tags field must not let a vault-comment
+        injection or a duplicate assignee token reach the task store. t2 is
+        assigned #me — typing an assignee token, a plain word, and an
+        HTML-comment-shaped token must save only the plain word alongside
+        the real assignee tag."""
+        task_puts = []
+        _open_board(page, agents_base_url, task_puts=task_puts)
+        page.locator('[data-card-id="t2"]').click()
+        tags = page.locator(".drawer-tags")
+        expect(tags).to_be_visible()
+        tags.fill("codex foo <!--id:abc-->")
+        page.locator(".drawer-title").click()  # blur the tags field
+        expect(page.locator(".toast.error")).to_be_visible(timeout=5000)
+        expect(tags).to_have_value("foo")
+        assert any(
+            sorted(p.get("tags") or []) == ["foo", "me"] for p in task_puts
+        ), task_puts
+        assert not any("<" in t for p in task_puts for t in (p.get("tags") or []))
+        assert not any("codex" in (p.get("tags") or []) for p in task_puts)
+
+
+class TestDrawerAssigneeRevert:
+    def test_failed_assignee_change_snaps_select_back(self, page: Page, agents_base_url):
+        """Round-1 finding 9: a rejected assignee change (the lane PUT 409s)
+        must not leave the unsaved value showing in the select."""
+        lane_calls = []
+        _open_board(page, agents_base_url, lane_calls=lane_calls, lane_status_code=[500])
+        page.locator('[data-card-id="t2"]').click()
+        assignee = page.locator(".drawer-assignee")
+        expect(assignee).to_have_value("me")
+        assignee.select_option("codex")
+        expect(page.locator(".toast.error")).to_be_visible(timeout=5000)
+        expect(assignee).to_have_value("me")
+        assert lane_calls == [{"lane": "assigned", "assignee": "codex"}]
+
+
+class TestScheduledCardDrawer:
+    def test_editing_title_message_and_enabled_all_save_through_scheduler_api(self, page: Page, agents_base_url):
+        """Round-1 finding 4: the scheduled card's title, message, and
+        enabled checkbox save through PUT /api/scheduler/{id}, not a new
+        board write path. Round-2 finding 9: the docstring claimed all
+        three but only title was ever exercised — the message textarea's
+        blur handler and the enabled checkbox's change handler
+        (web/agents/board.js) were untested."""
+        schedule_puts = []
+        _open_board(page, agents_base_url, schedule_puts=schedule_puts)
+        page.locator('[data-card-id="s1"]').click()
+        title = page.locator(".drawer-title")
+        message = page.locator(".drawer-notes")
+        enabled = page.locator('[data-field="enabled"]')
+        expect(title).to_have_value("Morning briefing")
+        title.fill("Evening briefing")
+        message.click()  # blur the title field
+        expect(message).to_have_value("Good morning")
+        _wait_for(lambda: {"name": "Evening briefing"} in schedule_puts, page=page)
+
+        # Blur message straight into the checkbox (never back through title —
+        # title's own blur handler compares against the value captured when
+        # its DOM node was created, and staying focused inside the drawer
+        # deliberately skips re-rendering it (#850 round-2 finding 4), so a
+        # second title blur here would re-save the same unchanged value).
+        message.fill("Good evening")
+        expect(enabled).to_be_checked()
+        enabled.uncheck()  # blurs message, then toggles enabled
+        _wait_for(lambda: {"message_content": "Good evening"} in schedule_puts, page=page)
+        _wait_for(lambda: {"enabled": False} in schedule_puts, page=page)
+
+        assert schedule_puts == [
+            {"name": "Evening briefing"},
+            {"message_content": "Good evening"},
+            {"enabled": False},
+        ]
+
+
+class TestLiveUpdates:
+    """Round-1 finding 12(b): the SSE live-update path itself was never
+    driven by a browser test — the stub only ever sent the empty ": ok"
+    comment. These deliver a real "event: board" frame on a reconnect."""
+
+    def test_board_frame_moves_a_card_with_no_navigation(self, page: Page, agents_base_url):
+        """#862: withhold the frame behind `stream_gate` (see the sibling
+        drawer tests below) so the "still in unassigned" assertion can't
+        lose a race with the stub's `retry: 20` reconnect on a slow first
+        paint — previously flaky (measured 6/30 and 3/30 in #860's
+        verification) because that frame could already have landed by the
+        time the first assertion polled."""
+        stream_gate = threading.Event()
+        moved_board = copy.deepcopy(_board_fixture())
+        _move_card_in_state(moved_board, "t1", "in_progress")
+        frame = f"event: board\ndata: {json.dumps(moved_board)}\n\n"
+
+        _open_board(page, agents_base_url, board_stream_frames=[frame], stream_gate=stream_gate)
+        expect(page.locator('.board-lane[data-lane="unassigned"] [data-card-id="t1"]')).to_be_visible()
+
+        url_before = page.url
+        stream_gate.set()
+        expect(page.locator('.board-lane[data-lane="in_progress"] [data-card-id="t1"]')).to_be_visible(timeout=8000)
+        expect(page.locator('.board-lane[data-lane="unassigned"] [data-card-id="t1"]')).to_have_count(0)
+        assert page.url == url_before  # no page reload/navigation happened
+
+    def test_drawer_notes_survive_a_board_frame_while_typing_and_flushes_on_blur(self, page: Page, agents_base_url):
+        """Round-2 finding 5 (reworks round-1 finding 12(b)'s test, which was
+        a false positive): the prior version delivered its frame on the
+        stub's *second* SSE connection, which — thanks to the `retry: 20`
+        reconnect — landed ~20ms after page load, before the drawer was
+        even opened. The guarded path (updateOpenDrawer's `!focused` check,
+        #850 round-2 finding 4) was therefore never entered; the test
+        passed even with that check deleted.
+
+        This version withholds every `/board/stream` response behind a
+        Python-side `threading.Event` the route handler polls non-blockingly
+        (`stream_gate` — see `_stub_routes`'s docstring for why an actual
+        block would deadlock Playwright's driver thread), so the frame
+        provably cannot arrive until the test releases it — after the
+        drawer is open and mid-edit. It also
+        changes a field on a DIFFERENT card (t1) so there's an unambiguous,
+        drawer-independent signal that the frame was actually applied."""
+        stream_gate = threading.Event()
+        board_state = _board_fixture()
+        board_stream_frames: list[str] = []
+
+        _open_board(
+            page, agents_base_url, board_state=board_state,
+            board_stream_frames=board_stream_frames, stream_gate=stream_gate,
+        )
+        page.locator('[data-card-id="t2"]').click()
+        notes = page.locator(".drawer-notes")
+        title = page.locator(".drawer-title")
+        expect(notes).to_be_visible()
+        expect(title).to_have_value("Ship the release")
+        notes.fill("typed while a tick arrives")  # focus stays in the notes field
+
+        # Mutate the board (a tag on a DIFFERENT card, t1; a title change on
+        # the OPEN card, t2) and only now let the withheld stream connection
+        # respond — proving the frame arrives after this point, not before.
+        for card in board_state["lanes"]["unassigned"]:
+            if card["id"] == "t1":
+                card["tags"] = ["urgent"]
+        for card in board_state["lanes"]["assigned"]:
+            if card["id"] == "t2":
+                card["title"] = "Ship the release (renamed in the vault)"
+        board_stream_frames.append(f"event: board\ndata: {json.dumps(board_state)}\n\n")
+        stream_gate.set()
+
+        # Proof the frame was actually applied: an unrelated card (t1, not
+        # open in the drawer) picks up its new tag chip in the lane view,
+        # which render() always rebuilds regardless of drawer focus.
+        expect(page.locator('[data-card-id="t1"] .board-chip-tag')).to_contain_text(
+            "urgent", timeout=5000,
+        )
+
+        # The open card's drawer must NOT have rebuilt while notes had focus
+        # — the typed text survived, and the title hasn't flushed yet.
+        expect(notes).to_have_value("typed while a tick arrives")
+        expect(title).to_have_value("Ship the release")
+
+        # Leaving the field (not just moving within the drawer — activeElement
+        # must actually leave drawerEl) flushes the deferred change.
+        page.evaluate("() => document.activeElement.blur()")
+        expect(title).to_have_value("Ship the release (renamed in the vault)")
+
+    def test_deferred_frame_flushes_when_focus_leaves_drawer_without_an_edit(self, page: Page, agents_base_url):
+        """#850 round-3 finding 1: the drawerEl `focusout` listener itself
+        must flush a deferred render once focus actually leaves the drawer
+        (blur() to <body>), independent of any field edit. Clicking into
+        notes WITHOUT typing means the notes blur handler's own
+        short-circuit (`value === card.notes`) never fires a PUT or
+        fetchBoard() — the ONLY path left that can flush the deferred
+        frame is the focusout listener. This isolates that listener from
+        the sibling test above, which types text and so is flushed by the
+        notes PUT's own fetchBoard(), never by the listener (verified by
+        temporarily deleting the listener: this test fails, the sibling
+        test above still passes)."""
+        stream_gate = threading.Event()
+        board_state = _board_fixture()
+        board_stream_frames: list[str] = []
+
+        _open_board(
+            page, agents_base_url, board_state=board_state,
+            board_stream_frames=board_stream_frames, stream_gate=stream_gate,
+        )
+        page.locator('[data-card-id="t2"]').click()
+        notes = page.locator(".drawer-notes")
+        title = page.locator(".drawer-title")
+        expect(notes).to_be_visible()
+        expect(title).to_have_value("Ship the release")
+        notes.click()  # focus only, no typing
+
+        for card in board_state["lanes"]["unassigned"]:
+            if card["id"] == "t1":
+                card["tags"] = ["urgent"]
+        for card in board_state["lanes"]["assigned"]:
+            if card["id"] == "t2":
+                card["title"] = "Ship the release (renamed in the vault)"
+        board_stream_frames.append(f"event: board\ndata: {json.dumps(board_state)}\n\n")
+        stream_gate.set()
+
+        # Proof the frame was actually applied: an unrelated card (t1)
+        # picks up its new tag chip in the lane view.
+        expect(page.locator('[data-card-id="t1"] .board-chip-tag')).to_contain_text(
+            "urgent", timeout=5000,
+        )
+        # Still deferred: the open card's drawer hasn't rebuilt yet.
+        expect(title).to_have_value("Ship the release")
+
+        page.evaluate("() => document.activeElement.blur()")
+        expect(title).to_have_value("Ship the release (renamed in the vault)")
+
+    def test_action_button_click_survives_a_deferred_frame(self, page: Page, agents_base_url):
+        """#850 round-3 finding 1: without a `relatedTarget` guard on the
+        focusout listener, mousedown on a drawer action button fires
+        focusout while `document.activeElement` is briefly <body> (focus
+        hasn't landed on the button yet). If a deferred frame is pending at
+        that instant, the drawer gets rebuilt via innerHTML between
+        mousedown and mouseup — the click lands on a now-detached node and
+        the Answer composer never opens."""
+        stream_gate = threading.Event()
+        board_state = _board_fixture()
+        board_stream_frames: list[str] = []
+
+        _open_board(
+            page, agents_base_url, board_state=board_state,
+            board_stream_frames=board_stream_frames, stream_gate=stream_gate,
+        )
+        page.locator('[data-card-id="t3"]').click()  # t3: pending_question id 1
+        notes = page.locator(".drawer-notes")
+        answer_btn = page.get_by_role("button", name="Answer")
+        expect(notes).to_be_visible()
+        expect(answer_btn).to_be_visible()
+        notes.click()  # focus only, no typing
+
+        for card in board_state["lanes"]["unassigned"]:
+            if card["id"] == "t1":
+                card["tags"] = ["urgent"]
+        for card in board_state["lanes"]["human_queue"]:
+            if card["id"] == "t3":
+                card["title"] = "Debug prod issue (renamed)"
+        board_stream_frames.append(f"event: board\ndata: {json.dumps(board_state)}\n\n")
+        stream_gate.set()
+
+        # Proof the frame landed (drawer-independent signal).
+        expect(page.locator('[data-card-id="t1"] .board-chip-tag')).to_contain_text(
+            "urgent", timeout=5000,
+        )
+
+        answer_btn.click()
+        expect(page.locator("#answer-title")).to_be_visible(timeout=3000)
+
+    def test_lane_mismatch_toast_shows_landed_lane(self, page: Page, agents_base_url):
+        """#850 round-2 finding 2b, untested until now: when the server
+        lands a card in a different lane than requested (e.g. a
+        human_queue card that stays put on an assign attempt), the client
+        must toast the actual landed lane instead of leaving the operator
+        to notice the card "snapped back" on its own."""
+        lane_calls = []
+        _open_board(
+            page, agents_base_url, lane_calls=lane_calls,
+            lane_response=["human_queue"],
+        )
+        _drag_card(page, "t4", "assigned")
+        expect(page.locator(".toast")).to_contain_text("landed in Human queue", timeout=5000)
+        assert lane_calls == [{"lane": "assigned", "assignee": "me"}]
+        expect(page.locator('.board-lane[data-lane="human_queue"] [data-card-id="t4"]')).to_be_visible()
+
+    def test_stale_answer_button_cleared_when_pending_question_resolves(self, page: Page, agents_base_url):
+        """#850 round-2 finding 3, untested until now: when a card's
+        pending_question is cleared elsewhere (the agent gets an answer
+        via another channel), the open drawer must swap out the stale
+        Answer button rather than leaving it behind for a second click
+        that would 404."""
+        stream_gate = threading.Event()
+        board_state = _board_fixture()
+        board_stream_frames: list[str] = []
+
+        _open_board(
+            page, agents_base_url, board_state=board_state,
+            board_stream_frames=board_stream_frames, stream_gate=stream_gate,
+        )
+        page.locator('[data-card-id="t3"]').click()  # t3: pending_question id 1, human_queue
+        expect(page.get_by_role("button", name="Answer")).to_be_visible()
+        expect(page.get_by_role("button", name="Resolve")).to_have_count(0)
+
+        for card in board_state["lanes"]["human_queue"]:
+            if card["id"] == "t3":
+                card["pending_question"] = None
+        board_stream_frames.append(f"event: board\ndata: {json.dumps(board_state)}\n\n")
+        stream_gate.set()
+
+        expect(page.get_by_role("button", name="Answer")).to_have_count(0, timeout=5000)
+        expect(page.get_by_role("button", name="Resolve")).to_be_visible()
+
+    def test_kill_button_cleared_when_linked_session_reaches_terminal_status(self, page: Page, agents_base_url):
+        """#850 round-2 finding 3's other half (round-4 finding 1): when the
+        card's linked session reaches a terminal status elsewhere (e.g. the
+        CLI process exits on its own), the open drawer must drop the stale
+        Kill button rather than leaving it behind for a click that would
+        404. Every card in _board_fixture() has session: None, so this half
+        of updateOpenDrawer's `prevSessionStatus !== freshSessionStatus`
+        clause (web/agents/board.js) was never exercised by any test."""
+        stream_gate = threading.Event()
+        board_state = copy.deepcopy(_board_fixture())
+        board_stream_frames: list[str] = []
+
+        for card in board_state["lanes"]["human_queue"]:
+            if card["id"] == "t3":
+                card["session"] = {
+                    "session_id": "s-t3", "status": "running",
+                    "host": "test-host", "routing": "claude_code",
+                    "model_label": "Sonnet", "source": "claude_code",
+                }
+
+        _open_board(
+            page, agents_base_url, board_state=board_state,
+            board_stream_frames=board_stream_frames, stream_gate=stream_gate,
+        )
+        page.locator('[data-card-id="t3"]').click()  # t3: pending_question id 1, human_queue
+        expect(page.get_by_role("button", name="Kill")).to_be_visible()
+
+        for card in board_state["lanes"]["human_queue"]:
+            if card["id"] == "t3":
+                card["session"]["status"] = "ended"
+        board_stream_frames.append(f"event: board\ndata: {json.dumps(board_state)}\n\n")
+        stream_gate.set()
+
+        expect(page.get_by_role("button", name="Kill")).to_have_count(0, timeout=5000)
+
+
+class TestFilters:
+    def test_assignee_me_shows_only_me_cards(self, page: Page, agents_base_url):
+        _open_board(page, agents_base_url)
+        page.locator("#board-filter-assignee").select_option("me")
+        expect(page.locator('[data-card-id="t2"]')).to_be_visible()
+        expect(page.locator('[data-card-id="t4"]')).to_be_visible()
+        expect(page.locator('[data-card-id="t1"]')).to_have_count(0)
+        expect(page.locator('[data-card-id="t3"]')).to_have_count(0)
+
+    def test_lane_human_queue_shows_both_agent_and_human_cards(self, page: Page, agents_base_url):
+        _open_board(page, agents_base_url)
+        page.locator("#board-filter-lane").select_option("human_queue")
+        expect(page.locator('[data-card-id="t3"]')).to_be_visible()
+        expect(page.locator('[data-card-id="t4"]')).to_be_visible()
+        expect(page.locator('[data-card-id="t1"]')).to_have_count(0)
+        expect(page.locator('[data-card-id="t2"]')).to_have_count(0)
+
+    def test_lane_human_queue_and_assignee_me_shows_only_human_card(self, page: Page, agents_base_url):
+        """AC: 'Filtering by lane Human queue and assignee me together shows
+        only #human cards.' t3 is agent-blocked/assignee=codex; t4 is the
+        #human card, tagged #me — only t4 should remain."""
+        _open_board(page, agents_base_url)
+        page.locator("#board-filter-lane").select_option("human_queue")
+        page.locator("#board-filter-assignee").select_option("me")
+        expect(page.locator('[data-card-id="t4"]')).to_be_visible()
+        expect(page.locator('[data-card-id="t3"]')).to_have_count(0)
+        expect(page.locator('[data-card-id="t1"]')).to_have_count(0)
+        expect(page.locator('[data-card-id="t2"]')).to_have_count(0)
+
+    def test_done_lane_visible_by_default_only_cancelled_behind_filter(self, page: Page, agents_base_url):
+        """Round-1 finding 3: the "include cancelled" checkbox only hides
+        cancelled cards — the Done lane itself (finished tasks) stays
+        visible whether it's checked or not."""
+        _open_board(page, agents_base_url)
+        expect(page.locator('[data-card-id="t5"]')).to_be_visible()
+        expect(page.locator('[data-card-id="t6"]')).to_have_count(0)
+        page.locator("#board-filter-done").check()
+        expect(page.locator('[data-card-id="t5"]')).to_be_visible()
+        expect(page.locator('[data-card-id="t6"]')).to_be_visible()
+
+    def test_search_filters_by_title(self, page: Page, agents_base_url):
+        _open_board(page, agents_base_url)
+        page.locator("#board-search").fill("outage")
+        expect(page.locator('[data-card-id="t1"]')).to_be_visible()
+        expect(page.locator('[data-card-id="t2"]')).to_have_count(0)
+        expect(page.locator('[data-card-id="t3"]')).to_have_count(0)
+        expect(page.locator('[data-card-id="t4"]')).to_have_count(0)
+
+    def test_tag_filter(self, page: Page, agents_base_url):
+        _open_board(page, agents_base_url)
+        page.locator("#board-filter-tag").fill("codex")
+        expect(page.locator('[data-card-id="t3"]')).to_be_visible()
+        expect(page.locator('[data-card-id="t1"]')).to_have_count(0)
+        expect(page.locator('[data-card-id="t2"]')).to_have_count(0)
+        expect(page.locator('[data-card-id="t4"]')).to_have_count(0)
+
+    def test_context_filter(self, page: Page, agents_base_url):
+        _open_board(page, agents_base_url)
+        page.locator("#board-filter-context").select_option("Work")
+        expect(page.locator('[data-card-id="t2"]')).to_be_visible()
+        expect(page.locator('[data-card-id="t1"]')).to_have_count(0)
+
+
+class TestTabSwitching:
+    """#850 verify-1 findings 1 and 2: `#board-view { display: flex }`
+    (specificity 1-0-0) and `.chips { display: flex }` (0-1-0) each beat
+    the generic `[hidden]` rule they were relying on, so setting
+    `.hidden = true` on either element never actually hid it. Assert on
+    COMPUTED style, not element reachability — Playwright's own visibility
+    helpers auto-scroll to an element, which hid this bug from every prior
+    test."""
+
+    def _computed_display(self, page: Page, selector: str) -> str:
+        return page.evaluate(
+            "(sel) => getComputedStyle(document.querySelector(sel)).display", selector,
+        )
+
+    def test_graph_tab_hides_board_view_and_chips_and_back(self, page: Page, agents_base_url):
+        _open_board(page, agents_base_url)
+        assert self._computed_display(page, "#board-view") != "none"
+        assert self._computed_display(page, "#graph-chips") == "none"
+
+        page.locator("#tab-btn-graph").click()
+        expect(page.locator("#graph-view")).to_be_visible()
+        assert self._computed_display(page, "#board-view") == "none"
+        assert self._computed_display(page, "#graph-chips") != "none"
+
+        page.locator("#tab-btn-board").click()
+        expect(page.locator("#board-view")).to_be_visible()
+        assert self._computed_display(page, "#board-view") != "none"
+        assert self._computed_display(page, "#graph-chips") == "none"
+
+
+class TestDragThenClick:
+    """#850 verify-1 finding 3: `suppressNextClick` was cleared only inside
+    the card's own click handler, but a drop's re-render replaces every
+    card node and the drag's trailing click often lands on a different
+    element (the drop target lane), so it never reaches that handler — the
+    flag then lingers and swallows the operator's NEXT genuine click on the
+    same card id. Reproduced for both the success path and a rejected
+    (409) move, matching what the verify agent observed live."""
+
+    def test_click_after_successful_drag_opens_drawer(self, page: Page, agents_base_url):
+        lane_calls = []
+        _open_board(page, agents_base_url, lane_calls=lane_calls, lane_status_code=[200])
+        _drag_card(page, "t1", "in_progress")
+        expect(page.locator('.board-lane[data-lane="in_progress"] [data-card-id="t1"]')).to_be_visible(timeout=5000)
+
+        page.locator('[data-card-id="t1"]').click()
+        expect(page.locator(".drawer-title")).to_have_value("Investigate outage")
+
+    def test_click_after_rejected_drag_opens_drawer(self, page: Page, agents_base_url):
+        lane_calls = []
+        _open_board(page, agents_base_url, lane_calls=lane_calls, lane_status_code=[409])
+        _drag_card(page, "t1", "in_progress")
+        expect(page.locator(".toast.error")).to_be_visible(timeout=5000)
+        # The rejected move re-renders in place — card never left "unassigned".
+        expect(page.locator('.board-lane[data-lane="unassigned"] [data-card-id="t1"]')).to_be_visible()
+
+        page.locator('[data-card-id="t1"]').click()
+        expect(page.locator(".drawer-title")).to_have_value("Investigate outage")
+
+
+class TestAssignmentPickers:
+    """#859: web/agents/assignment.js's model/effort/host pickers mounted
+    into the task drawer. t7 (assignee claude, lane Assigned) is the fixture
+    card for these — t2's assignee "me" can't drive the module's own engine
+    select (it only knows claude/codex/local/hermes)."""
+
+    def test_pickers_render_from_model_catalog_with_engine_row_hidden(self, page: Page, agents_base_url):
+        _open_board(page, agents_base_url)
+        page.locator('[data-card-id="t7"]').click()
+        assignment = page.locator(".drawer-assignment")
+        expect(assignment).to_be_visible()
+        # The drawer's OWN Assignee select stays the one assignee writer —
+        # the module's engine row must be hidden, not removed, to avoid a
+        # second, conflicting assignee control.
+        expect(assignment.locator('[data-row="engine"]')).to_be_hidden()
+        expect(assignment.locator('[data-row="model"]')).to_be_visible()
+        expect(assignment.locator('[data-row="effort"]')).to_be_visible()
+        expect(assignment.locator('[data-row="host"]')).to_be_visible()
+        # Model options populate asynchronously once GET /api/agents/models
+        # resolves — default + 2 claude models from _MODEL_CATALOG.
+        expect(assignment.locator("[data-field='model'] option")).to_have_count(3)
+
+    def test_pickers_hidden_for_me_assignee(self, page: Page, agents_base_url):
+        # t2 is assignee "me" — the module's ENGINES list (claude/codex/
+        # local/hermes) has no "me" entry, so its engine select falls back
+        # to no selection and none of model/effort/host accept it.
+        _open_board(page, agents_base_url)
+        page.locator('[data-card-id="t2"]').click()
+        assignment = page.locator(".drawer-assignment")
+        expect(assignment).to_be_attached()
+        expect(assignment.locator('[data-row="model"]')).to_be_hidden()
+        expect(assignment.locator('[data-row="effort"]')).to_be_hidden()
+        expect(assignment.locator('[data-row="host"]')).to_be_hidden()
+
+    def test_assignee_change_with_focus_held_remounts_pickers_and_open(self, page: Page, agents_base_url):
+        """#859 review round 1 finding 1: a native <select> keeps focus
+        after firing `change`, so `updateOpenDrawer`'s `!focused` check
+        would otherwise skip the rebuild and leave the pickers/Open button
+        hidden until focus later left the drawer. board.js's assignee
+        handler must re-render explicitly on its success path
+        (web/agents/board.js ~L649-657) — drive the select directly (no
+        `select_option`, which itself blurs) and assert with no click
+        outside the drawer."""
+        _open_board(page, agents_base_url)
+        page.locator('[data-card-id="t1"]').click()
+        expect(page.locator(".drawer-title")).to_have_value("Investigate outage")
+        page.locator(".drawer-assignee").evaluate(
+            "el => { el.focus(); el.value = 'claude'; "
+            "el.dispatchEvent(new Event('change', { bubbles: true })); }"
+        )
+        expect(page.locator(".drawer-assignment [data-row='model']")).to_be_visible()
+        expect(page.locator(".drawer-assignment [data-row='model']")).to_have_count(1)
+        expect(page.get_by_role("button", name="Open")).to_be_visible()
+        expect(page.get_by_role("button", name="Open")).to_have_count(1)
+
+    def test_changing_model_writes_exactly_one_fields_put(self, page: Page, agents_base_url):
+        task_puts = []
+        _open_board(page, agents_base_url, task_puts=task_puts)
+        page.locator('[data-card-id="t7"]').click()
+        model_select = page.locator(".drawer-assignment [data-field='model']")
+        expect(model_select.locator("option")).to_have_count(3)
+        model_select.select_option("claude-sonnet-5")
+        _wait_for(lambda: any("fields" in p for p in task_puts), page=page)
+        page.wait_for_timeout(100)  # let any second, unwanted PUT land before counting
+        fields_puts = [p for p in task_puts if "fields" in p]
+        assert len(fields_puts) == 1, task_puts
+        assert fields_puts[0] == {
+            "fields": {"model": "claude-sonnet-5", "effort": None, "host": None, "assigned_by": "board"}
+        }
+
+    def test_changing_effort_writes_exactly_one_fields_put(self, page: Page, agents_base_url):
+        task_puts = []
+        _open_board(page, agents_base_url, task_puts=task_puts)
+        page.locator('[data-card-id="t7"]').click()
+        expect(
+            page.locator(".drawer-assignment [data-field='model'] option")
+        ).to_have_count(3)
+        effort_select = page.locator(".drawer-assignment [data-field='effort']")
+        expect(effort_select).to_be_visible()
+        effort_select.select_option("high")
+        _wait_for(lambda: any("fields" in p for p in task_puts), page=page)
+        page.wait_for_timeout(100)  # let any second, unwanted PUT land before counting
+        fields_puts = [p for p in task_puts if "fields" in p]
+        assert len(fields_puts) == 1, task_puts
+        assert fields_puts[0] == {
+            "fields": {"model": None, "effort": "high", "host": None, "assigned_by": "board"}
+        }
+
+    def test_changing_host_writes_exactly_one_fields_put(self, page: Page, agents_base_url):
+        task_puts = []
+        _open_board(page, agents_base_url, task_puts=task_puts)
+        page.locator('[data-card-id="t7"]').click()
+        expect(
+            page.locator(".drawer-assignment [data-field='model'] option")
+        ).to_have_count(3)
+        host_input = page.locator(".drawer-assignment [data-field='host']")
+        expect(host_input).to_be_visible()
+        host_input.fill("build-box-2")
+        host_input.press("Tab")  # text input needs an explicit blur to fire `change`
+        _wait_for(lambda: any("fields" in p for p in task_puts), page=page)
+        page.wait_for_timeout(100)  # let any second, unwanted PUT land before counting
+        fields_puts = [p for p in task_puts if "fields" in p]
+        assert len(fields_puts) == 1, task_puts
+        assert fields_puts[0] == {
+            "fields": {"model": None, "effort": None, "host": "build-box-2", "assigned_by": "board"}
+        }
+
+    def test_saved_model_reflected_on_reopen(self, page: Page, agents_base_url):
+        task_puts = []
+        _open_board(page, agents_base_url, task_puts=task_puts)
+        page.locator('[data-card-id="t7"]').click()
+        model_select = page.locator(".drawer-assignment [data-field='model']")
+        expect(model_select.locator("option")).to_have_count(3)
+        model_select.select_option("claude-sonnet-5")
+        _wait_for(lambda: any("fields" in p for p in task_puts), page=page)
+        page.wait_for_timeout(100)  # let any second, unwanted PUT land before reload
+
+        # The stub mutates the fixture card synchronously before fulfilling
+        # the PUT (mirrors a real save), so a fresh page load's initial
+        # board fetch is guaranteed to see it — reloading avoids racing the
+        # client's own async fetchBoard()-after-save against a click-driven
+        # close+reopen.
+        page.reload()
+        page.wait_for_selector('[data-card-id="t1"]')
+        page.locator('[data-card-id="t7"]').click()
+        reopened_model = page.locator(".drawer-assignment [data-field='model']")
+        expect(reopened_model.locator("option")).to_have_count(3)
+        expect(reopened_model).to_have_value("claude-sonnet-5")
+
+    def test_open_button_posts_and_shows_success_toast(self, page: Page, agents_base_url):
+        open_calls = []
+        _open_board(page, agents_base_url, open_calls=open_calls)
+        page.locator('[data-card-id="t7"]').click()
+        open_btn = page.get_by_role("button", name="Open")
+        expect(open_btn).to_be_visible()
+        open_btn.click()
+        expect(page.locator(".toast:not(.error)")).to_contain_text("Opened.", timeout=5000)
+        assert open_calls == ["t7"]
+
+    def test_open_button_409_shows_detail_in_toast(self, page: Page, agents_base_url):
+        open_calls = []
+        _open_board(
+            page, agents_base_url, open_calls=open_calls,
+            open_response={"status": 409, "detail": "card is not in Assigned state"},
+        )
+        page.locator('[data-card-id="t7"]').click()
+        page.get_by_role("button", name="Open").click()
+        expect(page.locator(".toast.error")).to_contain_text(
+            "card is not in Assigned state", timeout=5000,
+        )
+        assert open_calls == ["t7"]
+
+    def test_open_button_absent_for_non_claude_codex_assignee(self, page: Page, agents_base_url):
+        # t2 is Assigned but assignee "me" — Open is only for claude/codex.
+        _open_board(page, agents_base_url)
+        page.locator('[data-card-id="t2"]').click()
+        expect(page.locator(".drawer-title")).to_have_value("Ship the release")
+        expect(page.get_by_role("button", name="Open")).to_have_count(0)
+
+    def test_open_button_absent_when_not_in_assigned_lane(self, page: Page, agents_base_url):
+        # t3 carries the "codex" assignee tag but sits in Human queue, not
+        # Assigned — the Open action is scoped to the Assigned lane.
+        _open_board(page, agents_base_url)
+        page.locator('[data-card-id="t3"]').click()
+        expect(page.locator(".drawer-title")).to_have_value("Debug prod issue")
+        expect(page.get_by_role("button", name="Open")).to_have_count(0)
+
+    def test_scheduled_card_drawer_has_no_assignment_pickers(self, page: Page, agents_base_url):
+        _open_board(page, agents_base_url)
+        page.locator('[data-card-id="s1"]').click()
+        expect(page.locator(".drawer-schedule-hint")).to_be_visible()
+        expect(page.locator(".drawer-assignment")).to_have_count(0)
+        expect(page.locator(".assignment-row")).to_have_count(0)
+        expect(page.get_by_role("button", name="Open")).to_have_count(0)

--- a/tests/test_agents_board_watch.py
+++ b/tests/test_agents_board_watch.py
@@ -1,0 +1,105 @@
+"""Watcher -> board publish path for the /agents Kanban board (#850).
+
+Acceptance criterion: "The board updates within three seconds of an external
+vault edit without a page reload." The task watcher's debounce is 2.0s (see
+`api/services/task_watcher.py`); this test proves an externally-written tag
+change is visible via the stream's cached read (`_get_board_cached()`, TTL
+`_BOARD_CACHE_TTL = 0.25s`) well inside the remaining budget, using the REAL
+production debounce (not sped up) so the 3s claim is actually exercised end
+to end: real filesystem watcher -> TaskManager.reindex_file ->
+_get_board_cached() reading the same TaskManager instance through the same
+cache the stream's own tick reads. This exercises the debounce leg and the
+cache leg (round-2 finding 7) — it does NOT add the stream's separate
+`_BOARD_STREAM_INTERVAL` (0.5s) tick delay, which only applies to an actual
+SSE connection (covered by `TestBoardStream` in
+tests/test_agents_board_api.py) and is accounted for arithmetically in the
+2.75s worst case documented in docs/specs/technical/agent-viz.md.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+
+import api.services.task_manager as task_manager_module
+import api.services.scheduler_store as scheduler_store_module
+from api.services.task_manager import TaskManager
+from api.services.scheduler_store import SchedulerStore
+from api.services.task_watcher import TaskWatcher, _DEBOUNCE_SECONDS
+from api.routes import agents as agents_route
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    task_manager = TaskManager(
+        vault_path=tmp_path / "vault", index_path=tmp_path / "task_index.json",
+    )
+    monkeypatch.setattr(task_manager_module, "_task_manager", task_manager)
+
+    scheduler_store = SchedulerStore(
+        vault_path=tmp_path / "vault", index_path=tmp_path / "scheduler_index.json",
+    )
+    monkeypatch.setattr(scheduler_store_module, "_scheduler_store", scheduler_store)
+
+    # Board building also touches the session store / snapshot — point those
+    # at empty temp fixtures so the board build doesn't fall over.
+    from api.services.agent_worker.session_store import SessionStore
+    from api.services.agent_worker.transcript_store import TranscriptStore
+    monkeypatch.setattr(agents_route, "_session_store", SessionStore(db_path=tmp_path / "sessions.db"))
+    monkeypatch.setattr(agents_route, "_transcript_store", TranscriptStore(transcripts_dir=tmp_path / "transcripts"))
+    monkeypatch.setattr(agents_route, "_claude_code_snapshot", lambda: ([], []))
+    monkeypatch.setattr(agents_route, "_codex_snapshot", lambda: ([], []))
+    # The board cache (round-2 finding 6) is module-level and TTL'd — reset
+    # it so an earlier test's cached board can't leak into this one.
+    monkeypatch.setattr(agents_route, "_board_cache", None)
+
+    return task_manager, scheduler_store
+
+
+class TestBoardReflectsExternalVaultEditWithinThreeSeconds:
+    async def test_external_tag_edit_moves_lane_within_three_seconds(self, stores):
+        task_manager, _scheduler_store = stores
+        task = task_manager.create("Handle the ticket")
+        first_board = await agents_route._get_board_cached()
+        assert first_board["lanes"]["unassigned"][0]["id"] == task.id
+
+        # Uses the REAL debounce (api/services/task_watcher.py's
+        # _DEBOUNCE_SECONDS = 2.0), not a sped-up test value, so this proves
+        # the actual production timing budget, not an idealized one.
+        watcher = TaskWatcher(tasks_dir=task_manager.tasks_dir, on_change=task_manager.reindex_file)
+        watcher.start()
+        try:
+            inbox = task_manager.tasks_dir / "Inbox.md"
+            content = inbox.read_text(encoding="utf-8")
+            assert task.id in content
+            # Tag the task #me from outside the process — like an operator
+            # editing the vault directly in Obsidian.
+            patched = content.replace(f"<!-- id:{task.id} -->", f"#me <!-- id:{task.id} -->")
+            edit_started_at = time.monotonic()
+            inbox.write_text(patched, encoding="utf-8")
+
+            deadline = edit_started_at + 3.0
+            lane = None
+            while time.monotonic() < deadline:
+                # Read through the same cached path the stream's own tick
+                # uses, not the raw builder — this is the leg round-2
+                # finding 7 asked the test to actually exercise.
+                board = await agents_route._get_board_cached()
+                assigned_ids = [c["id"] for c in board["lanes"]["assigned"]]
+                if task.id in assigned_ids:
+                    lane = "assigned"
+                    break
+                await asyncio.sleep(0.05)
+
+            elapsed = time.monotonic() - edit_started_at
+            assert lane == "assigned", (
+                f"external edit not reflected in the board within 3s "
+                f"(elapsed={elapsed:.2f}s, debounce={_DEBOUNCE_SECONDS}s)"
+            )
+            assert elapsed <= 3.0
+        finally:
+            watcher.stop()

--- a/tests/test_agents_host_filter_ui_browser.py
+++ b/tests/test_agents_host_filter_ui_browser.py
@@ -1,0 +1,222 @@
+"""Browser test for the /agents host filter + side panel fields (#849).
+
+Serves `web/` itself on an ephemeral port and stubs every `/api/` call, the
+same server-free pattern as `tests/test_voice_mic_block_ui_browser.py` —
+the assertions are about the JS in *this* checkout, and `/api/agents/snapshot`
+is the only response that matters, so a live LifeOS API isn't needed. That is
+why this carries no `requires_server` marker and runs at pre-push
+(`browser and not requires_server`).
+
+`/agents` loads d3 from a CDN (`https://d3js.org/d3.v7.min.js`) — only
+`/api/**` is intercepted here (same as the voice test), so that request goes
+to the real network like it does for every other browser test against this
+page family.
+
+#850 made the Kanban board the default /agents view and moved this graph
+(unchanged) behind a Graph tab, lazily initialized on first open — so every
+scenario here clicks into the Graph tab before touching graph-specific
+elements like `#filter-host` or `.node`, which now live in initially-hidden
+markup and aren't wired up until `initGraph()` runs.
+"""
+import http.server
+import json
+import threading
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+
+
+class _AgentsHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves agents.html the way api/main.py does: `/agents` is agents.html
+    and the web/agents/*.js modules (#850) hang off `/static/`."""
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        if path in ("/agents", "/"):
+            return str(WEB_DIR / "agents.html")
+        if path.startswith("/static/"):
+            return str(WEB_DIR / path[len("/static/"):])
+        return str(WEB_DIR / path.lstrip("/"))
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def agents_base_url():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _AgentsHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+# Two sessions on two different hosts — one carries branch + prompt_preview
+# (a cli_sessions row merged onto/registered without a local transcript),
+# the other is a bare local session so the "single host" collapse case
+# (host filter hidden) isn't accidentally exercised by every test.
+SNAPSHOT = {
+    "sessions": [
+        {
+            "session_id": "cc:host-filter-target",
+            "task_id": "t1",
+            "status": "running",
+            "status_inferred": False,
+            "routing": "claude_code",
+            "source": "claude_code",
+            "host": "laptop-a",
+            "branch": "feat/synthetic-branch",
+            "prompt_preview": "refactor the synthetic widget",
+            "started_at": 1000,
+            "last_activity_at": 2000,
+            "total_input_tokens": 10,
+            "total_output_tokens": 20,
+            "total_dollars": 0.01,
+            "spawn_depth": 0,
+            "label": "hosttest-alpha-session",
+            "model_label": "Sonnet",
+            "decoded_cwd": "/home/synthetic/proj-a",
+        },
+        {
+            "session_id": "sess_worker_on_apihost",
+            "task_id": "t2",
+            "status": "running",
+            "status_inferred": False,
+            "routing": "local",
+            "source": "lifeos_agent",
+            "host": "api-host",
+            "started_at": 1000,
+            "last_activity_at": 2000,
+            "total_input_tokens": 5,
+            "total_output_tokens": 5,
+            "total_dollars": 0.0,
+            "spawn_depth": 0,
+            "label": "hosttest-beta-session",
+            "model_label": "Local",
+            "decoded_cwd": "/home/synthetic/proj-b",
+        },
+        # A cli_sessions row whose SessionEnd event already fired — must be
+        # treated as terminal (hidden by default, shown with "include
+        # finished" on) rather than staying in the live view forever (#849
+        # round-1 finding: 'ended' was missing from the frontend TERMINAL set).
+        {
+            "session_id": "cc:host-filter-ended",
+            "task_id": "t3",
+            "status": "ended",
+            "status_inferred": False,
+            "routing": "claude_code",
+            "source": "claude_code",
+            "host": "laptop-a",
+            "branch": "feat/synthetic-branch",
+            "prompt_preview": "wrap up the synthetic widget",
+            "started_at": 1000,
+            "last_activity_at": 2000,
+            "total_input_tokens": 10,
+            "total_output_tokens": 20,
+            "total_dollars": 0.01,
+            "spawn_depth": 0,
+            "label": "hosttest-gamma-session",
+            "model_label": "Sonnet",
+            "decoded_cwd": "/home/synthetic/proj-a",
+        },
+    ],
+    "edges": [],
+    "generated_at": 1234567890,
+}
+
+
+def _open_agents(page: Page, base_url):
+    def handler(route):
+        if "/api/agents/snapshot" in route.request.url:
+            body = SNAPSHOT
+        elif "/api/agents/board" in route.request.url:
+            body = {"lanes": {}, "generated_at": 0}
+        else:
+            body = {}
+        route.fulfill(status=200, content_type="application/json",
+                      body=json.dumps(body))
+
+    page.route("**/api/**", handler)
+    page.goto(f"{base_url}/agents")
+    # #850: the board is the default tab; the graph (and its filters) live
+    # behind the Graph tab and only initialize once it's opened.
+    page.click('[data-tab="graph"]')
+    page.wait_for_selector("#filter-host")
+
+
+class TestHostFilter:
+    def test_filter_host_lists_every_host_from_the_snapshot(self, page: Page, agents_base_url):
+        _open_agents(page, agents_base_url)
+        select = page.locator("#filter-host")
+        options = select.locator("option").all_inner_texts()
+        assert "all" in options
+        assert "laptop-a" in options
+        assert "api-host" in options
+
+    def test_selecting_a_host_hides_sessions_from_other_hosts(self, page: Page, agents_base_url):
+        _open_agents(page, agents_base_url)
+        # Both sessions are recent enough to be visible under the default
+        # 30-minute recency filter only if last_activity_at is "now" — the
+        # fixture's timestamps are fixed epoch seconds in the past, so
+        # widen recency to "all time" first.
+        page.select_option("#filter-recency", "all")
+        page.select_option("#filter-host", "laptop-a")
+        page.wait_for_timeout(400)  # let the filtered re-render settle
+        nodes = page.locator(".node")
+        expect(nodes).to_have_count(1)
+
+
+class TestEndedStatus:
+    # The fixture has 3 sessions total: two 'running' and one 'ended'
+    # (cc:host-filter-ended). 'ended' must be treated as terminal — hidden
+    # by default and only shown once "include finished" is checked (#849
+    # round-1 finding: 'ended' was missing from the frontend TERMINAL set,
+    # so a closed CLI session stayed in the live view indefinitely).
+    def test_ended_session_hidden_by_default(self, page: Page, agents_base_url):
+        _open_agents(page, agents_base_url)
+        page.select_option("#filter-recency", "all")
+        page.wait_for_timeout(400)
+        expect(page.locator(".node")).to_have_count(2)
+
+    def test_ended_session_shown_when_include_finished_is_checked(self, page: Page, agents_base_url):
+        _open_agents(page, agents_base_url)
+        page.select_option("#filter-recency", "all")
+        page.locator("#filter-terminal").check()
+        page.wait_for_timeout(400)
+        expect(page.locator(".node")).to_have_count(3)
+
+
+class TestPanelFields:
+    def test_panel_shows_host_branch_and_prompt_preview(self, page: Page, agents_base_url):
+        _open_agents(page, agents_base_url)
+        page.select_option("#filter-recency", "all")
+        page.locator("#search-input").fill("hosttest-alpha-session")
+        result = page.locator(".search-result", has_text="hosttest-alpha-session")
+        expect(result).to_be_visible()
+        result.click()
+
+        panel = page.locator("#panel")
+        expect(panel.locator('[data-field="host"]')).to_have_text("laptop-a")
+        expect(panel.locator('[data-field="branch-hint"]')).to_contain_text("feat/synthetic-branch")
+        expect(panel.locator('[data-field="prompt-preview-hint"]')).to_contain_text(
+            "refactor the synthetic widget")
+
+    def test_panel_omits_branch_and_prompt_fields_when_absent(self, page: Page, agents_base_url):
+        _open_agents(page, agents_base_url)
+        page.select_option("#filter-recency", "all")
+        page.locator("#search-input").fill("hosttest-beta-session")
+        result = page.locator(".search-result", has_text="hosttest-beta-session")
+        expect(result).to_be_visible()
+        result.click()
+
+        panel = page.locator("#panel")
+        expect(panel.locator('[data-field="host"]')).to_have_text("api-host")
+        expect(panel.locator('[data-field="branch-hint"]')).to_have_count(0)
+        expect(panel.locator('[data-field="prompt-preview-hint"]')).to_have_count(0)

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -1,0 +1,102 @@
+"""
+Tests for api/services/atomic_write.py
+
+The shared atomic-write helper used by both task_manager.py and
+scheduler_store.py: temp file in the same directory, fsync, os.replace.
+"""
+import pytest
+from pathlib import Path
+
+from api.services.atomic_write import atomic_write_text, atomic_write_lines
+
+pytestmark = pytest.mark.unit
+
+
+def test_atomic_write_text_creates_file(tmp_path):
+    target = tmp_path / "sub" / "file.txt"
+    atomic_write_text(target, "hello world")
+    assert target.read_text(encoding="utf-8") == "hello world"
+
+
+def test_atomic_write_text_overwrites_existing_content(tmp_path):
+    target = tmp_path / "file.txt"
+    target.write_text("old", encoding="utf-8")
+    atomic_write_text(target, "new")
+    assert target.read_text(encoding="utf-8") == "new"
+
+
+def test_atomic_write_text_no_leftover_temp_file(tmp_path):
+    target = tmp_path / "file.txt"
+    atomic_write_text(target, "content")
+    assert list(tmp_path.glob(".*.tmp")) == []
+
+
+def test_atomic_write_lines_joins_with_trailing_newline(tmp_path):
+    target = tmp_path / "file.txt"
+    atomic_write_lines(target, ["a", "b", "c"])
+    assert target.read_text(encoding="utf-8") == "a\nb\nc\n"
+
+
+def test_atomic_write_uses_replace_with_temp_file_in_same_dir(tmp_path, monkeypatch):
+    import api.services.atomic_write as aw
+
+    calls = []
+    original = aw.os.replace
+
+    def spy(src, dst):
+        calls.append((src, dst))
+        return original(src, dst)
+
+    monkeypatch.setattr(aw.os, "replace", spy)
+
+    target = tmp_path / "file.txt"
+    atomic_write_text(target, "data")
+
+    assert len(calls) == 1
+    src, dst = calls[0]
+    assert Path(src).parent == target.parent
+    assert dst == str(target)
+
+
+def test_atomic_write_lines_leaves_destination_unchanged_on_replace_failure(tmp_path, monkeypatch):
+    """Same atomic-semantics proof as
+    `test_failed_replace_cleans_up_temp_file_and_leaves_original` below, for
+    `atomic_write_lines` specifically: if `os.replace` fails mid-write, the
+    destination keeps its old content in full and no temp file survives —
+    never a partial write. (The prior version of this test spied on
+    `builtins.open`, but `os.fdopen` routes through `io.open` regardless of
+    write path, so it passed even against a non-atomic `path.write_text` —
+    it proved nothing about atomicity.)"""
+    import api.services.atomic_write as aw
+
+    target = tmp_path / "file.txt"
+    target.write_text("old\n", encoding="utf-8")
+
+    def boom(src, dst):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(aw.os, "replace", boom)
+
+    with pytest.raises(OSError):
+        atomic_write_lines(target, ["new", "lines"])
+
+    assert target.read_text(encoding="utf-8") == "old\n"
+    assert list(tmp_path.glob(".*.tmp")) == []
+
+
+def test_failed_replace_cleans_up_temp_file_and_leaves_original(tmp_path, monkeypatch):
+    import api.services.atomic_write as aw
+
+    def boom(src, dst):
+        raise OSError("simulated failure")
+
+    monkeypatch.setattr(aw.os, "replace", boom)
+
+    target = tmp_path / "file.txt"
+    target.write_text("original", encoding="utf-8")
+
+    with pytest.raises(OSError):
+        atomic_write_text(target, "new data")
+
+    assert list(tmp_path.glob(".*.tmp")) == []
+    assert target.read_text(encoding="utf-8") == "original"

--- a/tests/test_audit_e2e.py
+++ b/tests/test_audit_e2e.py
@@ -1188,6 +1188,13 @@ class TestFuzzySuppressionBatch5:
         from scripts.seed_proactive_reminders import MORNING_BRIEFING_PROMPT
         assert "NOTHING_TO_REPORT" in MORNING_BRIEFING_PROMPT
 
+    def test_morning_briefing_surfaces_human_queue(self):
+        """#852: the morning briefing must surface open Human-queue cards
+        by naming the list tool the orchestrator calls to check them."""
+        from scripts.seed_proactive_reminders import MORNING_BRIEFING_PROMPT
+        assert "Waiting on You" in MORNING_BRIEFING_PROMPT
+        assert "manage_human_queue" in MORNING_BRIEFING_PROMPT
+
 
 # ---------------------------------------------------------------------------
 # Q) chat_via_api HTTP Status Check (Batch 6 — Gap #8 note)

--- a/tests/test_conversation_deep_link_ui_browser.py
+++ b/tests/test_conversation_deep_link_ui_browser.py
@@ -1,0 +1,90 @@
+"""Browser test for the `?conversation=<id>` deep link's URL-encoding
+(round 1 review, PR #858, finding #5).
+
+`web/chat/conversations.js`'s `loadConversation()` — the function
+`main.js`'s `maybeOpenDeepLinkedConversation()` calls with the raw
+`?conversation=` query value — builds its `GET /api/conversations/<id>`
+fetch path by raw string interpolation. Every other conversation-id fetch
+site (`ask-stream.js`, `pending-question.js`) already `encodeURIComponent`s
+the id; this one didn't, so an id containing a path-meaningful character
+(e.g. `/`) silently corrupted the request path instead of reaching the
+conversation the operator actually meant to open.
+
+Serves `web/` itself from an ephemeral port with every `/api/` call
+intercepted, so it runs at pre-push (`browser and not requires_server`) —
+same pattern as tests/test_voice_action_button_ui_browser.py and
+tests/test_backend_selector_ui_browser.py.
+"""
+import http.server
+import json
+import threading
+from pathlib import Path
+from urllib.parse import quote
+
+import pytest
+from playwright.sync_api import Page
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+
+
+class _ChatHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves the chat SPA the way api/main.py does: `/chat` is index.html and
+    the module tree hangs off `/static/`."""
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        if path in ("/chat", "/"):
+            return str(WEB_DIR / "index.html")
+        if path.startswith("/static/"):
+            return str(WEB_DIR / path[len("/static/"):])
+        return str(WEB_DIR / path.lstrip("/"))
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def chat_base_url():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _ChatHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_conversation_deep_link_encodes_id_in_fetch_path(page: Page, chat_base_url):
+    """A `?conversation=` id containing a `/` — meaningful in a URL path —
+    must be percent-encoded before it reaches the fetch call. Unencoded, it
+    would split the request into extra path segments instead of the single
+    `/api/conversations/<id>` GET the endpoint expects."""
+    raw_id = "abc/def"
+    requests: list[str] = []
+
+    def handler(route):
+        url = route.request.url
+        if "/api/conversations/" in url:
+            requests.append(url)
+        route.fulfill(
+            status=200, content_type="application/json",
+            body=json.dumps({"title": "t", "messages": []}),
+        )
+
+    page.route("**/api/**", handler)
+    page.goto(f"{chat_base_url}/chat?conversation={quote(raw_id, safe='')}")
+
+    # main.js awaits window.lifeChat.backendReady before opening the deep
+    # link, so the conversation-detail fetch doesn't fire on first paint —
+    # poll for it rather than asserting immediately.
+    for _ in range(100):
+        if requests:
+            break
+        page.wait_for_timeout(50)
+
+    assert requests, "no /api/conversations/<id> request was made"
+    request_url = requests[0]
+    assert request_url.endswith(f"/api/conversations/{quote(raw_id, safe='')}")
+    assert not request_url.endswith(f"/api/conversations/{raw_id}")  # unencoded would 404 mid-path

--- a/tests/test_human_queue.py
+++ b/tests/test_human_queue.py
@@ -1,0 +1,316 @@
+"""
+Tests for api/services/human_queue.py — the shared card-shape/dedupe/resolve
+logic behind the REST routes, the native chat tool, and the briefing line.
+
+Uses a real TaskManager against a temp vault (not a mock) since the
+dedupe-by-key and resolve-by-id-or-key behavior is the thing under test.
+"""
+import pytest
+
+from api.services import human_queue
+from api.services.task_manager import TaskManager
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def tm(tmp_path, monkeypatch):
+    manager = TaskManager(vault_path=tmp_path / "vault", index_path=tmp_path / "task_index.json")
+    monkeypatch.setattr(human_queue, "get_task_manager", lambda: manager)
+    return manager
+
+
+class TestValidateDoneWhen:
+    def test_none_passes_through(self):
+        assert human_queue.validate_done_when(None) is None
+
+    def test_endpoint_type_ok(self):
+        dw = {"type": "endpoint", "path": "/api/example/status", "pointer": "/status", "equals": "ok"}
+        assert human_queue.validate_done_when(dw) == dw
+
+    def test_file_exists_type_ok(self):
+        dw = {"type": "file_exists", "path": "/tmp/example-flag"}
+        assert human_queue.validate_done_when(dw) == dw
+
+    def test_endpoint_missing_fields_raises(self):
+        with pytest.raises(human_queue.DoneWhenError):
+            human_queue.validate_done_when({"type": "endpoint", "path": "/x"})
+
+    def test_file_exists_missing_path_raises(self):
+        with pytest.raises(human_queue.DoneWhenError):
+            human_queue.validate_done_when({"type": "file_exists"})
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(human_queue.DoneWhenError):
+            human_queue.validate_done_when({"type": "shell", "command": "rm -rf /"})
+
+    def test_non_dict_raises(self):
+        with pytest.raises(human_queue.DoneWhenError):
+            human_queue.validate_done_when("endpoint")
+
+    @pytest.mark.parametrize("path", ["@host/x", "//host/x", "http://host/x", "host/x"])
+    def test_endpoint_path_must_start_with_single_slash(self, path):
+        """A path that doesn't start with exactly one '/' could re-parse
+        the URL's authority when the worker builds f"{api_base}{path}"
+        (e.g. '@evil/x' -> 'http://localhost:8000@evil/x') — a blind SSRF
+        primitive reachable by any agent that can file a card."""
+        with pytest.raises(human_queue.DoneWhenError):
+            human_queue.validate_done_when(
+                {"type": "endpoint", "path": path, "pointer": "/status", "equals": "ok"}
+            )
+
+    @pytest.mark.parametrize("path", ["/api/x?y=1", "/api/x#f"])
+    def test_endpoint_path_with_query_or_fragment_raises(self, path):
+        """A query string or fragment would let the filer smuggle request
+        parameters into the worker's poll GET — a query-driven
+        side-effecting local request reachable by any agent that can file
+        a card."""
+        with pytest.raises(human_queue.DoneWhenError):
+            human_queue.validate_done_when(
+                {"type": "endpoint", "path": path, "pointer": "/status", "equals": "ok"}
+            )
+
+    def test_endpoint_non_string_path_raises(self):
+        with pytest.raises(human_queue.DoneWhenError):
+            human_queue.validate_done_when(
+                {"type": "endpoint", "path": ["/x"], "pointer": "/status", "equals": "ok"}
+            )
+
+    def test_endpoint_list_equals_raises(self):
+        with pytest.raises(human_queue.DoneWhenError):
+            human_queue.validate_done_when(
+                {"type": "endpoint", "path": "/x", "pointer": "/status", "equals": ["ok"]}
+            )
+
+    def test_endpoint_bracket_in_pointer_raises(self):
+        with pytest.raises(human_queue.DoneWhenError):
+            human_queue.validate_done_when(
+                {"type": "endpoint", "path": "/x", "pointer": "/a]b", "equals": "ok"}
+            )
+
+    def test_endpoint_bracket_in_string_equals_raises(self):
+        with pytest.raises(human_queue.DoneWhenError):
+            human_queue.validate_done_when(
+                {"type": "endpoint", "path": "/x", "pointer": "/status", "equals": "a]b"}
+            )
+
+    def test_endpoint_scalar_equals_types_accepted(self):
+        for equals in (1, 1.5, True, None):
+            dw = {"type": "endpoint", "path": "/x", "pointer": "/status", "equals": equals}
+            assert human_queue.validate_done_when(dw) == dw
+
+    def test_file_exists_non_string_path_raises(self):
+        with pytest.raises(human_queue.DoneWhenError):
+            human_queue.validate_done_when({"type": "file_exists", "path": 5})
+
+    def test_file_exists_empty_path_raises(self):
+        with pytest.raises(human_queue.DoneWhenError):
+            human_queue.validate_done_when({"type": "file_exists", "path": ""})
+
+    def test_file_exists_bracket_in_path_raises(self):
+        with pytest.raises(human_queue.DoneWhenError):
+            human_queue.validate_done_when({"type": "file_exists", "path": "/tmp/a]b"})
+
+
+class TestAddCard:
+    def test_add_creates_blocked_human_task(self, tm):
+        task = human_queue.add_card(title="Re-authenticate example service")
+        assert task.status == "blocked"
+        assert task.tags == ["human"]
+        assert task.description == "Re-authenticate example service"
+
+    def test_add_never_touches_status_of_other_tasks(self, tm):
+        other = tm.create("Unrelated todo")
+        human_queue.add_card(title="Something for the operator")
+        assert tm.get(other.id).status == "todo"
+
+    def test_key_with_slash_raises(self, tm):
+        """A key is interpolated unescaped into the resolve route's URL
+        path segment — '/', '?', '#' would split the path or start a
+        query/fragment, making the card unresolvable by key."""
+        with pytest.raises(ValueError):
+            human_queue.add_card(title="X", key="a/b")
+
+    def test_colon_key_accepted(self, tm):
+        task = human_queue.add_card(title="X", key="sync:gmail")
+        assert tm.get(task.id).fields.get("key") == "sync:gmail"
+
+    def test_key_with_trailing_newline_raises(self, tm):
+        """`$` (unlike `\\Z`) matches just before a trailing newline, and
+        re.match doesn't require consuming the whole string — '^[\\w.:-]+$'
+        would accept 'abc\\n'."""
+        with pytest.raises(ValueError):
+            human_queue.add_card(title="X", key="abc\n")
+
+    @pytest.mark.parametrize("key", [".", ".."])
+    def test_dot_only_key_raises(self, tm, key):
+        """A key of only dots passes the character-class regex but is a
+        path segment URL clients normalize away (RFC 3986 dot-segment
+        resolution) before it reaches the resolve route, making the card
+        unresolvable by key."""
+        with pytest.raises(ValueError):
+            human_queue.add_card(title="X", key=key)
+
+    def test_add_stores_source_and_key_fields(self, tm):
+        task = human_queue.add_card(
+            title="X",
+            key="example-key",
+            source_host="example-host",
+            source_cwd="/home/example/project",
+            source_session="sess-123",
+        )
+        refreshed = tm.get(task.id)
+        assert refreshed.fields["key"] == "example-key"
+        assert refreshed.fields["source_host"] == "example-host"
+        assert refreshed.fields["source_cwd"] == "/home/example/project"
+        assert refreshed.fields["source_session"] == "sess-123"
+
+    def test_add_stores_done_when_as_json_field(self, tm):
+        dw = {"type": "file_exists", "path": "/tmp/flag"}
+        task = human_queue.add_card(title="X", done_when=dw)
+        raw = tm.get(task.id).fields["done_when"]
+        import json
+        assert json.loads(raw) == dw
+
+    def test_add_with_invalid_done_when_raises_before_creating(self, tm):
+        with pytest.raises(human_queue.DoneWhenError):
+            human_queue.add_card(title="X", done_when={"type": "shell"})
+        assert tm.list_tasks(tag="human") == []
+
+    def test_dedupe_open_key_updates_notes_no_duplicate(self, tm):
+        first = human_queue.add_card(title="Re-auth", key="svc-reauth", notes="first notes")
+        second = human_queue.add_card(title="Re-auth", key="svc-reauth", notes="second notes")
+        assert second.id == first.id
+        assert len(tm.list_tasks(tag="human")) == 1
+        assert tm.get(first.id).notes == "second notes"
+
+    def test_dedupe_advances_updated_at(self, tm):
+        first = human_queue.add_card(title="Re-auth", key="svc-reauth", notes="v1")
+        first_updated = tm.get(first.id).updated_at
+        import time
+        time.sleep(0.01)
+        human_queue.add_card(title="Re-auth", key="svc-reauth", notes="v2")
+        assert tm.get(first.id).updated_at > first_updated
+
+    def test_key_only_matching_a_done_card_opens_a_new_one(self, tm):
+        first = human_queue.add_card(title="Re-auth", key="svc-reauth")
+        human_queue.resolve_card("svc-reauth", note="fixed")
+        assert tm.get(first.id).status == "done"
+
+        second = human_queue.add_card(title="Re-auth again", key="svc-reauth")
+        assert second.id != first.id
+        assert tm.get(second.id).status == "blocked"
+        open_cards = tm.list_tasks(tag="human", status="blocked")
+        assert len(open_cards) == 1
+        assert open_cards[0].id == second.id
+
+
+class TestResolveCard:
+    def test_resolve_by_id_marks_done_and_appends_note(self, tm):
+        task = human_queue.add_card(title="X", notes="original notes")
+        resolved = human_queue.resolve_card(task.id, note="fixed it")
+        assert resolved.status == "done"
+        assert "original notes" in resolved.notes
+        assert "fixed it" in resolved.notes
+
+    def test_resolve_by_key(self, tm):
+        task = human_queue.add_card(title="X", key="my-key")
+        resolved = human_queue.resolve_card("my-key", note="done")
+        assert resolved.id == task.id
+        assert resolved.status == "done"
+
+    def test_resolve_unknown_id_or_key_returns_none(self, tm):
+        assert human_queue.resolve_card("does-not-exist") is None
+
+    def test_resolve_already_done_card_by_key_returns_none(self, tm):
+        human_queue.add_card(title="X", key="k")
+        human_queue.resolve_card("k")
+        assert human_queue.resolve_card("k") is None
+
+    def test_resolve_does_not_touch_non_human_task(self, tm):
+        other = tm.create("Unrelated task", tags=["work"])
+        assert human_queue.resolve_card(other.id) is None
+        assert tm.get(other.id).status == "todo"
+
+    def test_resolve_without_note_still_marks_done(self, tm):
+        task = human_queue.add_card(title="X")
+        resolved = human_queue.resolve_card(task.id)
+        assert resolved.status == "done"
+        assert resolved.notes
+
+    def test_resolve_by_key_after_refile_succeeds(self, tm):
+        """Regression: once a key has both a done card (from the first
+        resolve) and a reopened open card (from refiling), resolve-by-key
+        must find the open one, not 404 against the done one."""
+        first = human_queue.add_card(title="X", key="svc-reauth")
+        assert human_queue.resolve_card("svc-reauth", note="fixed").id == first.id
+
+        second = human_queue.add_card(title="X again", key="svc-reauth")
+        assert second.id != first.id
+
+        resolved = human_queue.resolve_card("svc-reauth", note="fixed again")
+        assert resolved is not None
+        assert resolved.id == second.id
+        assert resolved.status == "done"
+
+
+class TestListOpenCards:
+    def test_list_only_returns_open_human_cards(self, tm):
+        open_card = human_queue.add_card(title="Open one")
+        done_card = human_queue.add_card(title="Done one", key="k2")
+        human_queue.resolve_card("k2")
+        tm.create("Unrelated", tags=["work"])
+
+        cards = human_queue.list_open_cards()
+        ids = {c["id"] for c in cards}
+        assert open_card.id in ids
+        assert done_card.id not in ids
+        assert len(cards) == 1
+
+    def test_list_shape(self, tm):
+        human_queue.add_card(
+            title="X", key="k", notes="n",
+            source_host="h", source_cwd="/cwd", source_session="s",
+            done_when={"type": "file_exists", "path": "/tmp/f"},
+        )
+        card = human_queue.list_open_cards()[0]
+        for field in ("id", "title", "key", "notes", "age_hours", "source_host",
+                      "source_cwd", "source_session", "done_when"):
+            assert field in card
+        assert card["key"] == "k"
+        assert card["source_host"] == "h"
+        assert card["source_cwd"] == "/cwd"
+        assert card["source_session"] == "s"
+        assert card["done_when"] == {"type": "file_exists", "path": "/tmp/f"}
+        assert card["age_hours"] is not None and card["age_hours"] >= 0
+
+    def test_list_empty(self, tm):
+        assert human_queue.list_open_cards() == []
+
+    def test_list_drops_ssrf_shaped_done_when_written_via_generic_task_api(self, tm):
+        """R2-1: validate_done_when only gated the human-queue write path
+        (add_card). The generic task-update API can write fields['done_when']
+        directly, so a card created (or edited) that way could carry an
+        unvalidated done_when straight through to the worker, which builds
+        a request URL from done_when.path — a stored-SSRF path around the
+        write-time guard. list_open_cards is the single read path the REST
+        route, the native tool, and the worker's poll all consume, so it
+        must re-validate on the way out."""
+        tm.create(
+            "Re-authenticate example service",
+            status="blocked",
+            tags=["human"],
+            fields={"done_when": '{"type":"endpoint","path":"@evil.example/x","pointer":"/a","equals":"ok"}'},
+        )
+        cards = human_queue.list_open_cards()
+        assert len(cards) == 1
+        assert cards[0]["done_when"] is None
+
+    def test_list_drops_done_when_with_non_string_file_exists_path(self, tm):
+        tm.create(
+            "X", status="blocked", tags=["human"],
+            fields={"done_when": '{"type":"file_exists","path":5}'},
+        )
+        cards = human_queue.list_open_cards()
+        assert len(cards) == 1
+        assert cards[0]["done_when"] is None

--- a/tests/test_human_queue_api.py
+++ b/tests/test_human_queue_api.py
@@ -1,0 +1,225 @@
+"""
+Tests for the /api/tasks/human-queue REST routes (#852).
+
+Uses the real FastAPI app + a real TaskManager against a temp vault (not
+mocks) — the behavior under test (dedupe, resolve, done_when validation) is
+exactly the kind of thing a mock would paper over.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from api.services import human_queue
+from api.services.task_manager import TaskManager
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def tm(tmp_path, monkeypatch):
+    manager = TaskManager(vault_path=tmp_path / "vault", index_path=tmp_path / "task_index.json")
+    monkeypatch.setattr(human_queue, "get_task_manager", lambda: manager)
+    return manager
+
+
+@pytest.fixture
+def client(tm):
+    from api.main import app
+    return TestClient(app)
+
+
+class TestAddRoute:
+    def test_add_creates_card(self, client, tm):
+        resp = client.post("/api/tasks/human-queue", json={"title": "Re-auth example service"})
+        assert resp.status_code == 200
+        task_id = resp.json()["id"]
+        assert tm.get(task_id).status == "blocked"
+        assert tm.get(task_id).tags == ["human"]
+
+    def test_add_stores_source_fields(self, client, tm):
+        resp = client.post("/api/tasks/human-queue", json={
+            "title": "X",
+            "source_host": "example-host",
+            "source_cwd": "/home/example",
+            "source_session": "sess-1",
+        })
+        task = tm.get(resp.json()["id"])
+        assert task.fields["source_host"] == "example-host"
+        assert task.fields["source_cwd"] == "/home/example"
+        assert task.fields["source_session"] == "sess-1"
+
+    def test_dedupe_by_open_key_returns_same_id_and_replaces_notes(self, client, tm):
+        first = client.post("/api/tasks/human-queue", json={
+            "title": "X", "key": "svc-reauth", "notes": "v1",
+        }).json()
+        second = client.post("/api/tasks/human-queue", json={
+            "title": "X", "key": "svc-reauth", "notes": "v2",
+        }).json()
+        assert second["id"] == first["id"]
+        assert tm.get(first["id"]).notes == "v2"
+        assert len(tm.list_tasks(tag="human")) == 1
+
+    def test_reopen_after_done_creates_new_card(self, client, tm):
+        first = client.post("/api/tasks/human-queue", json={"title": "X", "key": "k"}).json()
+        client.put("/api/tasks/human-queue/k/resolve", json={})
+        second = client.post("/api/tasks/human-queue", json={"title": "X again", "key": "k"}).json()
+        assert second["id"] != first["id"]
+        assert tm.get(second["id"]).status == "blocked"
+
+    def test_valid_done_when_endpoint_type_accepted(self, client, tm):
+        resp = client.post("/api/tasks/human-queue", json={
+            "title": "X",
+            "done_when": {"type": "endpoint", "path": "/api/example/status", "pointer": "/status", "equals": "ok"},
+        })
+        assert resp.status_code == 200
+
+    def test_valid_done_when_file_exists_type_accepted(self, client, tm):
+        resp = client.post("/api/tasks/human-queue", json={
+            "title": "X",
+            "done_when": {"type": "file_exists", "path": "/tmp/example-flag"},
+        })
+        assert resp.status_code == 200
+
+    def test_invalid_done_when_type_returns_422(self, client, tm):
+        resp = client.post("/api/tasks/human-queue", json={
+            "title": "X",
+            "done_when": {"type": "shell", "command": "echo hi"},
+        })
+        assert resp.status_code == 422
+
+    def test_done_when_missing_required_key_returns_422(self, client, tm):
+        resp = client.post("/api/tasks/human-queue", json={
+            "title": "X",
+            "done_when": {"type": "endpoint", "path": "/x"},
+        })
+        assert resp.status_code == 422
+
+    def test_missing_title_returns_400(self, client, tm):
+        # title is a required pydantic field with min_length=1 — enforced by
+        # FastAPI's own request-shape validation (400 via the global handler
+        # in api/main.py), distinct from the manual 422 done_when check.
+        resp = client.post("/api/tasks/human-queue", json={})
+        assert resp.status_code == 400
+
+    @pytest.mark.parametrize("path", ["@host/x", "//host/x", "http://host/x"])
+    def test_done_when_path_authority_injection_returns_422(self, client, tm, path):
+        resp = client.post("/api/tasks/human-queue", json={
+            "title": "X",
+            "done_when": {"type": "endpoint", "path": path, "pointer": "/status", "equals": "ok"},
+        })
+        assert resp.status_code == 422
+
+    def test_done_when_non_string_path_returns_422(self, client, tm):
+        resp = client.post("/api/tasks/human-queue", json={
+            "title": "X",
+            "done_when": {"type": "endpoint", "path": 5, "pointer": "/status", "equals": "ok"},
+        })
+        assert resp.status_code == 422
+
+    def test_done_when_list_equals_returns_422(self, client, tm):
+        resp = client.post("/api/tasks/human-queue", json={
+            "title": "X",
+            "done_when": {"type": "endpoint", "path": "/x", "pointer": "/status", "equals": ["ok"]},
+        })
+        assert resp.status_code == 422
+
+    def test_done_when_bracket_in_pointer_returns_422(self, client, tm):
+        resp = client.post("/api/tasks/human-queue", json={
+            "title": "X",
+            "done_when": {"type": "endpoint", "path": "/x", "pointer": "/a]b", "equals": "ok"},
+        })
+        assert resp.status_code == 422
+
+    def test_key_with_slash_returns_422(self, client, tm):
+        resp = client.post("/api/tasks/human-queue", json={"title": "X", "key": "a/b"})
+        assert resp.status_code == 422
+
+
+class TestListRoute:
+    def test_list_returns_open_cards(self, client, tm):
+        client.post("/api/tasks/human-queue", json={"title": "Open card", "key": "k1"})
+        client.post("/api/tasks/human-queue", json={"title": "Done card", "key": "k2"})
+        client.put("/api/tasks/human-queue/k2/resolve", json={})
+
+        resp = client.get("/api/tasks/human-queue")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        titles = {c["title"] for c in body["cards"]}
+        assert titles == {"Open card"}
+
+    def test_list_shape(self, client, tm):
+        client.post("/api/tasks/human-queue", json={
+            "title": "X", "key": "k", "notes": "n",
+            "done_when": {"type": "file_exists", "path": "/tmp/f"},
+        })
+        card = client.get("/api/tasks/human-queue").json()["cards"][0]
+        for field in ("id", "title", "key", "age_hours", "source_host",
+                      "source_cwd", "source_session", "done_when"):
+            assert field in card
+        assert card["done_when"] == {"type": "file_exists", "path": "/tmp/f"}
+
+    def test_list_empty(self, client, tm):
+        resp = client.get("/api/tasks/human-queue")
+        assert resp.json() == {"cards": [], "total": 0}
+
+
+class TestResolveRoute:
+    def test_resolve_by_id(self, client, tm):
+        card = client.post("/api/tasks/human-queue", json={"title": "X"}).json()
+        resp = client.put(f"/api/tasks/human-queue/{card['id']}/resolve", json={"note": "fixed"})
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "done"
+        assert "fixed" in tm.get(card["id"]).notes
+
+    def test_resolve_by_key(self, client, tm):
+        card = client.post("/api/tasks/human-queue", json={"title": "X", "key": "sync:gmail"}).json()
+        resp = client.put("/api/tasks/human-queue/sync:gmail/resolve", json={"note": "fixed"})
+        assert resp.status_code == 200
+        assert resp.json()["id"] == card["id"]
+
+    def test_resolve_unknown_returns_404(self, client, tm):
+        resp = client.put("/api/tasks/human-queue/does-not-exist/resolve", json={})
+        assert resp.status_code == 404
+
+    def test_resolve_without_note_body(self, client, tm):
+        card = client.post("/api/tasks/human-queue", json={"title": "X"}).json()
+        resp = client.put(f"/api/tasks/human-queue/{card['id']}/resolve", json={})
+        assert resp.status_code == 200
+
+    def test_resolve_note_rejected_by_store_returns_422(self, client, tm):
+        """A note the store would reject (here: an HTML comment opener that
+        could forge a task id comment) must map to 422, matching the add
+        route's ValueError -> 422 mapping, not bubble up as a 500."""
+        card = client.post("/api/tasks/human-queue", json={"title": "X"}).json()
+        resp = client.put(
+            f"/api/tasks/human-queue/{card['id']}/resolve",
+            json={"note": "done <!-- id:forged -->"},
+        )
+        assert resp.status_code == 422
+
+    def test_resolve_by_key_after_refile_succeeds(self, client, tm):
+        """Regression: file key -> resolve by key -> refile same key ->
+        resolve by key must succeed, not 404 against the now-done card."""
+        client.post("/api/tasks/human-queue", json={"title": "X", "key": "sync:gmail"})
+        assert client.put("/api/tasks/human-queue/sync:gmail/resolve", json={}).status_code == 200
+
+        second = client.post("/api/tasks/human-queue", json={"title": "X again", "key": "sync:gmail"}).json()
+        resp = client.put("/api/tasks/human-queue/sync:gmail/resolve", json={"note": "fixed again"})
+        assert resp.status_code == 200
+        assert resp.json()["id"] == second["id"]
+
+
+class TestRouteOrderingRegression:
+    """`/human-queue` and `/human-queue/{id_or_key}/resolve` must be matched
+    before `/{task_id}` — otherwise FastAPI would treat "human-queue" as a
+    task_id and this whole surface would 404/misroute."""
+
+    def test_get_human_queue_not_captured_as_task_id(self, client, tm):
+        resp = client.get("/api/tasks/human-queue")
+        assert resp.status_code == 200
+        assert "cards" in resp.json()
+
+    def test_post_human_queue_not_captured_as_task_id(self, client, tm):
+        resp = client.post("/api/tasks/human-queue", json={"title": "X"})
+        assert resp.status_code == 200
+        assert "id" in resp.json()

--- a/tests/test_human_queue_sync.py
+++ b/tests/test_human_queue_sync.py
@@ -1,0 +1,255 @@
+"""
+Tests for the Human-queue integration in scripts/run_all_syncs.py (#852):
+filing a keyed card for a classified sync failure, resolving it on the next
+success, and filing the monarch-reauth card on an expired/missing session.
+
+All HTTP calls are monkeypatched (urllib.request.urlopen) — no network, and
+no dependency on a running API server.
+"""
+import json
+from urllib.parse import urlparse
+
+import pytest
+
+from scripts import run_all_syncs as ras
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeResponse:
+    def __init__(self, body: dict):
+        self._body = json.dumps(body).encode("utf-8")
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _install_fake_urlopen(monkeypatch, calls, responses=None, raise_on=None):
+    """`responses`: {(method, path): body_dict}. `raise_on`: set of
+    (method, path) that should raise instead of responding."""
+    responses = responses or {}
+    raise_on = raise_on or set()
+
+    def fake_urlopen(req, timeout=None):
+        method = req.get_method()
+        path = urlparse(req.full_url).path
+        payload = json.loads(req.data) if req.data else None
+        calls.append((method, path, payload))
+        if (method, path) in raise_on:
+            raise OSError("connection refused")
+        return _FakeResponse(responses.get((method, path), {}))
+
+    monkeypatch.setattr(ras.urllib.request, "urlopen", fake_urlopen)
+
+
+class TestHumanQueueRequestHelpers:
+    def test_file_card_posts_title_notes_key(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls)
+        ras._human_queue_file_card(title="X", notes="why", key="k1")
+        assert calls == [("POST", "/api/tasks/human-queue", {"title": "X", "notes": "why", "key": "k1"})]
+
+    def test_file_card_includes_done_when(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls)
+        dw = {"type": "file_exists", "path": "/tmp/f"}
+        ras._human_queue_file_card(title="X", done_when=dw)
+        assert calls[0][2]["done_when"] == dw
+
+    def test_resolve_key_puts_note(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls)
+        ras._human_queue_resolve_key("sync:example", note="sync succeeded")
+        assert calls == [("PUT", "/api/tasks/human-queue/sync:example/resolve", {"note": "sync succeeded"})]
+
+    def test_open_keys_parses_cards(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls, responses={
+            ("GET", "/api/tasks/human-queue"): {"cards": [{"key": "sync:a"}, {"key": None}, {"key": "sync:b"}]},
+        })
+        assert ras._human_queue_open_keys() == {"sync:a", "sync:b"}
+
+    def test_request_failure_returns_none_never_raises(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls, raise_on={("GET", "/api/tasks/human-queue")})
+        assert ras._human_queue_open_keys() == set()
+
+
+class TestFileHumanQueueCardsForSync:
+    def test_failed_source_files_keyed_card_with_error_text(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls, responses={
+            ("GET", "/api/tasks/human-queue"): {"cards": []},
+        })
+        result = {
+            "failed_sources": ["gmail"],
+            "results": {"gmail": {"success": False, "error": "401 Unauthorized"}},
+        }
+        ras.file_human_queue_cards_for_sync(result)
+        posts = [c for c in calls if c[0] == "POST"]
+        assert len(posts) == 1
+        _, path, payload = posts[0]
+        assert path == "/api/tasks/human-queue"
+        assert payload["key"] == "sync:gmail"
+        assert "401 Unauthorized" in payload["notes"]
+
+    def test_error_text_with_carriage_return_is_sanitized(self, monkeypatch):
+        """A raw \\r desyncs the store's \\n-joined notes body and silently
+        drops the whole card — the filed notes must contain no \\r."""
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls, responses={
+            ("GET", "/api/tasks/human-queue"): {"cards": []},
+        })
+        result = {
+            "failed_sources": ["gmail"],
+            "results": {"gmail": {"success": False, "error": "line one\r\nline two\rline three"}},
+        }
+        ras.file_human_queue_cards_for_sync(result)
+        payload = next(c[2] for c in calls if c[0] == "POST")
+        assert "\r" not in payload["notes"]
+        assert "line one" in payload["notes"] and "line two" in payload["notes"]
+
+    def test_error_text_with_token_is_redacted(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls, responses={
+            ("GET", "/api/tasks/human-queue"): {"cards": []},
+        })
+        result = {
+            "failed_sources": ["telegram"],
+            "results": {"telegram": {"success": False, "error": "failed for bot123456:ABCdefGHIjkl"}},
+        }
+        ras.file_human_queue_cards_for_sync(result)
+        payload = next(c[2] for c in calls if c[0] == "POST")
+        assert "bot123456:ABCdefGHIjkl" not in payload["notes"]
+        assert "bot<REDACTED>" in payload["notes"]
+
+    def test_missing_error_text_defaults_to_generic_message(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls, responses={
+            ("GET", "/api/tasks/human-queue"): {"cards": []},
+        })
+        result = {"failed_sources": ["calendar"], "results": {"calendar": {"success": False}}}
+        ras.file_human_queue_cards_for_sync(result)
+        payload = next(c[2] for c in calls if c[0] == "POST")
+        assert payload["notes"] == "sync failed"
+
+    def test_succeeding_source_with_open_card_is_resolved(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls, responses={
+            ("GET", "/api/tasks/human-queue"): {"cards": [{"key": "sync:slack"}]},
+        })
+        result = {"failed_sources": [], "results": {"slack": {"success": True}}}
+        ras.file_human_queue_cards_for_sync(result)
+        puts = [c for c in calls if c[0] == "PUT"]
+        assert puts == [("PUT", "/api/tasks/human-queue/sync:slack/resolve", {"note": "sync succeeded"})]
+
+    def test_succeeding_source_without_open_card_triggers_no_resolve_call(self, monkeypatch):
+        """Efficiency: don't fire a resolve (and its inevitable 404) for
+        every healthy source on every run — only ones with an actual open
+        card."""
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls, responses={
+            ("GET", "/api/tasks/human-queue"): {"cards": []},
+        })
+        result = {"failed_sources": [], "results": {"gmail": {"success": True}, "calendar": {"success": True}}}
+        ras.file_human_queue_cards_for_sync(result)
+        assert [c for c in calls if c[0] == "PUT"] == []
+
+    def test_failed_source_is_never_also_resolved(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls, responses={
+            ("GET", "/api/tasks/human-queue"): {"cards": [{"key": "sync:gmail"}]},
+        })
+        result = {"failed_sources": ["gmail"], "results": {"gmail": {"success": False, "error": "boom"}}}
+        ras.file_human_queue_cards_for_sync(result)
+        assert [c for c in calls if c[0] == "PUT"] == []
+
+    def test_skipped_source_with_open_card_is_not_resolved(self, monkeypatch):
+        """A pre-run skip (recently_synced, disabled, monthly-not-due, ...)
+        never ran, so its open card must stay open, not be marked 'sync
+        succeeded' just because the source isn't in failed_sources."""
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls, responses={
+            ("GET", "/api/tasks/human-queue"): {"cards": [{"key": "sync:gmail"}]},
+        })
+        result = {
+            "failed_sources": [],
+            "results": {"gmail": {"skipped": True, "reason": "recently_synced"}},
+        }
+        ras.file_human_queue_cards_for_sync(result)
+        assert [c for c in calls if c[0] == "PUT"] == []
+
+    def test_dependency_skipped_source_with_open_card_is_not_resolved(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls, responses={
+            ("GET", "/api/tasks/human-queue"): {"cards": [{"key": "sync:calendar"}]},
+        })
+        result = {
+            "failed_sources": [],
+            "results": {
+                "calendar": {
+                    "skipped": True,
+                    "reason": "dependency_failed",
+                    "failed_dependencies": ["gmail"],
+                }
+            },
+        }
+        ras.file_human_queue_cards_for_sync(result)
+        assert [c for c in calls if c[0] == "PUT"] == []
+
+    def test_never_raises_even_if_every_call_fails(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(
+            monkeypatch, calls,
+            raise_on={("GET", "/api/tasks/human-queue"), ("POST", "/api/tasks/human-queue")},
+        )
+        result = {"failed_sources": ["gmail"], "results": {"gmail": {"success": False, "error": "x"}}}
+        ras.file_human_queue_cards_for_sync(result)  # must not raise
+
+
+class TestFileHumanQueueCardForMonarch:
+    def test_expired_files_card_with_done_when(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls)
+        ras.file_human_queue_card_for_monarch({"status": "expired", "message": "session is 45d old"})
+        assert len(calls) == 1
+        method, path, payload = calls[0]
+        assert method == "POST" and path == "/api/tasks/human-queue"
+        assert payload["key"] == "monarch-reauth"
+        assert payload["notes"] == "session is 45d old"
+        assert payload["done_when"] == {
+            "type": "endpoint",
+            "path": "/api/monarch/session_status",
+            "pointer": "/status",
+            "equals": "ok",
+        }
+
+    def test_missing_files_card(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls)
+        ras.file_human_queue_card_for_monarch({"status": "missing", "message": "no session"})
+        assert len(calls) == 1
+
+    def test_ok_status_does_not_file(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls)
+        ras.file_human_queue_card_for_monarch({"status": "ok", "message": "fine"})
+        assert calls == []
+
+    def test_expiring_soon_does_not_file(self, monkeypatch):
+        """Not yet operator-actionable — only expired/missing should file."""
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls)
+        ras.file_human_queue_card_for_monarch({"status": "expiring_soon", "message": "soon"})
+        assert calls == []
+
+    def test_never_raises_on_request_failure(self, monkeypatch):
+        calls = []
+        _install_fake_urlopen(monkeypatch, calls, raise_on={("POST", "/api/tasks/human-queue")})
+        ras.file_human_queue_card_for_monarch({"status": "expired", "message": "x"})  # must not raise

--- a/tests/test_install_agent_hooks.py
+++ b/tests/test_install_agent_hooks.py
@@ -1,0 +1,165 @@
+"""Tests for scripts/install-agent-hooks.sh (issue #849).
+
+Runs the installer via subprocess against temp copies of a Claude Code
+settings.json and a Codex hooks.json — NEVER the operator's real
+~/.claude/settings.json or ~/.codex/hooks.json, which are pointed at only
+via LIFEOS_CLAUDE_SETTINGS / LIFEOS_CODEX_HOOKS overrides here. Confirms
+idempotency (running twice adds exactly one lifeos-agent-hook.sh entry per
+event) and that every pre-existing entry — a synthetic Orca-like entry, an
+atuin-like entry, a legacy claude-session-pane.sh entry — survives
+byte-for-byte.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "install-agent-hooks.sh"
+BASH = shutil.which("bash") or "/bin/bash"
+
+pytestmark = pytest.mark.unit
+
+_SYNTHETIC_SETTINGS = {
+    "hooks": {
+        "SessionStart": [
+            {"matcher": "*", "hooks": [{"type": "command", "command": "orca-session-hook"}]},
+            {"matcher": "*", "hooks": [{"type": "command", "command": "atuin-init-hook"}]},
+            {"matcher": "*", "hooks": [{"type": "command",
+                                        "command": "/opt/synthetic/scripts/claude-session-pane.sh"}]},
+        ],
+        "Stop": [
+            {"matcher": "*", "hooks": [{"type": "command", "command": "orca-stop-hook"}]},
+        ],
+    },
+    "someOtherTopLevelSetting": "preserve-me",
+}
+
+_SYNTHETIC_HOOKS_JSON = {
+    "hooks": {
+        "SessionStart": [
+            {"matcher": "startup|resume",
+             "hooks": [{"type": "command", "command": "/opt/synthetic/scripts/codex-session-pane.sh"}]},
+        ],
+    },
+}
+
+
+def _run_installer(settings_path: Path, hooks_path: Path):
+    env = {
+        "LIFEOS_CLAUDE_SETTINGS": str(settings_path),
+        "LIFEOS_CODEX_HOOKS": str(hooks_path),
+        "PATH": "/usr/bin:/bin:/usr/local/bin",
+        "HOME": str(settings_path.parent),
+    }
+    return subprocess.run(
+        [BASH, str(SCRIPT)], env=env, capture_output=True, timeout=15,
+    )
+
+
+def _lifeos_entries(hook_list: list[dict]) -> list[dict]:
+    out = []
+    for group in hook_list:
+        for h in group.get("hooks", []):
+            if "lifeos-agent-hook.sh" in h.get("command", ""):
+                out.append(group)
+    return out
+
+
+@pytest.fixture
+def temp_configs(tmp_path: Path):
+    settings_path = tmp_path / "settings.json"
+    hooks_path = tmp_path / "hooks.json"
+    settings_path.write_text(json.dumps(_SYNTHETIC_SETTINGS, indent=2), encoding="utf-8")
+    hooks_path.write_text(json.dumps(_SYNTHETIC_HOOKS_JSON, indent=2), encoding="utf-8")
+    return settings_path, hooks_path
+
+
+@pytest.mark.unit
+def test_installer_adds_one_entry_per_event_and_preserves_existing(temp_configs):
+    settings_path, hooks_path = temp_configs
+    original_settings = copy.deepcopy(_SYNTHETIC_SETTINGS)
+    original_hooks = copy.deepcopy(_SYNTHETIC_HOOKS_JSON)
+
+    r = _run_installer(settings_path, hooks_path)
+    assert r.returncode == 0, r.stderr.decode()
+
+    new_settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    new_hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+
+    # Every pre-existing entry survives unchanged, in the same order.
+    assert new_settings["hooks"]["SessionStart"][:3] == original_settings["hooks"]["SessionStart"]
+    assert new_settings["hooks"]["Stop"][:1] == original_settings["hooks"]["Stop"]
+    assert new_settings["someOtherTopLevelSetting"] == "preserve-me"
+    assert new_hooks["hooks"]["SessionStart"][:1] == original_hooks["hooks"]["SessionStart"]
+
+    # Exactly one lifeos-agent-hook.sh entry per Claude Code event.
+    for event in ("SessionStart", "UserPromptSubmit", "Stop", "SessionEnd"):
+        entries = _lifeos_entries(new_settings["hooks"].get(event, []))
+        assert len(entries) == 1, f"{event}: expected 1 lifeos entry, found {len(entries)}"
+
+    # Exactly one for each Codex event the installer supports; no SessionEnd.
+    for event in ("SessionStart", "UserPromptSubmit", "Stop"):
+        entries = _lifeos_entries(new_hooks["hooks"].get(event, []))
+        assert len(entries) == 1, f"{event}: expected 1 lifeos entry, found {len(entries)}"
+    assert "SessionEnd" not in new_hooks["hooks"]
+
+
+@pytest.mark.unit
+def test_installer_is_idempotent_across_two_runs(temp_configs):
+    settings_path, hooks_path = temp_configs
+
+    r1 = _run_installer(settings_path, hooks_path)
+    assert r1.returncode == 0, r1.stderr.decode()
+    after_first = json.loads(settings_path.read_text(encoding="utf-8"))
+    after_first_hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+
+    r2 = _run_installer(settings_path, hooks_path)
+    assert r2.returncode == 0, r2.stderr.decode()
+    after_second = json.loads(settings_path.read_text(encoding="utf-8"))
+    after_second_hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+
+    assert after_first == after_second
+    assert after_first_hooks == after_second_hooks
+
+    for event in ("SessionStart", "UserPromptSubmit", "Stop", "SessionEnd"):
+        entries = _lifeos_entries(after_second["hooks"].get(event, []))
+        assert len(entries) == 1
+
+
+@pytest.mark.unit
+def test_installer_creates_missing_files(tmp_path: Path):
+    settings_path = tmp_path / "nested" / "settings.json"
+    hooks_path = tmp_path / "nested2" / "hooks.json"
+    assert not settings_path.exists()
+    assert not hooks_path.exists()
+
+    r = _run_installer(settings_path, hooks_path)
+    assert r.returncode == 0, r.stderr.decode()
+
+    new_settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    new_hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+    for event in ("SessionStart", "UserPromptSubmit", "Stop", "SessionEnd"):
+        assert len(_lifeos_entries(new_settings["hooks"].get(event, []))) == 1
+    for event in ("SessionStart", "UserPromptSubmit", "Stop"):
+        assert len(_lifeos_entries(new_hooks["hooks"].get(event, []))) == 1
+
+
+@pytest.mark.unit
+def test_installer_never_writes_a_token(temp_configs):
+    settings_path, hooks_path = temp_configs
+    r = _run_installer(settings_path, hooks_path)
+    assert r.returncode == 0, r.stderr.decode()
+    for path in (settings_path, hooks_path):
+        text = path.read_text(encoding="utf-8")
+        assert "LIFEOS_AGENT_HOOK_TOKEN=" not in text
+
+
+@pytest.mark.unit
+def test_bash_syntax_check():
+    r = subprocess.run([BASH, "-n", str(SCRIPT)], capture_output=True, timeout=5)
+    assert r.returncode == 0, r.stderr.decode()

--- a/tests/test_lifeos_agent_hook.py
+++ b/tests/test_lifeos_agent_hook.py
@@ -1,0 +1,339 @@
+"""Tests for scripts/lifeos-agent-hook.sh (issue #849).
+
+Runs the script via subprocess against a stub HTTP server (a bare
+`http.server` in a thread on an ephemeral port) and asserts on what it
+posted. Every subprocess call clears LIFEOS_AGENT_HOOK_TOKEN and
+LIFEOS_API_URL from the environment and points LIFEOS_AGENT_HOOK_ENV at a
+scratch path, so the operator's real token/URL (this box's real .env and
+~/.config/lifeos/agent-hook.env) can never leak into a test run or be
+read by one.
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import shutil
+import socket
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "lifeos-agent-hook.sh"
+# Resolved once from the real environment, not from a test's (possibly
+# PATH-stripped) subprocess env — the interpreter invoking the script must
+# always be found even when a test is exercising a missing-jq/curl PATH.
+BASH = shutil.which("bash") or "/bin/bash"
+
+pytestmark = pytest.mark.unit
+
+
+class _CapturingHandler(http.server.BaseHTTPRequestHandler):
+    requests: list[dict] = []
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length) if length else b""
+        try:
+            body = json.loads(raw.decode("utf-8")) if raw else None
+        except json.JSONDecodeError:
+            body = None
+        _CapturingHandler.requests.append({
+            "path": self.path,
+            "headers": dict(self.headers),
+            "body": body,
+        })
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"registered": true}')
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture
+def stub_server():
+    _CapturingHandler.requests = []
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _CapturingHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server, _CapturingHandler.requests
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _dead_port() -> int:
+    """A port nothing is listening on: bind then immediately close."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _base_env(tmp_path: Path, **overrides) -> dict:
+    env = dict(os.environ)
+    env.pop("LIFEOS_AGENT_HOOK_TOKEN", None)
+    env.pop("LIFEOS_API_URL", None)
+    env.pop("LIFEOS_TASK_ID", None)
+    env.pop("WEZTERM_PANE", None)
+    env.pop("XDG_RUNTIME_DIR", None)
+    # Never let the script fall back to the operator's real config file.
+    env["LIFEOS_AGENT_HOOK_ENV"] = str(tmp_path / "no-such-agent-hook.env")
+    env.update(overrides)
+    return env
+
+
+def _run(argv, stdin: str, env: dict, timeout: float = 5.0):
+    return subprocess.run(
+        [BASH, str(SCRIPT), *argv],
+        input=stdin.encode("utf-8"),
+        env=env,
+        capture_output=True,
+        timeout=timeout,
+    )
+
+
+@pytest.mark.unit
+def test_bash_syntax_check():
+    r = subprocess.run([BASH, "-n", str(SCRIPT)], capture_output=True, timeout=5)
+    assert r.returncode == 0, r.stderr.decode()
+
+
+@pytest.mark.unit
+def test_posts_session_start_with_expected_fields(stub_server, tmp_path):
+    server, requests = stub_server
+    env = _base_env(
+        tmp_path,
+        LIFEOS_AGENT_HOOK_TOKEN="test-token-value",
+        LIFEOS_API_URL=f"http://127.0.0.1:{server.server_port}",
+        LIFEOS_TASK_ID="task-77",
+    )
+    stdin = json.dumps({
+        "session_id": "hook-sid-1",
+        "cwd": str(tmp_path),
+        "transcript_path": "/tmp/does-not-matter.jsonl",
+        "source": "startup",
+    })
+    r = _run(["claude_code", "session_start"], stdin, env)
+    assert r.returncode == 0, r.stderr.decode()
+    assert r.stdout == b""
+
+    assert len(requests) == 1
+    req = requests[0]
+    assert req["path"] == "/api/agents/cli-sessions/events"
+    assert req["headers"]["Authorization"] == "Bearer test-token-value"
+    body = req["body"]
+    assert body["engine"] == "claude_code"
+    assert body["event"] == "session_start"
+    assert body["session_id"] == "hook-sid-1"
+    assert body["cwd"] == str(tmp_path)
+    assert body["task_id"] == "task-77"
+    assert "host" in body and body["host"]
+    # No git repo in tmp_path -> branch resolves to empty.
+    assert body["branch"] == ""
+    # Outside wezterm -> no pane fields at all.
+    assert "pane_id" not in body
+    assert "wezterm_pid" not in body
+
+
+@pytest.mark.unit
+def test_posts_user_prompt_submit_with_prompt_preview(stub_server, tmp_path):
+    server, requests = stub_server
+    env = _base_env(
+        tmp_path,
+        LIFEOS_AGENT_HOOK_TOKEN="tok",
+        LIFEOS_API_URL=f"http://127.0.0.1:{server.server_port}",
+    )
+    stdin = json.dumps({
+        "session_id": "hook-sid-2",
+        "cwd": str(tmp_path),
+        "prompt": "please refactor the widget",
+    })
+    r = _run(["claude_code", "user_prompt_submit"], stdin, env)
+    assert r.returncode == 0
+    body = requests[0]["body"]
+    assert body["event"] == "user_prompt_submit"
+    assert body["prompt_preview"] == "please refactor the widget"
+
+
+@pytest.mark.unit
+def test_git_branch_resolved_from_cwd(stub_server, tmp_path):
+    server, requests = stub_server
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "synthetic-branch", str(repo)],
+                    check=True, capture_output=True)
+    # An unborn branch (no commits yet) makes `rev-parse --abbrev-ref HEAD`
+    # print the literal "HEAD" on some git versions — commit once so the
+    # branch ref actually resolves.
+    (repo / "f.txt").write_text("x", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "f.txt"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "-c", "user.email=t@example.com", "-c", "user.name=t",
+         "commit", "-q", "-m", "synthetic"],
+        check=True, capture_output=True,
+    )
+    env = _base_env(
+        tmp_path,
+        LIFEOS_AGENT_HOOK_TOKEN="tok",
+        LIFEOS_API_URL=f"http://127.0.0.1:{server.server_port}",
+    )
+    stdin = json.dumps({"session_id": "hook-sid-3", "cwd": str(repo)})
+    r = _run(["codex", "session_start"], stdin, env)
+    assert r.returncode == 0
+    body = requests[0]["body"]
+    assert body["branch"] == "synthetic-branch"
+
+
+@pytest.mark.unit
+def test_pane_fields_present_only_when_wezterm_pane_set(stub_server, tmp_path):
+    server, requests = stub_server
+    rtdir = tmp_path / "xdg"
+    sockdir = rtdir / "wezterm"
+    sockdir.mkdir(parents=True)
+    my_pid = os.getpid()  # always alive for the duration of this test
+    (sockdir / f"gui-sock-{my_pid}").write_text("", encoding="utf-8")
+
+    env = _base_env(
+        tmp_path,
+        LIFEOS_AGENT_HOOK_TOKEN="tok",
+        LIFEOS_API_URL=f"http://127.0.0.1:{server.server_port}",
+        WEZTERM_PANE="42",
+        XDG_RUNTIME_DIR=str(rtdir),
+    )
+    stdin = json.dumps({"session_id": "hook-sid-4", "cwd": str(tmp_path)})
+    r = _run(["claude_code", "stop"], stdin, env)
+    assert r.returncode == 0, r.stderr.decode()
+    body = requests[0]["body"]
+    assert body["pane_id"] == 42
+    assert body["wezterm_pid"] == my_pid
+
+
+@pytest.mark.unit
+def test_non_numeric_wezterm_pane_omits_pane_fields_but_still_posts(stub_server, tmp_path):
+    # A non-numeric $WEZTERM_PANE must not make `jq --argjson pane_id` fail
+    # and empty the whole request body — it should just drop the pane
+    # fields and post everything else normally.
+    server, requests = stub_server
+    env = _base_env(
+        tmp_path,
+        LIFEOS_AGENT_HOOK_TOKEN="tok",
+        LIFEOS_API_URL=f"http://127.0.0.1:{server.server_port}",
+        WEZTERM_PANE="abc",
+    )
+    stdin = json.dumps({"session_id": "hook-sid-4b", "cwd": str(tmp_path)})
+    r = _run(["claude_code", "stop"], stdin, env)
+    assert r.returncode == 0, r.stderr.decode()
+    assert len(requests) == 1
+    body = requests[0]["body"]
+    assert body["session_id"] == "hook-sid-4b"
+    assert "pane_id" not in body
+    assert "wezterm_pid" not in body
+
+
+@pytest.mark.unit
+def test_exits_0_when_api_unreachable_within_two_seconds(tmp_path):
+    env = _base_env(
+        tmp_path,
+        LIFEOS_AGENT_HOOK_TOKEN="tok",
+        LIFEOS_API_URL=f"http://127.0.0.1:{_dead_port()}",
+    )
+    stdin = json.dumps({"session_id": "hook-sid-5", "cwd": str(tmp_path)})
+    start = time.monotonic()
+    r = _run(["claude_code", "session_start"], stdin, env, timeout=5.0)
+    elapsed = time.monotonic() - start
+    assert r.returncode == 0
+    assert r.stdout == b""
+    assert elapsed < 2.0
+
+
+@pytest.mark.unit
+def test_exits_0_when_jq_and_curl_missing(tmp_path):
+    empty_bin = tmp_path / "empty-bin"
+    empty_bin.mkdir()
+    env = _base_env(
+        tmp_path,
+        LIFEOS_AGENT_HOOK_TOKEN="tok",
+        LIFEOS_API_URL="http://127.0.0.1:1",
+        PATH=str(empty_bin),
+    )
+    stdin = json.dumps({"session_id": "hook-sid-6", "cwd": str(tmp_path)})
+    r = _run(["claude_code", "session_start"], stdin, env)
+    assert r.returncode == 0
+    assert r.stdout == b""
+
+
+@pytest.mark.unit
+def test_exits_0_and_makes_no_request_when_no_token_configured(stub_server, tmp_path):
+    server, requests = stub_server
+    env = _base_env(
+        tmp_path,
+        LIFEOS_API_URL=f"http://127.0.0.1:{server.server_port}",
+        # LIFEOS_AGENT_HOOK_TOKEN deliberately absent, and the env file
+        # points at a nonexistent path, so no token is discoverable.
+    )
+    stdin = json.dumps({"session_id": "hook-sid-7", "cwd": str(tmp_path)})
+    r = _run(["claude_code", "session_start"], stdin, env)
+    assert r.returncode == 0
+    assert r.stdout == b""
+    assert requests == []
+
+
+@pytest.mark.unit
+def test_exits_0_on_empty_stdin(tmp_path):
+    env = _base_env(
+        tmp_path,
+        LIFEOS_AGENT_HOOK_TOKEN="tok",
+        LIFEOS_API_URL="http://127.0.0.1:1",
+    )
+    r = _run(["claude_code", "session_start"], "", env)
+    assert r.returncode == 0
+    assert r.stdout == b""
+
+
+@pytest.mark.unit
+def test_env_file_supplies_token_when_environment_unset(stub_server, tmp_path):
+    """Values already in the environment take precedence over the file —
+    but when the environment has none, the file alone is enough."""
+    server, requests = stub_server
+    env_file = tmp_path / "agent-hook.env"
+    env_file.write_text(
+        f'LIFEOS_API_URL=http://127.0.0.1:{server.server_port}\n'
+        f'LIFEOS_AGENT_HOOK_TOKEN=file-token-value\n',
+        encoding="utf-8",
+    )
+    env = dict(os.environ)
+    env.pop("LIFEOS_AGENT_HOOK_TOKEN", None)
+    env.pop("LIFEOS_API_URL", None)
+    env["LIFEOS_AGENT_HOOK_ENV"] = str(env_file)
+    stdin = json.dumps({"session_id": "hook-sid-8", "cwd": str(tmp_path)})
+    r = _run(["claude_code", "session_start"], stdin, env)
+    assert r.returncode == 0, r.stderr.decode()
+    assert len(requests) == 1
+    assert requests[0]["headers"]["Authorization"] == "Bearer file-token-value"
+
+
+@pytest.mark.unit
+def test_environment_token_wins_over_env_file(stub_server, tmp_path):
+    env_file = tmp_path / "agent-hook.env"
+    env_file.write_text(
+        "LIFEOS_API_URL=http://127.0.0.1:1\n"
+        "LIFEOS_AGENT_HOOK_TOKEN=file-token-should-be-overridden\n",
+        encoding="utf-8",
+    )
+    server, requests = stub_server
+    env = dict(os.environ)
+    env["LIFEOS_AGENT_HOOK_ENV"] = str(env_file)
+    env["LIFEOS_API_URL"] = f"http://127.0.0.1:{server.server_port}"
+    env["LIFEOS_AGENT_HOOK_TOKEN"] = "env-token-value"
+    stdin = json.dumps({"session_id": "hook-sid-9", "cwd": str(tmp_path)})
+    r = _run(["claude_code", "session_start"], stdin, env)
+    assert r.returncode == 0, r.stderr.decode()
+    assert requests[0]["headers"]["Authorization"] == "Bearer env-token-value"

--- a/tests/test_mcp_human_queue.py
+++ b/tests/test_mcp_human_queue.py
@@ -1,0 +1,206 @@
+"""
+Tests that the three Human-queue MCP tools (#852) are registered and
+reachable over both the stdio and HTTP transports, and that the total tool
+count (67 = 59 CURATED_ENDPOINTS + 8 lifeos_agent_*) matches AGENTS.md.
+"""
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.unit
+
+MCP_SERVER_PATH = Path(__file__).parent.parent / "mcp_server.py"
+
+_HUMAN_QUEUE_TOOL_NAMES = {
+    "lifeos_human_queue_add",
+    "lifeos_human_queue_list",
+    "lifeos_human_queue_resolve",
+}
+
+
+def _load_mcp_module():
+    spec = importlib.util.spec_from_file_location("mcp_server", MCP_SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _server_built_from_live_spec(module):
+    """A LifeOSMCPServer with `.tools` built from this checkout's live
+    OpenAPI spec, in-process — no HTTP round-trip, no running server. Same
+    helper pattern as tests/test_workout_mcp_route.py."""
+    from api.main import app
+    openapi_spec = app.openapi()
+    with patch.object(module.LifeOSMCPServer, "_load_openapi_spec", lambda self: None):
+        server = module.LifeOSMCPServer()
+    server.openapi_spec = openapi_spec
+    server._build_tools_from_spec()
+    return server
+
+
+class TestCuratedEndpointsRegistration:
+    def test_curated_endpoint_count(self):
+        """56 pre-#852 + 3 human-queue tools."""
+        module = _load_mcp_module()
+        assert len(module.CURATED_ENDPOINTS) == 59
+
+    def test_three_tools_in_curated_endpoints(self):
+        module = _load_mcp_module()
+        names = {c["name"] for c in module.CURATED_ENDPOINTS.values()}
+        assert _HUMAN_QUEUE_TOOL_NAMES <= names
+
+    def test_descriptions_within_30_word_budget(self):
+        module = _load_mcp_module()
+        for cfg in module.CURATED_ENDPOINTS.values():
+            if cfg["name"] in _HUMAN_QUEUE_TOOL_NAMES:
+                assert len(cfg["description"].split()) <= 30, cfg["name"]
+
+    def test_tools_do_not_require_worker_handle(self):
+        """Unlike lifeos_agent_user_ask, these are plain CURATED_ENDPOINTS
+        REST-mapped tools — dispatched via _call_api's HTTP path, never
+        _handle_inter_agent (the only path that touches ctx.worker_handle).
+        A real dispatch, not just a name-prefix check: patch _handle_inter_
+        agent and assert it's never reached for any of the three tools."""
+        module = _load_mcp_module()
+        server = module.LifeOSMCPServer()
+        fake = MagicMock()
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {"id": "task-1", "cards": [], "total": 0}
+        fake_response.raise_for_status = MagicMock()
+        fake.get.return_value = fake_response
+        fake.post.return_value = fake_response
+        fake.request.return_value = fake_response
+        server.client = fake
+
+        with patch.object(module.LifeOSMCPServer, "_handle_inter_agent") as mock_inter_agent:
+            server._call_api("lifeos_human_queue_add", {"title": "X"})
+            server._call_api("lifeos_human_queue_list", {})
+            server._call_api("lifeos_human_queue_resolve", {"id_or_key": "x", "note": "done"})
+            mock_inter_agent.assert_not_called()
+
+
+class TestCallApiDispatch:
+    """Real `_call_api` dispatch coverage (#852 review): the tool-count and
+    schema tests above never actually invoke the dispatcher against a
+    mocked HTTP client."""
+
+    def _server_with_mock_client(self, module, response_json):
+        server = module.LifeOSMCPServer()
+        fake = MagicMock()
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = response_json
+        fake_response.raise_for_status = MagicMock()
+        fake.get.return_value = fake_response
+        fake.post.return_value = fake_response
+        fake.request.return_value = fake_response
+        server.client = fake
+        return server, fake
+
+    def test_resolve_dispatches_put_with_key_in_url_and_note_in_body(self):
+        module = _load_mcp_module()
+        server, fake = self._server_with_mock_client(module, {"id": "task-1", "status": "done"})
+
+        server._call_api(
+            "lifeos_human_queue_resolve", {"id_or_key": "sync:gmail", "note": "done"}
+        )
+
+        assert fake.request.call_count == 1
+        method, url = fake.request.call_args.args
+        assert method == "PUT"
+        assert url.endswith("/api/tasks/human-queue/sync:gmail/resolve")
+        assert fake.request.call_args.kwargs["json"] == {"note": "done"}
+
+    def test_format_response_list_includes_both_cards_titles_and_keys(self):
+        module = _load_mcp_module()
+        server = module.LifeOSMCPServer()
+        payload = {
+            "total": 2,
+            "cards": [
+                {"id": "t1", "title": "Re-authenticate example service", "key": "example-reauth", "age_hours": 5.2},
+                {"id": "t2", "title": "Sync source 'gmail' needs attention", "key": "sync:gmail", "age_hours": 30.0},
+            ],
+        }
+        formatted = server._format_response("lifeos_human_queue_list", payload)
+        assert "Re-authenticate example service" in formatted
+        assert "example-reauth" in formatted
+        assert "Sync source 'gmail' needs attention" in formatted
+        assert "sync:gmail" in formatted
+
+
+class TestHttpTransportRegistration:
+    def test_tools_list_includes_human_queue_tools(self):
+        module = _load_mcp_module()
+        server = _server_built_from_live_spec(module)
+        app = module.build_http_app(server, bearer_token="test-token")
+        client = TestClient(app)
+        resp = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+        assert resp.status_code == 200
+        names = {t["name"] for t in resp.json()["result"]["tools"]}
+        assert _HUMAN_QUEUE_TOOL_NAMES <= names
+
+    def test_total_tool_count_matches_agents_md(self):
+        """67 = 59 CURATED_ENDPOINTS + 8 lifeos_agent_* — see AGENTS.md's
+        mcp_server.py row."""
+        module = _load_mcp_module()
+        server = _server_built_from_live_spec(module)
+        assert len(server.tools) == 67
+
+
+def _server_built_from_fallback(module):
+    """A LifeOSMCPServer with `.tools` built from the offline fallback
+    schemas (`_build_tools_fallback`) — the path taken when the OpenAPI
+    spec is unreachable, and the deterministic way to exercise the stdio
+    registration in a test environment that may have a real lifeos-api
+    reachable on localhost:8000 (whose live spec predates this checkout's
+    new routes and would otherwise make this test environment-dependent).
+    """
+    with patch.object(
+        module.LifeOSMCPServer, "_load_openapi_spec",
+        lambda self: self._build_tools_fallback(),
+    ):
+        return module.LifeOSMCPServer()
+
+
+class TestStdioTransportRegistration:
+    def test_tools_list_includes_human_queue_tools(self):
+        module = _load_mcp_module()
+        server = _server_built_from_fallback(module)
+        response = module.dispatch(
+            server,
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+        names = {t["name"] for t in response["result"]["tools"]}
+        assert _HUMAN_QUEUE_TOOL_NAMES <= names
+
+    def test_add_tool_input_schema_requires_title(self):
+        module = _load_mcp_module()
+        server = _server_built_from_fallback(module)
+        response = module.dispatch(
+            server,
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+        tools = {t["name"]: t for t in response["result"]["tools"]}
+        schema = tools["lifeos_human_queue_add"]["inputSchema"]
+        assert "title" in schema["properties"]
+        assert "title" in schema.get("required", [])
+
+    def test_resolve_tool_input_schema_requires_id_or_key(self):
+        module = _load_mcp_module()
+        server = _server_built_from_fallback(module)
+        response = module.dispatch(
+            server,
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+        tools = {t["name"]: t for t in response["result"]["tools"]}
+        schema = tools["lifeos_human_queue_resolve"]["inputSchema"]
+        assert "id_or_key" in schema["properties"]
+        assert "id_or_key" in schema.get("required", [])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -182,3 +182,30 @@ def test_investments_sync_dir_from_env(monkeypatch):
 
     s = Settings()
     assert s.investments_sync_dir == "/tmp/some/other/investments"
+
+
+@pytest.mark.parametrize(
+    "raw_value, expected",
+    [
+        ("", {}),
+        ("{{bad", {}),
+        ('["a"]', {}),
+        ('{"studio": "user@studio.example"}', {"studio": "user@studio.example"}),
+    ],
+)
+def test_agent_hosts_validator_receives_raw_string(monkeypatch, raw_value, expected):
+    """Round 1, finding #8: `LIFEOS_AGENT_HOSTS` is a plain `dict[str, str]`
+    field, so pydantic-settings' own complex-field JSON pre-decode used to
+    run BEFORE `_parse_agent_hosts` (a `mode="before"` validator) — an
+    empty string or malformed JSON raised `SettingsError` straight out of
+    `Settings()`, before the validator's empty/invalid branches (which
+    promise `{}`, not a crash) ever ran. `NoDecode` on the field makes the
+    validator receive the raw env string in every case, including empty.
+
+    `_env_file=None` so a real `.env`'s own `LIFEOS_AGENT_HOSTS` (if any)
+    can't leak into this test."""
+    monkeypatch.setenv("LIFEOS_AGENT_HOSTS", raw_value)
+    from config.settings import Settings
+
+    s = Settings(_env_file=None)
+    assert s.agent_hosts == expected

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -5,6 +5,7 @@ Tests task CRUD operations, status transitions, context changes, fuzzy search,
 parse/format round-trip, reindexing, and persistence.
 """
 import json
+import re
 import pytest
 from datetime import date
 from pathlib import Path
@@ -12,12 +13,15 @@ from pathlib import Path
 from api.services.task_manager import (
     Task,
     TaskManager,
+    TaskConflictError,
     STATUS_TO_SYMBOL,
     SYMBOL_TO_STATUS,
     VALID_STATUSES,
     _format_task_line,
+    _format_task_block,
     _parse_task_line,
     _fuzzy_filter,
+    is_conflict_file,
 )
 
 pytestmark = pytest.mark.unit
@@ -799,13 +803,28 @@ class TestParseTaskLine:
 
         assert task is None
 
-    def test_parse_checkbox_without_todo_keyword_returns_none(self):
-        """Test that checkbox without TODO keyword returns None."""
+    def test_parse_checkbox_without_todo_keyword_still_parses(self):
+        """#853: the literal TODO keyword is no longer required to parse a
+        checkbox line as a task — any `- [.] ...` line counts, so a hand-
+        written checklist item gets an id comment written back on reindex
+        instead of being silently ignored forever. (This intentionally
+        replaces the old test_parse_checkbox_without_todo_keyword_returns_none,
+        which pinned the opposite behavior.)"""
         line = "- [ ] Regular checklist item"
 
         task = _parse_task_line(line, "/path/to/Inbox.md", 1)
 
-        assert task is None
+        assert task is not None
+        assert task.description == "Regular checklist item"
+        assert task.status == "todo"
+
+    def test_parse_non_checkbox_line_returns_none(self):
+        """A line that isn't a checkbox at all (heading, blank, prose,
+        non-checkbox bullet) is never mistaken for a task."""
+        assert _parse_task_line("## A heading", "/path/to/Inbox.md", 1) is None
+        assert _parse_task_line("", "/path/to/Inbox.md", 1) is None
+        assert _parse_task_line("- a plain bullet, no checkbox", "/path/to/Inbox.md", 1) is None
+        assert _parse_task_line("Just a sentence.", "/path/to/Inbox.md", 1) is None
 
 
 class TestParseFormatRoundTrip:
@@ -1074,6 +1093,111 @@ class TestReindexFile:
         retrieved = task_manager.get(task.id)
         assert retrieved is None
 
+    def test_external_edit_detection_survives_repeated_reindexes(self, task_manager):
+        """#853 round 1 finding #1: `reindex_file` used to pop
+        `_last_written_line` for every task whose `source_file` matched —
+        exactly the set it had just repopulated — which erased the record
+        `reindex_file` itself needs to detect the NEXT external edit. A
+        second consecutive external edit would then go undetected."""
+        task = task_manager.create("Edit twice", context="RepeatEdit")
+        file_path = task_manager.tasks_dir / "RepeatEdit.md"
+
+        content = file_path.read_text(encoding="utf-8")
+        file_path.write_text(content.replace("Edit twice", "First edit"), encoding="utf-8")
+        task_manager.reindex_file(str(file_path))
+        first = task_manager.get(task.id)
+        assert first.description == "First edit"
+        first_stamp = first.updated_at
+
+        content = file_path.read_text(encoding="utf-8")
+        file_path.write_text(content.replace("First edit", "Second edit"), encoding="utf-8")
+        task_manager.reindex_file(str(file_path))
+        second = task_manager.get(task.id)
+
+        assert second.description == "Second edit"
+        assert second.updated_at != first_stamp
+        assert f"[updated:: {second.updated_at}]" in file_path.read_text(encoding="utf-8")
+
+
+class TestReindexWriteBackCas:
+    """#853 round 1 finding #14: `reindex_file`'s own write-back (minting an
+    id, restamping an external edit) had no compare-and-swap check against a
+    write landing between its read and its write — a concurrent writer's
+    change could be silently lost."""
+
+    def test_single_mismatch_then_writes_id_back_on_retry(self, task_manager, monkeypatch):
+        file_path = task_manager.tasks_dir / "ReindexCas.md"
+        file_path.write_text("- [ ] TODO Buy milk\n", encoding="utf-8")
+
+        import api.services.task_manager as tm_mod
+        original_mtime = tm_mod._mtime_or_none
+        calls = {"n": 0}
+
+        def mismatch_once_then_real(path):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return 111  # first attempt's mtime_before
+            if calls["n"] == 2:
+                return 222  # first attempt's mtime_now -> forces a mismatch/retry
+            return original_mtime(path)  # every later call: the real, stable value
+
+        monkeypatch.setattr(tm_mod, "_mtime_or_none", mismatch_once_then_real)
+
+        task_manager.reindex_file(str(file_path))
+
+        content = file_path.read_text(encoding="utf-8")
+        assert re.search(r"<!-- id:\w+ -->", content), "id was never written back after the retry"
+
+    def test_persistent_mismatch_skips_write_logs_warning_no_exception(
+        self, task_manager, monkeypatch, caplog
+    ):
+        file_path = task_manager.tasks_dir / "ReindexCasPersistent.md"
+        original_content = "- [ ] TODO Buy milk\n"
+        file_path.write_text(original_content, encoding="utf-8")
+
+        import itertools
+        counter = itertools.count()
+        monkeypatch.setattr(
+            "api.services.task_manager._mtime_or_none",
+            lambda path: next(counter),
+        )
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="api.services.task_manager"):
+            task_manager.reindex_file(str(file_path))  # must not raise
+
+        assert file_path.read_text(encoding="utf-8") == original_content
+        assert any("conflict" in r.message.lower() for r in caplog.records)
+
+    def test_persistent_mismatch_does_not_merge_unwritten_parse_into_index(
+        self, task_manager, monkeypatch
+    ):
+        """#853 round 2 finding #2: on a persistent conflict the write-back
+        is correctly skipped, but `self._tasks` used to be updated anyway
+        from a parse that never reached disk — seeding a "ghost" id (minted
+        while appending a missing id comment) that nothing on disk carries —
+        and every abandoned attempt's `_reparse_lines` mutations to
+        `self._last_written_line` leaked through, not just the final one."""
+        file_path = task_manager.tasks_dir / "ReindexCasGhost.md"
+        original_content = "- [ ] TODO Buy milk\n"
+        file_path.write_text(original_content, encoding="utf-8")
+
+        tasks_before = dict(task_manager._tasks)
+        last_written_before = dict(task_manager._last_written_line)
+
+        import itertools
+        counter = itertools.count()
+        monkeypatch.setattr(
+            "api.services.task_manager._mtime_or_none",
+            lambda path: next(counter),
+        )
+
+        task_manager.reindex_file(str(file_path))  # must not raise
+
+        assert file_path.read_text(encoding="utf-8") == original_content
+        assert task_manager._tasks == tasks_before
+        assert task_manager._last_written_line == last_written_before
+
 
 class TestRebuildIndex:
     """Tests for rebuild_index method."""
@@ -1320,3 +1444,936 @@ class TestListFilterSemanticsMatchDocs:
         # Fixture has 5 tasks, only 2 with due dates.
         assert len(populated_manager.list_tasks(due_before="2099-01-01")) == 2
         assert all(t.due_date is not None for t in populated_manager.list_tasks(due_before="2099-01-01"))
+
+
+# =============================================================================
+# #853 — Task store hardening: id write-back, atomic writes, id-addressed
+# writes, notes body, unknown-field round-trip, cache-field merge-forward,
+# external-edit-wins, CAS retry + conflict, and Syncthing conflict-file skip.
+# =============================================================================
+
+class TestIdWriteBack:
+    """Reindexing mints and writes back a stable id for any hand-authored
+    checkbox line that lacks one, without disturbing anything else."""
+
+    def test_reindex_mints_and_writes_back_id(self, task_manager):
+        file_path = task_manager.tasks_dir / "Handwritten.md"
+        file_path.write_text("- [ ] TODO Buy milk\n", encoding="utf-8")
+
+        task_manager.reindex_file(str(file_path))
+
+        content = file_path.read_text(encoding="utf-8")
+        assert content.startswith("- [ ] TODO Buy milk <!-- id:")
+        m = re.search(r"<!-- id:(\w+) -->", content)
+        assert m
+        minted_id = m.group(1)
+        assert task_manager.get(minted_id).description == "Buy milk"
+
+        # Stable + idempotent on a second reindex.
+        task_manager.reindex_file(str(file_path))
+        assert file_path.read_text(encoding="utf-8") == content
+        assert task_manager.get(minted_id) is not None
+
+    def test_reindex_preserves_mixed_content_byte_for_byte(self, task_manager):
+        lines_in = [
+            "---",
+            "type: tasks",
+            "---",
+            "# Mixed Tasks",
+            "",
+            "Some prose note that isn't a task at all.",
+            "",
+            "- A plain bullet, not a checkbox",
+            "  - nested content under it",
+            "",
+            "- [ ] TODO Buy milk",
+            "- [x] TODO Already has an id <!-- id:existing1 -->",
+            "- [ ] Another hand-written item, no TODO keyword",
+            "",
+            "## Section 2",
+            "",
+            "Example syntax for the docs:",
+            "```markdown",
+            "- [ ] example checkbox inside a fence, not a real task",
+            "```",
+            "",
+        ]
+        file_path = task_manager.tasks_dir / "Mixed.md"
+        original_bytes = ("\n".join(lines_in) + "\n").encode("utf-8")
+        file_path.write_bytes(original_bytes)
+
+        task_manager.reindex_file(str(file_path))
+
+        out_bytes = file_path.read_bytes()
+        lines_out = out_bytes.decode("utf-8").splitlines()
+        assert len(lines_out) == len(lines_in)
+
+        task_line_idx = {10, 11, 12}
+        for i, original in enumerate(lines_in):
+            if i in task_line_idx:
+                continue
+            assert lines_out[i] == original, f"non-task line {i} changed: {lines_out[i]!r}"
+
+        # The fenced checkbox line (idx 18) is untouched byte-for-byte and
+        # never indexed as a task — #853 round 1 finding #7.
+        assert lines_out[18] == lines_in[18]
+        assert task_manager.list_tasks(query="example checkbox") == []
+
+        # Already-id'd line: fully untouched.
+        assert lines_out[11] == lines_in[11]
+
+        # Id-less task lines: original text preserved, exactly one id
+        # comment appended.
+        for i in (10, 12):
+            assert lines_out[i].startswith(lines_in[i])
+            suffix = lines_out[i][len(lines_in[i]):]
+            assert re.fullmatch(r" <!-- id:\w+ -->", suffix), f"line {i} suffix: {suffix!r}"
+
+        # Idempotent — a second reindex makes no further change, down to the
+        # raw bytes (trailing newline / line endings included).
+        task_manager.reindex_file(str(file_path))
+        assert file_path.read_bytes() == out_bytes
+
+    def test_reindex_preserves_crlf_line_endings(self, task_manager):
+        """#853 round 1 finding #9: a CRLF file must not become LF wholesale
+        when an id gets written back."""
+        file_path = task_manager.tasks_dir / "Crlf.md"
+        original_bytes = b"# CRLF Tasks\r\n\r\n- [ ] TODO Buy milk\r\n"
+        file_path.write_bytes(original_bytes)
+
+        task_manager.reindex_file(str(file_path))
+
+        out_bytes = file_path.read_bytes()
+        assert out_bytes.endswith(b"\r\n")
+        # No bare LF was introduced — every newline is part of a CRLF pair.
+        assert out_bytes.count(b"\n") == out_bytes.count(b"\r\n")
+        lines_out = out_bytes.decode("utf-8").split("\r\n")
+        assert lines_out[0] == "# CRLF Tasks"
+        assert lines_out[1] == ""
+        assert re.fullmatch(r"- \[ \] TODO Buy milk <!-- id:\w+ -->", lines_out[2])
+        assert lines_out[3] == ""  # trailing terminator preserved
+
+    def test_reindex_preserves_missing_trailing_newline(self, task_manager):
+        """#853 round 1 finding #9: a file with no final newline must not
+        gain one just because an id got written back to one of its lines."""
+        file_path = task_manager.tasks_dir / "NoTrailingNewline.md"
+        content = "# No Trailing Newline\n\n- [ ] TODO Buy milk"
+        file_path.write_bytes(content.encode("utf-8"))
+        assert not file_path.read_bytes().endswith(b"\n")
+
+        task_manager.reindex_file(str(file_path))
+
+        out_bytes = file_path.read_bytes()
+        assert not out_bytes.endswith(b"\n")
+        out_text = out_bytes.decode("utf-8")
+        assert out_text.startswith("# No Trailing Newline\n\n- [ ] TODO Buy milk <!-- id:")
+
+
+class TestFencedCodeBlocks:
+    """#853 round 1 finding #7: a checkbox line inside a fenced (``` or
+    ~~~) code block is documentation/example text, never a real task."""
+
+    def test_create_inserts_above_first_real_task_not_inside_fence(self, task_manager):
+        file_path = task_manager.tasks_dir / "FenceInsert.md"
+        file_path.write_text(
+            "# Fence Insert\n\n"
+            "```markdown\n"
+            "- [ ] example, not a real task\n"
+            "```\n\n"
+            "- [ ] TODO Real task <!-- id:realtask1 -->\n",
+            encoding="utf-8",
+        )
+        task_manager.reindex_file(str(file_path))
+
+        task = task_manager.create("New task", context="FenceInsert")
+
+        content = file_path.read_text(encoding="utf-8")
+        lines = content.splitlines()
+        # The example checkbox inside the fence is unchanged and comes
+        # before the newly created task's line, which comes before "Real
+        # task" — the new task must not land inside the fence.
+        fence_idx = next(i for i, ln in enumerate(lines) if "example, not a real task" in ln)
+        new_task_idx = next(i for i, ln in enumerate(lines) if f"<!-- id:{task.id} -->" in ln)
+        real_task_idx = next(i for i, ln in enumerate(lines) if "realtask1" in ln)
+        assert fence_idx < new_task_idx < real_task_idx
+        assert lines[fence_idx] == "- [ ] example, not a real task"
+        assert task_manager.get("realtask1") is not None
+
+
+class TestDuplicateIds:
+    """#853 round 1 finding #8: two task lines sharing the same id comment
+    (e.g. a hand-copied line) must not fight over it forever."""
+
+    def test_duplicate_id_gets_a_fresh_id_and_both_are_indexed(self, task_manager):
+        file_path = task_manager.tasks_dir / "Dupes.md"
+        file_path.write_text(
+            "- [ ] TODO First copy <!-- id:dupe0001 -->\n"
+            "- [ ] TODO Second copy <!-- id:dupe0001 -->\n",
+            encoding="utf-8",
+        )
+
+        task_manager.reindex_file(str(file_path))
+
+        first = task_manager.get("dupe0001")
+        assert first is not None
+        assert first.description == "First copy"
+
+        content = file_path.read_text(encoding="utf-8")
+        lines = content.splitlines()
+        second_line = next(ln for ln in lines if "Second copy" in ln)
+        m = re.search(r"<!-- id:(\w+) -->", second_line)
+        assert m
+        second_id = m.group(1)
+        assert second_id != "dupe0001"
+        second = task_manager.get(second_id)
+        assert second is not None
+        assert second.description == "Second copy"
+        # Only one id comment on the rewritten line.
+        assert second_line.count("<!-- id:") == 1
+
+        # A second reindex makes no further change — bytes identical.
+        before = file_path.read_bytes()
+        task_manager.reindex_file(str(file_path))
+        assert file_path.read_bytes() == before
+
+    def test_cross_file_duplicate_id_resolved_on_rebuild(self, task_manager):
+        """#853 round 2 finding #3: a same-file duplicate id is deduplicated
+        by `_reparse_lines` already, but two DIFFERENT files each carrying
+        `<!-- id:dupe0001 -->` were never deduplicated — `rebuild_index`
+        just let whichever file was parsed last silently win in
+        `self._tasks`, with the losing file's on-disk id now pointing at
+        the wrong task."""
+        inbox_path = task_manager.tasks_dir / "Inbox.md"
+        work_path = task_manager.tasks_dir / "Work.md"
+        inbox_path.write_text("- [ ] TODO Inbox copy <!-- id:dupe0001 -->\n", encoding="utf-8")
+        work_path.write_text("- [ ] TODO Work copy <!-- id:dupe0001 -->\n", encoding="utf-8")
+
+        task_manager.rebuild_index()
+
+        inbox_content = inbox_path.read_text(encoding="utf-8")
+        work_content = work_path.read_text(encoding="utf-8")
+        kept_original = [c for c in (inbox_content, work_content) if "dupe0001" in c]
+        assert len(kept_original) == 1, "exactly one file should keep the original id"
+
+        original = task_manager.get("dupe0001")
+        assert original is not None
+
+        other_content = work_content if "dupe0001" in inbox_content else inbox_content
+        m = re.search(r"<!-- id:(\w+) -->", other_content)
+        assert m
+        fresh_id = m.group(1)
+        assert fresh_id != "dupe0001"
+        fresh = task_manager.get(fresh_id)
+        assert fresh is not None
+        assert fresh.id != original.id
+
+        # Two distinct tasks are indexed, not one clobbering the other.
+        assert {original.description, fresh.description} == {"Inbox copy", "Work copy"}
+
+        # A second rebuild makes no further change — both files byte-identical.
+        inbox_before = inbox_path.read_bytes()
+        work_before = work_path.read_bytes()
+        task_manager.rebuild_index()
+        assert inbox_path.read_bytes() == inbox_before
+        assert work_path.read_bytes() == work_before
+
+
+class TestIdAddressedWrites:
+    """Writes locate their task by id, not by cached line number, so an
+    external insert above a task doesn't misdirect the next write."""
+
+    def test_update_targets_correct_line_after_external_insert_above(self, task_manager):
+        task_a = task_manager.create("Task A", context="AddressTest")
+        task_manager.create("Task B", context="AddressTest")
+        file_path = task_manager.tasks_dir / "AddressTest.md"
+
+        # Simulate an external edit landing before the watcher reindexes.
+        content = file_path.read_text(encoding="utf-8")
+        file_path.write_text("New line one\nNew line two\n" + content, encoding="utf-8")
+        before_lines = file_path.read_text(encoding="utf-8").splitlines()
+        task_a_idx = next(i for i, ln in enumerate(before_lines) if f"<!-- id:{task_a.id} -->" in ln)
+
+        updated = task_manager.update(task_a.id, description="Task A updated")
+
+        assert updated.description == "Task A updated"
+        # #853 round 1 finding #16: every line except task A's own must be
+        # byte-identical before and after — not just spot-checked strings.
+        after_lines = file_path.read_text(encoding="utf-8").splitlines()
+        assert len(after_lines) == len(before_lines)
+        for i, before_line in enumerate(before_lines):
+            if i == task_a_idx:
+                continue
+            assert after_lines[i] == before_line, f"line {i} changed unexpectedly: {after_lines[i]!r}"
+        assert after_lines[task_a_idx] != before_lines[task_a_idx]
+        assert "Task A updated" in after_lines[task_a_idx]
+
+
+class TestNotesBody:
+    def test_create_with_notes_writes_indented_body(self, task_manager):
+        task = task_manager.create("Notes test", context="NotesTest", notes="line one\nline two")
+        content = (task_manager.tasks_dir / "NotesTest.md").read_text(encoding="utf-8")
+        assert "    > line one" in content
+        assert "    > line two" in content
+        assert task_manager.get(task.id).notes == "line one\nline two"
+
+    def test_delete_removes_task_line_and_body(self, task_manager):
+        task = task_manager.create("Delete with notes", context="NotesTest", notes="body line")
+        file_path = task_manager.tasks_dir / "NotesTest.md"
+        before_lines = file_path.read_text(encoding="utf-8").splitlines()
+        assert "body line" in file_path.read_text(encoding="utf-8")
+
+        task_line_idx = next(i for i, ln in enumerate(before_lines) if f"<!-- id:{task.id} -->" in ln)
+        body_end = task_line_idx + 1
+        while body_end < len(before_lines) and before_lines[body_end].lstrip().startswith(">"):
+            body_end += 1
+        # #853 round 1 finding #16: the remaining file must equal the
+        # fixture minus exactly the task's line and its body lines — not
+        # just "the description string is gone somewhere."
+        expected_lines = before_lines[:task_line_idx] + before_lines[body_end:]
+
+        task_manager.delete(task.id)
+
+        after_lines = file_path.read_text(encoding="utf-8").splitlines()
+        assert after_lines == expected_lines
+
+    def test_context_change_moves_notes_body_too(self, task_manager):
+        task = task_manager.create("Move with notes", context="NotesA", notes="keep me")
+        task_manager.update(task.id, context="NotesB")
+
+        old_content = (task_manager.tasks_dir / "NotesA.md").read_text(encoding="utf-8")
+        new_content = (task_manager.tasks_dir / "NotesB.md").read_text(encoding="utf-8")
+        assert "keep me" not in old_content
+        assert "keep me" in new_content
+        assert task_manager.get(task.id).notes == "keep me"
+
+    def test_update_notes_rewrites_body(self, task_manager):
+        task = task_manager.create("Update notes", context="NotesTest", notes="old body")
+        task_manager.update(task.id, notes="new body")
+        content = (task_manager.tasks_dir / "NotesTest.md").read_text(encoding="utf-8")
+        assert "old body" not in content
+        assert "new body" in content
+
+
+class TestUnknownFieldRoundTrip:
+    def test_unknown_field_survives_reindex_and_rewrite(self, task_manager):
+        file_path = task_manager.tasks_dir / "Unknown.md"
+        file_path.write_text(
+            "- [ ] TODO Custom field task [foo:: bar] <!-- id:custom01 -->\n",
+            encoding="utf-8",
+        )
+        task_manager.reindex_file(str(file_path))
+
+        task = task_manager.get("custom01")
+        assert task is not None
+        assert task.fields == {"foo": "bar"}
+
+        # Any API rewrite of the task must not drop the unknown field.
+        task_manager.update("custom01", priority="high")
+        content = file_path.read_text(encoding="utf-8")
+        assert "[foo:: bar]" in content
+        assert task_manager.get("custom01").fields == {"foo": "bar"}
+
+
+class TestOperatorFields:
+    def test_create_with_fields_writes_inline(self, task_manager):
+        task = task_manager.create(
+            "Field test", context="Fields", fields={"host": "laptop", "effort": "high"}
+        )
+        content = (task_manager.tasks_dir / "Fields.md").read_text(encoding="utf-8")
+        assert "[host:: laptop]" in content
+        assert "[effort:: high]" in content
+        assert task.fields == {"host": "laptop", "effort": "high"}
+
+    def test_update_fields_null_removes_field(self, task_manager):
+        task = task_manager.create("Remove field", context="Fields", fields={"host": "laptop"})
+        updated = task_manager.update(task.id, fields={"host": None})
+
+        assert "host" not in updated.fields
+        content = (task_manager.tasks_dir / "Fields.md").read_text(encoding="utf-8")
+        assert "[host::" not in content
+
+    def test_update_fields_merges_not_replaces(self, task_manager):
+        task = task_manager.create("Merge fields", context="Fields", fields={"host": "laptop"})
+        updated = task_manager.update(task.id, fields={"effort": "high"})
+        assert updated.fields == {"host": "laptop", "effort": "high"}
+
+
+class TestMergeForwardCacheFields:
+    def test_reminder_id_survives_reindex_after_external_touch(self, task_manager):
+        task = task_manager.create("Linked task", context="Reminder", reminder_id="rem-123")
+        file_path = task_manager.tasks_dir / "Reminder.md"
+
+        # reminder_id has no markdown representation at all — an unrelated
+        # external touch must not lose it on reindex.
+        content = file_path.read_text(encoding="utf-8")
+        file_path.write_text(content + "\n", encoding="utf-8")
+
+        task_manager.reindex_file(str(file_path))
+
+        assert task_manager.get(task.id).reminder_id == "rem-123"
+
+
+class TestExternalEditWins:
+    def test_external_edit_reflected_and_restamped(self, task_manager):
+        task = task_manager.create("Original", context="ExtEdit")
+        file_path = task_manager.tasks_dir / "ExtEdit.md"
+        first_stamp = task_manager.get(task.id).updated_at
+
+        content = file_path.read_text(encoding="utf-8")
+        file_path.write_text(content.replace("Original", "Externally renamed"), encoding="utf-8")
+
+        task_manager.reindex_file(str(file_path))
+
+        refreshed = task_manager.get(task.id)
+        assert refreshed.description == "Externally renamed"
+        assert refreshed.updated_at != first_stamp
+        final_content = file_path.read_text(encoding="utf-8")
+        assert f"[updated:: {refreshed.updated_at}]" in final_content
+
+    def test_unrelated_task_untouched_when_only_one_task_edited(self, task_manager):
+        task_a = task_manager.create("Task A", context="ExtEdit2")
+        task_b = task_manager.create("Task B", context="ExtEdit2")
+        file_path = task_manager.tasks_dir / "ExtEdit2.md"
+
+        content = file_path.read_text(encoding="utf-8")
+        file_path.write_text(content.replace("Task A", "Task A renamed"), encoding="utf-8")
+
+        b_stamp_before = task_manager.get(task_b.id).updated_at
+
+        task_manager.reindex_file(str(file_path))
+
+        assert task_manager.get(task_a.id).description == "Task A renamed"
+        b_after = task_manager.get(task_b.id)
+        assert b_after.description == "Task B"
+        assert b_after.updated_at == b_stamp_before
+
+
+class TestCasRewriteAbsorbsUnreindexedExternalEdit:
+    """#853 round 1 finding #5: `_cas_rewrite` used to build its replacement
+    purely from `self._tasks`, so an external edit that had landed on disk
+    but not yet been through `reindex_file` (the normal case under the
+    watcher's 2s debounce, not a rare race) was silently reverted by an
+    unrelated field update."""
+
+    def test_update_preserves_unreindexed_external_retitle_and_body(self, task_manager):
+        task = task_manager.create("Original title", context="Absorb", notes="original body")
+        file_path = task_manager.tasks_dir / "Absorb.md"
+
+        content = file_path.read_text(encoding="utf-8")
+        content = content.replace("Original title", "Externally retitled")
+        content = content.replace(
+            "    > original body", "    > original body\n    > added externally"
+        )
+        file_path.write_text(content, encoding="utf-8")
+
+        updated = task_manager.update(task.id, priority="high")
+
+        assert updated.description == "Externally retitled"
+        assert updated.notes == "original body\nadded externally"
+        assert updated.priority == "high"
+        final_content = file_path.read_text(encoding="utf-8")
+        assert "Externally retitled" in final_content
+        assert "added externally" in final_content
+        assert "[priority:: high]" in final_content
+
+    def test_swap_tag_preserves_unreindexed_external_retitle(self, task_manager):
+        task = task_manager.create("Claim me", context="Absorb2", tags=["agent"])
+        file_path = task_manager.tasks_dir / "Absorb2.md"
+
+        content = file_path.read_text(encoding="utf-8")
+        file_path.write_text(content.replace("Claim me", "Retitled before claim"), encoding="utf-8")
+
+        ok = task_manager.swap_tag(task.id, "agent", "agent-running")
+
+        assert ok is True
+        refreshed = task_manager.get(task.id)
+        assert refreshed.description == "Retitled before claim"
+        assert refreshed.tags == ["agent-running"]
+        final_content = file_path.read_text(encoding="utf-8")
+        assert "Retitled before claim" in final_content
+        assert "#agent-running" in final_content
+
+    def test_update_preserves_unreindexed_external_body_only_edit(self, task_manager):
+        """#853 round 2 finding #4: `test_update_preserves_unreindexed_
+        external_retitle_and_body` changes the task LINE (a retitle) and the
+        body together, so it stays green even if `_external_edit_pending`'s
+        notes-comparison branch is deleted — the raw-line comparison alone
+        still catches it. This test changes ONLY the body, leaving the task
+        line byte-identical, so it isolates that branch: it fails if the
+        notes comparison is removed."""
+        task = task_manager.create("Body only", context="Absorb3", notes="original body")
+        file_path = task_manager.tasks_dir / "Absorb3.md"
+
+        content = file_path.read_text(encoding="utf-8")
+        content = content.replace(
+            "    > original body", "    > original body\n    > added externally"
+        )
+        file_path.write_text(content, encoding="utf-8")
+
+        updated = task_manager.update(task.id, priority="high")
+
+        assert updated.notes == "original body\nadded externally"
+        final_content = file_path.read_text(encoding="utf-8")
+        assert "added externally" in final_content
+        assert "[priority:: high]" in final_content
+
+
+class TestMoveTaskConflict:
+    """#853 round 1 finding #6: a context-change move used to remove the
+    block from the source file BEFORE inserting into the destination — if
+    the destination insert then raised, the task was in neither file while
+    the index still pointed at the source."""
+
+    def test_destination_conflict_leaves_task_in_source_only(self, task_manager, monkeypatch):
+        task = task_manager.create("Move me", context="MoveSrc", notes="keep this body")
+        source_path = task_manager.tasks_dir / "MoveSrc.md"
+        dest_path = task_manager.tasks_dir / "MoveDest.md"
+
+        import api.services.task_manager as tm_mod
+        original_mtime = tm_mod._mtime_or_none
+        dest_counter = {"n": 0}
+
+        def flaky_for_dest(path):
+            if Path(path) == dest_path:
+                dest_counter["n"] += 1
+                return dest_counter["n"]  # always different -> destination CAS never matches
+            return original_mtime(path)
+
+        monkeypatch.setattr(tm_mod, "_mtime_or_none", flaky_for_dest)
+
+        with pytest.raises(TaskConflictError):
+            task_manager.update(task.id, context="MoveDest")
+
+        source_content = source_path.read_text(encoding="utf-8")
+        assert "Move me" in source_content
+        assert "keep this body" in source_content
+        dest_content = dest_path.read_text(encoding="utf-8") if dest_path.exists() else ""
+        assert "Move me" not in dest_content
+        # Index still points at the source — not left dangling.
+        assert task_manager.get(task.id).context == "MoveSrc"
+
+    def test_source_conflict_rollback_leaves_index_pointing_at_intact_source(
+        self, task_manager, monkeypatch
+    ):
+        """#853 round 2 finding #1: when the destination insert succeeds and
+        the SOURCE removal then raises `TaskConflictError`, the best-effort
+        rollback used to run `_external_edit_pending` against a stale
+        (still-the-source) `self._last_written_line`, treat the freshly
+        inserted destination block as an unabsorbed external edit, restamp
+        and absorb it into `self._tasks` via `reindex_file` (context/
+        source_file now pointing at the destination), and then delete that
+        same block from the destination on retry — leaving the index
+        pointing at a file with no block for this id, even though the
+        source file still held the task byte for byte, untouched."""
+        task = task_manager.create("Move me too", context="MoveSrc2", notes="keep this body too")
+        source_path = task_manager.tasks_dir / "MoveSrc2.md"
+        dest_path = task_manager.tasks_dir / "MoveDest2.md"
+        source_content_before = source_path.read_text(encoding="utf-8")
+
+        import api.services.task_manager as tm_mod
+        original_mtime = tm_mod._mtime_or_none
+        state = {"flaky": True, "n": 0}
+
+        def flaky_for_source(path):
+            if state["flaky"] and Path(path) == source_path:
+                state["n"] += 1
+                return state["n"]  # always different -> source CAS never matches
+            return original_mtime(path)
+
+        monkeypatch.setattr(tm_mod, "_mtime_or_none", flaky_for_source)
+
+        with pytest.raises(TaskConflictError):
+            task_manager.update(task.id, context="MoveDest2")
+
+        # Destination has no block for the id — the rollback did its job.
+        dest_content = dest_path.read_text(encoding="utf-8") if dest_path.exists() else ""
+        assert "Move me too" not in dest_content
+        # Source is completely untouched, byte for byte.
+        source_content = source_path.read_text(encoding="utf-8")
+        assert source_content == source_content_before
+        assert "keep this body too" in source_content
+
+        indexed = task_manager.get(task.id)
+        assert indexed is not None
+        assert indexed.source_file.endswith("MoveSrc2.md")
+        assert indexed.context == "MoveSrc2"
+
+        # A subsequent, unmocked update must still succeed against the
+        # (correctly indexed) source file.
+        state["flaky"] = False
+        updated = task_manager.update(task.id, priority="high")
+        assert updated is not None
+        final_content = source_path.read_text(encoding="utf-8")
+        assert "[priority:: high]" in final_content
+
+    def test_uncontended_move_does_not_reindex_or_extra_write(self, task_manager, monkeypatch):
+        """#853 round 3 finding #1: seeding `self._last_written_line[task.id]`
+        with the destination's just-written line unconditionally, right
+        after the destination insert (rather than only if the source-side
+        removal later raises), made the source removal's
+        `_external_edit_pending` check compare the still-on-disk source
+        line against that destination line. They always mismatch (fresh
+        `updated_at`), so an ordinary, uncontended move triggered a
+        spurious `reindex_file` call and an extra write, burning a CAS
+        retry for no reason. An uncontended move must write exactly twice
+        (once to each file) and never reindex."""
+        task = task_manager.create(
+            "Move me cleanly", context="MoveSrc3", notes="keep this body clean"
+        )
+
+        import api.services.task_manager as tm_mod
+
+        reindex_calls = []
+        monkeypatch.setattr(
+            tm_mod.TaskManager,
+            "reindex_file",
+            lambda self, file_path: reindex_calls.append(file_path),
+        )
+
+        write_calls = []
+        original_atomic_write_lines = tm_mod.atomic_write_lines
+
+        def recording_atomic_write_lines(path, *args, **kwargs):
+            write_calls.append(Path(path))
+            return original_atomic_write_lines(path, *args, **kwargs)
+
+        monkeypatch.setattr(tm_mod, "atomic_write_lines", recording_atomic_write_lines)
+
+        updated = task_manager.update(task.id, context="MoveDest3", priority="high")
+
+        assert reindex_calls == []
+        assert len(write_calls) == 2
+        assert {p.name for p in write_calls} == {"MoveDest3.md", "MoveSrc3.md"}
+
+        dest_content = (task_manager.tasks_dir / "MoveDest3.md").read_text(encoding="utf-8")
+        assert "[priority:: high]" in dest_content
+        assert "Move me cleanly" in dest_content
+
+        source_content = (task_manager.tasks_dir / "MoveSrc3.md").read_text(encoding="utf-8")
+        assert "Move me cleanly" not in source_content
+
+        assert updated.context == "MoveDest3"
+
+
+class TestFieldValidation:
+    """#853 round 1 findings #2 and #3: description/notes/fields content
+    that would corrupt the task line's format, or a `fields` key that
+    shadows a reserved attribute (or the id comment), is rejected with
+    `ValueError` rather than silently corrupting the line or hijacking
+    another task's id."""
+
+    def test_create_rejects_newline_in_description(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Two\nlines", context="Validate")
+        assert task_manager.list_tasks(context="Validate") == []
+
+    def test_create_rejects_bracket_in_description(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Truncate me]", context="Validate")
+
+    def test_create_rejects_html_comment_opener_in_description(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Hijack <!-- id:other -->", context="Validate")
+
+    def test_create_rejects_newline_in_fields_value(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Field newline", context="Validate", fields={"host": "a\nb"})
+
+    def test_create_rejects_bracket_in_fields_value(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Field bracket", context="Validate", fields={"host": "a]b"})
+
+    def test_create_rejects_html_comment_in_fields_value(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create(
+                "Field hijack", context="Validate", fields={"host": "<!-- id:x -->"}
+            )
+
+    def test_create_rejects_spaced_fields_key(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Bad key", context="Validate", fields={"my key": "v"})
+
+    def test_create_rejects_reserved_fields_key(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Spoof updated", context="Validate", fields={"updated": "SPOOFED"})
+
+    def test_create_rejects_id_as_fields_key(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Spoof id", context="Validate", fields={"id": "hijacked"})
+
+    def test_create_rejects_carriage_return_in_notes(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Notes CR", context="Validate", notes="line\rbreak")
+
+    def test_create_rejects_html_comment_in_notes(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Notes hijack", context="Validate", notes="<!-- id:x -->")
+
+    def test_create_allows_multiline_notes(self, task_manager):
+        # Sanity: multi-line notes are the whole point of the field and
+        # must not be rejected by the same newline check used for description.
+        task = task_manager.create("Notes ok", context="Validate", notes="line one\nline two")
+        assert task.notes == "line one\nline two"
+
+    def test_update_rejects_hostile_fields_value(self, task_manager):
+        task = task_manager.create("To update", context="Validate")
+        with pytest.raises(ValueError):
+            task_manager.update(task.id, fields={"host": "bad]value"})
+        assert task_manager.get(task.id).fields == {}
+
+    def test_update_rejects_reserved_fields_key(self, task_manager):
+        task = task_manager.create("To update 2", context="Validate")
+        with pytest.raises(ValueError):
+            task_manager.update(task.id, fields={"priority": "spoofed"})
+        assert "priority" not in task_manager.get(task.id).fields
+
+
+class TestStatusValidation:
+    """#853 round 1 finding #11: `status` was accepted unchecked by the
+    manager — `status="Done"` silently wrote a `[ ]` (unrecognized symbol
+    falls back to a blank checkbox) and round-tripped as `Done` until the
+    next reindex flipped it back to `todo`."""
+
+    def test_create_rejects_unrecognized_status(self, task_manager):
+        with pytest.raises(ValueError):
+            task_manager.create("Bad status", status="Done")
+        assert task_manager.list_tasks(query="Bad status") == []
+
+    def test_update_rejects_unrecognized_status(self, task_manager):
+        task = task_manager.create("To update", context="StatusValidate")
+        with pytest.raises(ValueError):
+            task_manager.update(task.id, status="Done")
+        assert task_manager.get(task.id).status == "todo"
+
+
+class TestCasRetryAndConflict:
+    def test_retries_three_times_then_raises_conflict(self, task_manager, monkeypatch):
+        task = task_manager.create("CAS test", context="CasTest")
+
+        import itertools
+        counter = itertools.count()
+        monkeypatch.setattr(
+            "api.services.task_manager._mtime_or_none",
+            lambda path: next(counter),
+        )
+
+        reindex_calls = []
+        original_reindex = task_manager.reindex_file
+
+        def spy_reindex(path):
+            reindex_calls.append(path)
+            return original_reindex(path)
+
+        monkeypatch.setattr(task_manager, "reindex_file", spy_reindex)
+
+        with pytest.raises(TaskConflictError):
+            task_manager.update(task.id, description="new desc")
+
+        assert len(reindex_calls) == 3
+
+    def test_update_conflict_leaves_in_memory_task_unchanged(self, task_manager, monkeypatch):
+        """#853 round 1 finding #4: `update.apply()` used to mutate
+        `self._tasks[task_id]` in place via `setattr`, so even a losing CAS
+        attempt's edits were visible through `get()` — the file kept the old
+        description but memory had the new one. `compute()` must build a
+        new `Task` from a copy and `_cas_rewrite` must rebind
+        `self._tasks[task_id]` only on the success branch."""
+        task = task_manager.create("Original description", context="CasTest3")
+        file_path = task_manager.tasks_dir / "CasTest3.md"
+        before_content = file_path.read_text(encoding="utf-8")
+
+        import itertools
+        counter = itertools.count()
+        monkeypatch.setattr(
+            "api.services.task_manager._mtime_or_none",
+            lambda path: next(counter),
+        )
+
+        with pytest.raises(TaskConflictError):
+            task_manager.update(task.id, description="conflicting description")
+
+        assert task_manager.get(task.id).description == "Original description"
+        assert file_path.read_text(encoding="utf-8") == before_content
+
+    def test_swap_tag_conflict_leaves_in_memory_task_unchanged(self, task_manager, monkeypatch):
+        """#853 round 1 finding #4, swap_tag half: same in-place-mutation
+        bug in swap_tag's `compute()` closure — the index would show the new
+        tag while the vault still had the old one."""
+        task = task_manager.create("Swap conflict", context="CasTest4", tags=["agent"])
+        file_path = task_manager.tasks_dir / "CasTest4.md"
+        before_content = file_path.read_text(encoding="utf-8")
+
+        import itertools
+        counter = itertools.count()
+        monkeypatch.setattr(
+            "api.services.task_manager._mtime_or_none",
+            lambda path: next(counter),
+        )
+
+        with pytest.raises(TaskConflictError):
+            task_manager.swap_tag(task.id, "agent", "agent-running")
+
+        assert task_manager.get(task.id).tags == ["agent"]
+        assert file_path.read_text(encoding="utf-8") == before_content
+
+    def test_no_retry_needed_in_the_normal_case(self, task_manager):
+        task = task_manager.create("No conflict", context="CasTest2")
+        updated = task_manager.update(task.id, description="updated fine")
+        assert updated.description == "updated fine"
+
+
+class TestCreateCasRetryAndConflict:
+    """#853 round 1 finding #15: `_cas_insert_at_top` (the create path) had
+    no manager-level retry/conflict test — only a mocked-manager route test
+    (`test_create_task_conflict_is_409`)."""
+
+    def test_create_retries_three_times_then_raises_conflict(self, task_manager, monkeypatch):
+        import api.services.task_manager as tm_mod
+
+        call_count = {"n": 0}
+
+        def flaky_mtime(path):
+            call_count["n"] += 1
+            return call_count["n"]  # always different from the previous call
+
+        monkeypatch.setattr(tm_mod, "_mtime_or_none", flaky_mtime)
+
+        with pytest.raises(TaskConflictError):
+            task_manager.create("Conflict test", context="CreateCasTest")
+
+        # `_cas_insert_at_top` calls `_mtime_or_none` twice per attempt
+        # (before + now); `_CAS_MAX_RETRIES` retries means
+        # `_CAS_MAX_RETRIES + 1` attempts.
+        assert call_count["n"] == 2 * (tm_mod._CAS_MAX_RETRIES + 1)
+
+        file_path = task_manager.tasks_dir / "CreateCasTest.md"
+        content = file_path.read_text(encoding="utf-8") if file_path.exists() else ""
+        assert "Conflict test" not in content
+        assert task_manager.list_tasks(query="Conflict test") == []
+
+
+class TestConflictFiles:
+    def test_conflict_files_never_indexed(self, task_manager):
+        task_manager.create("Real task", context="ConflictTest")
+        conflict_path = (
+            task_manager.tasks_dir / "ConflictTest.sync-conflict-20260101-120000-ABCDEFG.md"
+        )
+        conflict_path.write_text("- [ ] TODO Ghost task <!-- id:ghost001 -->\n", encoding="utf-8")
+        temp_path = task_manager.tasks_dir / ".syncthing.ConflictTest.md.tmp"
+        temp_path.write_text("- [ ] TODO Temp ghost <!-- id:ghost002 -->\n", encoding="utf-8")
+
+        task_manager.rebuild_index()
+
+        assert task_manager.get("ghost001") is None
+        assert task_manager.get("ghost002") is None
+
+    def test_reindex_file_is_noop_for_conflict_file(self, task_manager):
+        conflict_path = task_manager.tasks_dir / "X.sync-conflict-20260101-120000-ABCDEFG.md"
+        conflict_path.write_text("- [ ] TODO Ghost <!-- id:ghost003 -->\n", encoding="utf-8")
+
+        task_manager.reindex_file(str(conflict_path))
+
+        assert task_manager.get("ghost003") is None
+
+    def test_list_conflicts_reports_name_and_mtime(self, task_manager):
+        conflict_path = task_manager.tasks_dir / "Y.sync-conflict-20260101-120000-ABCDEFG.md"
+        conflict_path.write_text("stub", encoding="utf-8")
+        temp_path = task_manager.tasks_dir / ".syncthing.Y.md.tmp"
+        temp_path.write_text("stub", encoding="utf-8")
+
+        conflicts = task_manager.list_conflicts()
+        names = {c["name"] for c in conflicts}
+        assert conflict_path.name in names
+        assert temp_path.name in names
+        for c in conflicts:
+            assert c["mtime"]
+
+    def test_is_conflict_file_helper(self):
+        assert is_conflict_file(Path("Inbox.sync-conflict-20260101-120000-ABCDEFG.md"))
+        assert is_conflict_file(Path(".syncthing.Inbox.md.tmp"))
+        assert not is_conflict_file(Path("Inbox.md"))
+
+    def test_is_conflict_file_matches_any_suffix_after_the_marker(self):
+        """#853 round 1 finding #10: the criterion is `*.sync-conflict-*`,
+        not Syncthing's own `-YYYYMMDD-HHMMSS-DEVICEID` timestamp format —
+        match the substring regardless of what follows it."""
+        assert is_conflict_file(Path("Inbox.sync-conflict-foo.md"))
+
+
+class TestUpdatedStamp:
+    def test_create_stamps_updated_with_utc_offset(self, task_manager):
+        task = task_manager.create("Stamped", context="Stamp")
+        assert task.updated_at is not None
+        assert re.search(r"[+-]\d{2}:\d{2}$", task.updated_at)
+        content = (task_manager.tasks_dir / "Stamp.md").read_text(encoding="utf-8")
+        assert f"[updated:: {task.updated_at}]" in content
+
+    def test_update_bumps_updated_stamp(self, task_manager):
+        task = task_manager.create("Stamped2", context="Stamp")
+        updated = task_manager.update(task.id, priority="high")
+        assert updated.updated_at is not None
+        assert re.search(r"[+-]\d{2}:\d{2}$", updated.updated_at)
+
+    def test_complete_stamps_updated(self, task_manager):
+        task = task_manager.create("Stamped3", context="Stamp")
+        completed = task_manager.complete(task.id)
+        assert completed.updated_at is not None
+
+    def test_swap_tag_stamps_updated(self, task_manager):
+        task = task_manager.create("Stamped4", context="Stamp", tags=["agent"])
+        task_manager.swap_tag(task.id, "agent", "agent-running")
+        assert task_manager.get(task.id).updated_at is not None
+
+
+class TestAtomicWriteIntegration:
+    def test_writes_go_through_os_replace(self, task_manager, monkeypatch):
+        import api.services.atomic_write as aw
+
+        calls = []
+        original_replace = aw.os.replace
+
+        def spy_replace(src, dst):
+            calls.append((src, dst))
+            return original_replace(src, dst)
+
+        monkeypatch.setattr(aw.os, "replace", spy_replace)
+
+        task_manager.create("Atomic test", context="Atomic")
+
+        assert len(calls) >= 1
+        for src, dst in calls:
+            assert Path(src).parent == Path(dst).parent
+        # #853 round 1 finding #16: the task markdown file itself must be
+        # among the atomically-written destinations, not just "some file
+        # was written via os.replace" (the index write alone satisfies the
+        # old assertion).
+        task_file = str(task_manager.tasks_dir / "Atomic.md")
+        assert task_file in [dst for _, dst in calls], "task markdown file was never atomically written"
+
+    def test_no_leftover_temp_files_after_write(self, task_manager):
+        task_manager.create("No leftovers", context="Atomic2")
+        assert list(task_manager.tasks_dir.glob(".*.tmp")) == []
+
+
+class TestBlockedStatus:
+    def test_blocked_status_formats_as_question_mark(self, task_manager):
+        task = task_manager.create("Waiting on X", context="StatusTest", status="blocked")
+        assert task.status == "blocked"
+        content = (task_manager.tasks_dir / "StatusTest.md").read_text(encoding="utf-8")
+        assert "- [?] TODO Waiting on X" in content
+
+
+class TestFormatTaskBlock:
+    def test_format_task_block_no_notes_is_single_line(self):
+        task = Task(id="t1", description="No notes", status="todo", context="Inbox", created_date="2025-02-08")
+        assert _format_task_block(task) == [_format_task_line(task)]
+
+    def test_format_task_block_with_notes_appends_indented_lines(self):
+        task = Task(
+            id="t1", description="Has notes", status="todo", context="Inbox",
+            created_date="2025-02-08", notes="line one\nline two",
+        )
+        block = _format_task_block(task)
+        assert block[0] == _format_task_line(task)
+        assert block[1] == "    > line one"
+        assert block[2] == "    > line two"

--- a/tests/test_task_watcher.py
+++ b/tests/test_task_watcher.py
@@ -78,6 +78,39 @@ class TestHandlerScheduling:
         time.sleep(0.2)
         assert calls == []
 
+    def test_skips_sync_conflict_file(self):
+        """#853: a Syncthing conflict copy is never a reindex source."""
+        calls = []
+        handler = _TaskFileHandler(lambda p: calls.append(p))
+        handler.on_modified(_FakeEvent("/x/Tasks/Inbox.sync-conflict-20260101-120000-ABCDEFG.md"))
+        time.sleep(0.2)
+        assert calls == []
+
+    def test_skips_syncthing_temp_file(self):
+        """#853: a Syncthing in-progress temp file is never a reindex source.
+
+        This particular path is dropped by `on_modified`'s `.endswith(".md")`
+        check before `is_conflict_file` ever runs — kept as-is because it
+        documents that suffix filter. `test_schedule_skips_syncthing_temp_file_directly`
+        below exercises the `is_conflict_file` guard inside `_schedule` itself.
+        """
+        calls = []
+        handler = _TaskFileHandler(lambda p: calls.append(p))
+        handler.on_modified(_FakeEvent("/x/Tasks/.syncthing.Inbox.md.tmp"))
+        time.sleep(0.2)
+        assert calls == []
+
+    def test_schedule_skips_syncthing_temp_file_directly(self):
+        """Calls `_schedule` directly with a path `on_modified` would never
+        forward (no `.md` suffix), so this actually exercises the
+        `is_conflict_file` guard at `task_watcher.py`'s top of `_schedule` —
+        the previous test above never reaches it."""
+        calls = []
+        handler = _TaskFileHandler(lambda p: calls.append(p))
+        handler._schedule("/x/Tasks/.syncthing.Inbox.md.tmp")
+        time.sleep(0.2)
+        assert calls == []
+
     def test_move_event_fires_for_both_paths(self):
         calls = []
         done = threading.Event()

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -57,20 +57,45 @@ class TestTasksAPI:
         data = response.json()
         assert data["description"] == "Pull 1099 from Schwab"
         assert data["id"] == "abc12345"
-        # context comes from the fixture's sample_task; the API itself no
-        # longer accepts a context on create — everything lands in Inbox.
+        # No context in the request -> defaults to Inbox.
         _, kwargs = mock_task_manager.create.call_args
-        assert "context" not in kwargs
+        assert kwargs["context"] == "Inbox"
 
-    def test_create_task_ignores_context_input(self, client, mock_task_manager):
-        """Stray 'context' in the request body is dropped, not forwarded."""
+    def test_create_task_forwards_context(self, client, mock_task_manager):
+        """#853: unlike the chat `manage_tasks` tool (which always lands in
+        Inbox to avoid an LLM guessing a wrong context), the raw HTTP API
+        honors an explicit context on create — a direct API client (the
+        Kanban board) knows exactly where it wants the task filed. This
+        intentionally replaces the old test_create_task_ignores_context_input,
+        which pinned the opposite behavior at this layer."""
         response = client.post("/api/tasks", json={
             "description": "Quick task",
-            "context": "Work",  # silently dropped by Pydantic
+            "context": "Work",
         })
         assert response.status_code == 200
         _, kwargs = mock_task_manager.create.call_args
-        assert "context" not in kwargs
+        assert kwargs["context"] == "Work"
+
+    def test_create_task_forwards_status_notes_fields(self, client, mock_task_manager):
+        response = client.post("/api/tasks", json={
+            "description": "Rich task",
+            "status": "blocked",
+            "notes": "line one\nline two",
+            "fields": {"host": "laptop", "effort": "high"},
+        })
+        assert response.status_code == 200
+        _, kwargs = mock_task_manager.create.call_args
+        assert kwargs["status"] == "blocked"
+        assert kwargs["notes"] == "line one\nline two"
+        assert kwargs["fields"] == {"host": "laptop", "effort": "high"}
+
+    def test_create_task_invalid_status_is_422(self, client, mock_task_manager):
+        response = client.post("/api/tasks", json={
+            "description": "Bad status",
+            "status": "not_a_real_status",
+        })
+        assert response.status_code == 422
+        mock_task_manager.create.assert_not_called()
 
     def test_create_task_minimal(self, client, mock_task_manager):
         response = client.post("/api/tasks", json={
@@ -102,6 +127,34 @@ class TestTasksAPI:
         client = TestClient(app, raise_server_exceptions=False)
         response = client.post("/api/tasks", json={"description": "Pull 1099 from Schwab"})
         assert not (200 <= response.status_code < 300)
+
+    def test_create_task_conflict_is_409(self, client, mock_task_manager):
+        from api.services.task_manager import TaskConflictError
+        mock_task_manager.create.side_effect = TaskConflictError("too many conflicting writes")
+        response = client.post("/api/tasks", json={"description": "Pull 1099 from Schwab"})
+        assert response.status_code == 409
+
+    def test_create_task_hostile_field_value_is_422(self, client, mock_task_manager):
+        """#853 round 1 finding #2: a `ValueError` from `TaskManager.create`
+        (hostile description/notes/fields content) maps to 422, not an
+        unhandled 500."""
+        mock_task_manager.create.side_effect = ValueError("description must not contain '\\n'")
+        response = client.post("/api/tasks", json={"description": "Pull 1099 from Schwab"})
+        assert response.status_code == 422
+        assert "must not contain" in response.json()["detail"]
+
+    def test_create_task_reserved_field_key_is_422(self, client, mock_task_manager):
+        """#853 round 1 finding #3: a reserved `fields` key (e.g. `updated`)
+        maps to 422."""
+        mock_task_manager.create.side_effect = ValueError(
+            "'updated' is a reserved field and cannot be set via fields"
+        )
+        response = client.post("/api/tasks", json={
+            "description": "Pull 1099 from Schwab",
+            "fields": {"updated": "SPOOFED"},
+        })
+        assert response.status_code == 422
+        assert "reserved" in response.json()["detail"]
 
     # --- DRY RUN (#138) ---
 
@@ -297,6 +350,37 @@ class TestTasksAPI:
         })
         assert response.status_code == 404
 
+    def test_update_task_invalid_status_is_422(self, client, mock_task_manager):
+        response = client.put("/api/tasks/abc12345", json={
+            "status": "not_a_real_status",
+        })
+        assert response.status_code == 422
+        mock_task_manager.update.assert_not_called()
+
+    def test_update_task_forwards_notes_and_fields(self, client, mock_task_manager):
+        response = client.put("/api/tasks/abc12345", json={
+            "notes": "new notes",
+            "fields": {"host": "laptop", "effort": None},
+        })
+        assert response.status_code == 200
+        _, kwargs = mock_task_manager.update.call_args
+        assert kwargs["notes"] == "new notes"
+        assert kwargs["fields"] == {"host": "laptop", "effort": None}
+
+    def test_update_task_conflict_is_409(self, client, mock_task_manager):
+        from api.services.task_manager import TaskConflictError
+        mock_task_manager.update.side_effect = TaskConflictError("too many conflicting writes")
+        response = client.put("/api/tasks/abc12345", json={"priority": "high"})
+        assert response.status_code == 409
+
+    def test_update_task_hostile_field_value_is_422(self, client, mock_task_manager):
+        """#853 round 1 finding #2: a `ValueError` from `TaskManager.update`
+        maps to 422, not an unhandled 500."""
+        mock_task_manager.update.side_effect = ValueError("fields['x'] must not contain ']'")
+        response = client.put("/api/tasks/abc12345", json={"fields": {"x": "bad]value"}})
+        assert response.status_code == 422
+        assert "must not contain" in response.json()["detail"]
+
     # --- COMPLETE ---
 
     def test_complete_task(self, client, mock_task_manager):
@@ -308,6 +392,12 @@ class TestTasksAPI:
         mock_task_manager.complete.return_value = None
         response = client.put("/api/tasks/nonexistent/complete")
         assert response.status_code == 404
+
+    def test_complete_task_conflict_is_409(self, client, mock_task_manager):
+        from api.services.task_manager import TaskConflictError
+        mock_task_manager.complete.side_effect = TaskConflictError("too many conflicting writes")
+        response = client.put("/api/tasks/abc12345/complete")
+        assert response.status_code == 409
 
     # --- TAGS ---
 
@@ -345,6 +435,12 @@ class TestTasksAPI:
         response = client.delete("/api/tasks/nonexistent")
         assert response.status_code == 404
 
+    def test_delete_task_conflict_is_409(self, client, mock_task_manager):
+        from api.services.task_manager import TaskConflictError
+        mock_task_manager.delete.side_effect = TaskConflictError("too many conflicting writes")
+        response = client.delete("/api/tasks/abc12345")
+        assert response.status_code == 409
+
     # --- RESPONSE SHAPE ---
 
     def test_task_response_shape(self, client, mock_task_manager):
@@ -354,10 +450,45 @@ class TestTasksAPI:
         expected_fields = [
             "id", "description", "status", "context", "priority",
             "due_date", "created_date", "done_date", "cancelled_date",
-            "tags", "reminder_id", "source_file", "line_number",
+            "updated_at", "tags", "reminder_id", "notes", "fields",
+            "source_file", "line_number",
         ]
         for f in expected_fields:
             assert f in data, f"Missing field: {f}"
+
+    # --- CONFLICTS ---
+
+    def test_list_conflicts(self, client, mock_task_manager):
+        mock_task_manager.list_conflicts.return_value = [
+            {"name": "Inbox.sync-conflict-20260101-120000-ABCDEFG.md", "mtime": "2026-01-01T12:00:00+00:00"},
+        ]
+        response = client.get("/api/tasks/conflicts")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["conflicts"]) == 1
+        assert data["conflicts"][0]["name"] == "Inbox.sync-conflict-20260101-120000-ABCDEFG.md"
+
+    def test_list_conflicts_empty(self, client, mock_task_manager):
+        mock_task_manager.list_conflicts.return_value = []
+        response = client.get("/api/tasks/conflicts")
+        assert response.status_code == 200
+        assert response.json() == {"conflicts": []}
+
+    def test_conflicts_route_not_captured_by_task_id(self, client, mock_task_manager):
+        """'conflicts' must never be treated as a task id — regression guard
+        for route registration order."""
+        mock_task_manager.list_conflicts.return_value = []
+        response = client.get("/api/tasks/conflicts")
+        assert response.status_code == 200
+        mock_task_manager.get.assert_not_called()
+
+    # --- SWAP-TAG ---
+
+    def test_swap_tag_conflict_is_409(self, client, mock_task_manager):
+        from api.services.task_manager import TaskConflictError
+        mock_task_manager.swap_tag.side_effect = TaskConflictError("too many conflicting writes")
+        response = client.post("/api/tasks/abc12345/swap-tag?from=agent&to=agent-running")
+        assert response.status_code == 409
 
 
 class TestListTasksParameterDocs:

--- a/tests/test_workout_mcp_route.py
+++ b/tests/test_workout_mcp_route.py
@@ -182,10 +182,11 @@ class TestSharedStore:
 
 class TestNoUnrelatedChange:
     def test_curated_endpoint_count(self):
-        """Pins the new total (56 = the pre-existing 55 + this one) so a
-        future change to this count is a deliberate, reviewed edit."""
+        """Pins the new total (59 = the pre-existing 56 [55 + this one] plus
+        the 3 Human-queue tools added by #852) so a future change to this
+        count is a deliberate, reviewed edit."""
         module = _load_mcp_module()
-        assert len(module.CURATED_ENDPOINTS) == 56
+        assert len(module.CURATED_ENDPOINTS) == 59
 
     def test_other_tools_unaffected(self):
         module = _load_mcp_module()
@@ -198,9 +199,13 @@ class TestNoUnrelatedChange:
     def test_agentic_loop_tool_count_unchanged(self):
         """manage_workouts already existed in the native agentic-loop tool
         set (#320) — this PR only adds an MCP-side route to it, so the
-        agentic-loop tool count must not move."""
+        agentic-loop tool count must not move.
+
+        Pinned total: 22 = the pre-existing 21 + `manage_human_queue`,
+        added by #852. A future change to this count should be deliberate
+        and reviewed, same as the CURATED_ENDPOINTS count above."""
         from api.services.agent_tools import TOOL_DEFINITIONS
-        assert len(TOOL_DEFINITIONS) == 21
+        assert len(TOOL_DEFINITIONS) == 22
 
 
 # ---------------------------------------------------------------------------

--- a/web/agents.html
+++ b/web/agents.html
@@ -26,6 +26,26 @@
     --completed: #6b7280;
     --failed: #f87171;
   }
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--border) transparent;
+  }
+  *::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: var(--border);
+    border-radius: 6px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+  }
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: var(--text-dim);
+  }
   body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     background: var(--bg-primary);

--- a/web/agents.html
+++ b/web/agents.html
@@ -88,6 +88,7 @@
     flex-wrap: wrap;
     margin-left: auto;
   }
+  .chips[hidden] { display: none; }
   .chip {
     background: var(--bg-card);
     border: 1px solid var(--border);
@@ -112,7 +113,7 @@
     color: var(--text-secondary);
   }
   .filters label { display: flex; align-items: center; gap: 0.35rem; cursor: pointer; }
-  .filters select {
+  .filters select, .filters input[type="text"] {
     background: var(--bg-card);
     color: var(--text-primary);
     border: 1px solid var(--border);
@@ -361,8 +362,10 @@
   .badge.status-claimed { color: var(--claimed); border-color: var(--claimed); }
   .badge.status-yielded { color: var(--yielded); border-color: var(--yielded); }
   .badge.status-inactive { color: var(--yielded); border-color: var(--yielded); }
+  .badge.status-idle { color: var(--yielded); border-color: var(--yielded); }
   .badge.status-blocked { color: var(--blocked); border-color: var(--blocked); }
   .badge.status-completed { color: var(--completed); border-color: var(--completed); }
+  .badge.status-ended { color: var(--completed); border-color: var(--completed); }
   .badge.status-failed,
   .badge.status-budget_exceeded { color: var(--failed); border-color: var(--failed); }
   .panel-empty {
@@ -765,6 +768,229 @@
     }
     .chips { display: none; }
   }
+
+  /* -------------------------------------------------------------------
+     Board tab (#850) — Kanban board that reuses the styles above for
+     chips, panel-*, modal-*, and toast markup (the drawer's session
+     panel section renders the same `.panel-header` / `.events` / etc.
+     structure SessionPanel builds for the Graph tab).
+     ------------------------------------------------------------------- */
+  .tabs {
+    display: flex;
+    gap: 0.25rem;
+    margin-left: 0.5rem;
+  }
+  .tab-btn {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    font-weight: 500;
+    padding: 0.375rem 0.75rem;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .tab-btn:hover { background: var(--bg-card); color: var(--text-primary); }
+  .tab-btn.active { background: var(--accent); color: var(--bg-primary); }
+  .tab-view[hidden] { display: none; }
+  #board-view {
+    height: calc(100vh - 56px - 45px);
+    display: flex;
+    flex-direction: column;
+  }
+  #board-view[hidden] { display: none; }
+  .board-filters {
+    display: flex;
+    gap: 0.6rem;
+    align-items: center;
+    padding: 0.5rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    flex-wrap: wrap;
+  }
+  .board-filters select,
+  .board-filters input[type="text"],
+  .board-filters input[type="search"] {
+    background: var(--bg-card);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.8rem;
+  }
+  .board-filters label { display: flex; align-items: center; gap: 0.3rem; cursor: pointer; }
+  #board-new-card {
+    margin-left: auto;
+    background: var(--accent);
+    color: var(--bg-primary);
+    border: none;
+    border-radius: 6px;
+    padding: 0.35rem 0.8rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  #board-lanes {
+    flex: 1;
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.75rem 1.25rem;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+  .board-lane {
+    flex: 0 0 260px;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .board-lane.drag-over { border-color: var(--accent); }
+  .board-lane-header {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    justify-content: space-between;
+  }
+  .board-lane-count { color: var(--text-dim); font-weight: 400; }
+  .board-lane-cards {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .board-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.5rem 0.6rem;
+    font-size: 0.8rem;
+    cursor: pointer;
+  }
+  .board-card:hover { border-color: var(--accent); }
+  .board-card.dragging-source { opacity: 0.4; }
+  .board-card-ghost { opacity: 0.9; box-shadow: 0 8px 24px rgba(0,0,0,0.5); }
+  .board-card-title { font-weight: 600; word-break: break-word; }
+  .board-card-question {
+    margin-top: 0.3rem;
+    font-size: 0.72rem;
+    color: var(--blocked);
+  }
+  .board-card-lastrun {
+    margin-top: 0.3rem;
+    font-size: 0.7rem;
+    color: var(--text-dim);
+  }
+  .board-card-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    margin-top: 0.35rem;
+  }
+  .board-chip {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.05rem 0.5rem;
+    font-size: 0.68rem;
+    color: var(--text-secondary);
+  }
+  .board-chip-assignee { color: var(--accent); border-color: var(--accent); }
+  .board-chip-host { color: var(--claimed); border-color: var(--claimed); }
+  #board-connection-state { margin-left: 0.5rem; color: var(--text-dim); font-size: 0.75rem; }
+
+  .board-drawer-backdrop {
+    position: fixed; inset: 0;
+    background: rgba(0,0,0,0.5);
+    z-index: 90;
+    display: flex;
+    justify-content: flex-end;
+  }
+  .board-drawer-backdrop[hidden] { display: none; }
+  .board-drawer {
+    width: min(440px, 92vw);
+    height: 100vh;
+    background: var(--bg-secondary);
+    border-left: 1px solid var(--border);
+    overflow-y: auto;
+    padding: 1rem;
+  }
+  .drawer-header { position: relative; margin-bottom: 0.75rem; }
+  .drawer-title {
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: var(--text-primary);
+    font-size: 1rem;
+    font-weight: 600;
+    padding: 0.2rem 1.75rem 0.2rem 0;
+  }
+  .drawer-title:focus { outline: 1px solid var(--accent); border-radius: 4px; }
+  .drawer-label {
+    display: block;
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-dim);
+    margin: 0.6rem 0 0.25rem;
+  }
+  .drawer-notes, .drawer-tags, .drawer-context, .drawer-assignee {
+    width: 100%;
+    background: var(--bg-elev);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.4rem 0.55rem;
+    font-family: inherit;
+    font-size: 0.8rem;
+  }
+  .drawer-notes { min-height: 5rem; resize: vertical; }
+  .drawer-row { display: grid; grid-template-columns: 1fr 1fr; gap: 0.6rem; }
+  .drawer-actions { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.75rem; }
+  .drawer-action {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    border-radius: 6px;
+    padding: 0.3rem 0.65rem;
+    font-size: 0.75rem;
+    cursor: pointer;
+  }
+  .drawer-action:hover { border-color: var(--accent); }
+  .drawer-session { margin-top: 0.75rem; border-top: 1px solid var(--border); padding-top: 0.5rem; }
+  .drawer-session .panel-header { padding: 0; border: none; }
+  .drawer-session .events { max-height: 40vh; padding: 0.5rem 0; }
+  .drawer-schedule-hint { color: var(--text-dim); font-size: 0.8rem; margin-top: 0.5rem; }
+  .drawer-assignment { margin-top: 0.6rem; }
+  .assignment-row { margin: 0.6rem 0; }
+  .assignment-label {
+    display: block;
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-dim);
+    margin: 0 0 0.25rem;
+  }
+  .assignment-engine, .assignment-model, .assignment-effort, .assignment-host {
+    width: 100%;
+    background: var(--bg-elev);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.4rem 0.55rem;
+    font-family: inherit;
+    font-size: 0.8rem;
+  }
+  .assignment-ran { color: var(--text-dim); font-size: 0.75rem; margin-top: 0.3rem; }
+  .assignment-error { color: var(--failed); font-size: 0.75rem; margin-top: 0.3rem; }
 </style>
 </head>
 <body>
@@ -775,7 +1001,11 @@
     <a href="/crm" class="nav-link">👥 CRM</a>
     <a href="/agents" class="nav-link active">🛠️ Agents</a>
   </nav>
-  <div class="chips" id="chips">
+  <div class="tabs" id="tabs">
+    <button class="tab-btn active" id="tab-btn-board" data-tab="board">Board</button>
+    <button class="tab-btn" id="tab-btn-graph" data-tab="graph">Graph</button>
+  </div>
+  <div class="chips" id="graph-chips" hidden>
     <span class="chip running">running <strong id="chip-running">0</strong></span>
     <span class="chip blocked">blocked <strong id="chip-blocked">0</strong></span>
     <span class="chip">recent <strong id="chip-recent">0</strong></span>
@@ -788,1824 +1018,147 @@
     </span>
   </div>
 </header>
-<div class="filters">
-  <div class="search-wrap" id="search-wrap">
-    <input type="search" id="search-input" placeholder="Search sessions…" autocomplete="off" spellcheck="false"
-           title="Search session names and summaries. Matches in visible nodes rank above filtered-out ones; click a result to highlight it." />
-    <div class="search-results" id="search-results" hidden></div>
-  </div>
-  <label title="Include sessions that already finished — completed, failed, or budget-exceeded. Hidden by default so the graph focuses on what's live right now."><input type="checkbox" id="filter-terminal" /> include finished</label>
-  <label title="Hide sessions whose last activity is older than this. Default flips to 1 week when 'include finished' is on; 30min otherwise.">recency
-    <select id="filter-recency">
-      <option value="60">1 min</option>
-      <option value="1800" selected>30 min</option>
+
+<!-- Board tab (#850) — the primary /agents view. -->
+<div class="tab-view" id="board-view">
+  <div class="board-filters" id="board-filters">
+    <input type="search" id="board-search" placeholder="Search cards…" autocomplete="off" spellcheck="false" />
+    <select id="board-filter-lane" title="Lane">
+      <option value="all">all lanes</option>
+      <option value="unassigned">Unassigned</option>
+      <option value="assigned">Assigned</option>
+      <option value="in_progress">In progress</option>
+      <option value="human_queue">Human queue</option>
+      <option value="scheduled">Scheduled</option>
+      <option value="review">Review</option>
+      <option value="done">Done</option>
+    </select>
+    <select id="board-filter-assignee" title="Assignee">
+      <option value="all">any assignee</option>
+      <option value="unassigned">unassigned</option>
+      <option value="me">me</option>
+      <option value="claude">claude</option>
+      <option value="codex">codex</option>
+      <option value="hermes">hermes</option>
+      <option value="local">local</option>
+    </select>
+    <select id="board-filter-host" title="Host"><option value="all">all hosts</option></select>
+    <input type="text" id="board-filter-tag" placeholder="tag" />
+    <select id="board-filter-context" title="Context"><option value="all">all contexts</option></select>
+    <select id="board-filter-recency" title="Recency">
+      <option value="all" selected>all time</option>
+      <option value="3600">1 h</option>
       <option value="86400">24 h</option>
       <option value="604800">1 wk</option>
-      <option value="all">all time</option>
     </select>
-  </label>
-  <label title="Limit to sessions whose project working directory matches.">cwd
-    <select id="filter-cwd">
-      <option value="all">all</option>
-    </select>
-  </label>
-  <label>route
-    <select id="filter-route">
-      <option value="all">all</option>
-      <option value="local">local</option>
-      <option value="remote">remote</option>
-      <option value="claude">claude</option>
-      <option value="claude_code">claude code</option>
-      <option value="codex">codex</option>
-    </select>
-  </label>
-  <label>status
-    <select id="filter-status">
-      <option value="all">all</option>
-      <option value="running">running</option>
-      <option value="claimed">claimed</option>
-      <option value="yielded">yielded</option>
-      <option value="inactive">inactive</option>
-      <option value="blocked">blocked</option>
-      <option value="completed">completed</option>
-      <option value="failed">failed</option>
-    </select>
-  </label>
-  <span style="margin-left:auto;color:var(--text-dim);font-size:0.75rem" id="connection-state">connecting…</span>
+    <label><input type="checkbox" id="board-filter-done" /> include cancelled</label>
+    <button id="board-new-card" type="button">+ New card</button>
+    <span id="board-connection-state">connecting…</span>
+  </div>
+  <div id="board-lanes"></div>
 </div>
-<main>
-  <section id="graph">
-    <svg id="graph-svg" preserveAspectRatio="xMidYMid meet"></svg>
-    <div class="empty-state" id="empty-state">
-      <div class="icon">🛠️</div>
-      <div class="label">No agent sessions yet</div>
-      <div class="hint">Sessions will appear here when an <code>#agent</code> task is claimed.</div>
+<div class="board-drawer-backdrop" id="board-drawer-backdrop" hidden>
+  <aside class="board-drawer" id="board-drawer"></aside>
+</div>
+
+<!-- Graph tab (#850) — the pre-#850 /agents page, unchanged, as a secondary tab. -->
+<div class="tab-view" id="graph-view" hidden>
+  <div class="filters">
+    <div class="search-wrap" id="search-wrap">
+      <input type="search" id="search-input" placeholder="Search sessions…" autocomplete="off" spellcheck="false"
+             title="Search session names and summaries. Matches in visible nodes rank above filtered-out ones; click a result to highlight it." />
+      <div class="search-results" id="search-results" hidden></div>
     </div>
-  </section>
-  <aside class="panel" id="panel-outer">
-    <div class="panel-resizer" id="panel-resizer" title="Drag to resize"></div>
-    <div class="panel-content" id="panel">
-      <div class="panel-empty" id="panel-empty">Click a node to inspect its transcript.</div>
-    </div>
-  </aside>
-</main>
-
-<script>
-(() => {
-  const STATUS_COLORS = {
-    running:   '#34d399',
-    claimed:   '#60a5fa',
-    yielded:   '#fbbf24',  // agent worker — paused waiting on children
-    inactive:  '#fbbf24',  // claude code — paused, resumable
-    blocked:   '#fb923c',
-    completed: '#6b7280',
-    failed:    '#f87171',
-    budget_exceeded: '#f87171',
-  };
-  const TERMINAL = new Set(['completed', 'failed', 'budget_exceeded']);
-
-  const filterTerminalEl = document.getElementById('filter-terminal');
-  const filterRouteEl = document.getElementById('filter-route');
-  const filterStatusEl = document.getElementById('filter-status');
-  const filterRecencyEl = document.getElementById('filter-recency');
-  const filterCwdEl = document.getElementById('filter-cwd');
-  const connStateEl = document.getElementById('connection-state');
-  const emptyStateEl = document.getElementById('empty-state');
-  const panelEl = document.getElementById('panel');
-  const panelOuterEl = document.getElementById('panel-outer');
-  const panelResizerEl = document.getElementById('panel-resizer');
-  // Operator chooses recency manually → don't auto-flip on include-finished toggle.
-  let recencyManuallySet = false;
-
-  let allSessions = [];
-  let allEdges = [];
-  let selectedSessionId = null;
-  let transcriptES = null;
-
-  // -------------------------------------------------------------------
-  // D3 force-directed graph (mirrors /crm/graph patterns).
-  // Replaced an earlier vis-network implementation — see #173 for context.
-  // -------------------------------------------------------------------
-  const graphEl = document.getElementById('graph');
-  const svg = d3.select('#graph-svg');
-  // viewBox-driven coordinates: pick a virtual canvas and let SVG scale
-  // it to fit the actual element. Easier than tracking pixel size and
-  // resizing canvases — and gives us a clean window for the recency-x rail.
-  const VIEW_W = 1600;
-  const VIEW_H = 1100;
-  svg.attr('viewBox', `0 0 ${VIEW_W} ${VIEW_H}`);
-  // Allow the SVG to render content outside the viewBox so collision-pushed
-  // nodes don't get clipped at the edges. The viewBox is the *intended*
-  // window; physics may briefly nudge nodes beyond it.
-  svg.style('overflow', 'visible');
-  // Single zoomable viewport that wraps both layers — the d3.zoom behavior
-  // mutates this group's transform, mirroring /crm/graph (crm.html:17528).
-  const viewport = svg.append('g').attr('class', 'viewport');
-  const linkLayer = viewport.append('g').attr('class', 'links');
-  const nodeLayer = viewport.append('g').attr('class', 'nodes');
-
-  // Pan (drag background) + zoom (wheel / pinch). d3.drag on nodes stops
-  // propagation, so node-drags don't also pan the canvas.
-  const zoom = d3.zoom()
-    .scaleExtent([0.2, 5])
-    .on('zoom', (event) => {
-      viewport.attr('transform', event.transform);
-    });
-  svg.call(zoom);
-  // Match crm.html: cursor hint on the background so the operator knows it's
-  // pannable. Node cursors override this when hovering a draggable node.
-  svg.style('cursor', 'grab');
-  svg.on('mousedown.cursor', () => svg.style('cursor', 'grabbing'));
-  svg.on('mouseup.cursor',   () => svg.style('cursor', 'grab'));
-
-  // Click on empty SVG background → deselect (mirrors /crm/graph's
-  // close-panels-on-empty-click pattern at crm.html:17522). Node clicks bubble
-  // up too, but we only act when the target is the svg itself.
-  svg.on('click', (event) => {
-    if (event.target === svg.node() && selectedSessionId) closePanel();
-  });
-
-  // Width fraction of the viewBox used by the recency rail. Scales with the
-  // visible-node count: 1 node centers, 2 nodes sit on a narrow band, many
-  // nodes spread across most of the canvas.
-  let visibleCount = 0;
-  // Sorted-and-joined visible session_id set from the previous render. Used
-  // to detect structural changes (filter operations, new sessions arriving,
-  // sessions terminating out of view) so the simulation only re-energizes
-  // when there's an actual reason to move nodes — never on a same-set
-  // snapshot tick, which would otherwise jitter every 2 seconds.
-  let _lastVisibleIdsKey = '';
-  // Click-vs-dblclick debounce on graph nodes. See node `.on('click')` /
-  // `.on('dblclick')` handlers — a deferred timer lets a second click
-  // arrive in time to cancel the panel toggle and run Go To instead.
-  let _nodeClickTimer = null;
-  function recencyRailSpan() {
-    if (visibleCount <= 1) return 0;
-    return Math.min(0.84, 0.15 + 0.15 * Math.log2(visibleCount));
-  }
-
-  // Map session.last_activity_at → x in viewBox coords. Newer to the right,
-  // older to the left, clamped at 24h. Width of the rail shrinks as
-  // visibleCount shrinks so single-node filters end up centered.
-  function recencyTargetX(s) {
-    const span = recencyRailSpan();
-    const nowSec = Date.now() / 1000;
-    const ageSec = Math.max(0, nowSec - (s.last_activity_at || nowSec));
-    const ageNorm = Math.min(ageSec, 86400) / 86400;
-    return VIEW_W * (0.5 + span / 2 - ageNorm * span);
-  }
-
-  // Force simulation. Constants chosen to mirror /crm/graph's settled feel:
-  // weak link strength, strong charge, very weak centering, and aggressive
-  // collision so the token-based-sized nodes never overlap.
-  const simulation = d3.forceSimulation()
-    .force('link', d3.forceLink().id(d => d.session_id).distance(80).strength(0.04))
-    .force('charge', d3.forceManyBody().strength(-220).distanceMax(600))
-    .force('center-y', d3.forceY(VIEW_H / 2).strength(0.12))
-    .force('recency-x', d3.forceX(recencyTargetX).strength(0.18))
-    .force('collide', d3.forceCollide().radius(d => collideRadius(d)).strength(0.9))
-    .alphaDecay(0.025)
-    .alphaMin(0.001)
-    .velocityDecay(0.45);
-
-  // 8-second backstop in case the simulation doesn't naturally converge.
-  setTimeout(() => simulation.alpha(0).stop(), 8000);
-
-  // Per-tick: position SVG elements from the simulation's computed (x, y).
-  simulation.on('tick', () => {
-    nodeLayer.selectAll('.node').attr('transform', d => `translate(${d.x},${d.y})`);
-    linkLayer.selectAll('.link').attr('d', d => {
-      const sx = d.source.x, sy = d.source.y;
-      const tx = d.target.x, ty = d.target.y;
-      // Gentle curve so spawn edges don't all sit on top of each other.
-      const dx = tx - sx, dy = ty - sy;
-      const dr = Math.sqrt(dx * dx + dy * dy) * 1.6 || 1;
-      return `M${sx},${sy}A${dr},${dr} 0 0,1 ${tx},${ty}`;
-    });
-  });
-
-  // Strip the user's home directory prefix for display.
-  // /home/user/Code/LifeOS → /Code/LifeOS
-  function shortenCwd(p) {
-    if (!p) return p;
-    const m = p.match(/^\/(home|Users)\/[^/]+(\/.*)?$/);
-    if (m) return m[2] || '/';
-    return p;
-  }
-
-  // Re-populate the cwd dropdown with unique decoded_cwd values from the
-  // snapshot. Preserves operator selection if the chosen cwd still exists.
-  let _lastCwdOptionKey = '';
-  function updateCwdOptions(sessions) {
-    if (!filterCwdEl) return;
-    const cwds = [...new Set(sessions.map(s => s.decoded_cwd).filter(Boolean))].sort();
-    const key = cwds.join('|');
-    if (key === _lastCwdOptionKey) return;
-    _lastCwdOptionKey = key;
-    const current = filterCwdEl.value;
-    filterCwdEl.innerHTML = '<option value="all">all</option>'
-      + cwds.map(c => `<option value="${escapeHtml(c)}">${escapeHtml(shortenCwd(c))}</option>`).join('');
-    if (current && (current === 'all' || cwds.includes(current))) {
-      filterCwdEl.value = current;
-    }
-    const wrap = filterCwdEl.closest('label');
-    if (wrap) wrap.style.display = cwds.length > 0 ? '' : 'none';
-  }
-
-  function applyFilters(sessions) {
-    const showTerm = filterTerminalEl.checked;
-    const route = filterRouteEl.value;
-    const status = filterStatusEl.value;
-    const recencyRaw = filterRecencyEl ? filterRecencyEl.value : 'all';
-    const recencySec = (recencyRaw === 'all') ? null : Number(recencyRaw);
-    const cwdSel = filterCwdEl ? filterCwdEl.value : 'all';
-    const nowSec = Date.now() / 1000;
-    return sessions.filter(s => {
-      if (!showTerm && TERMINAL.has(s.status)) return false;
-      if (recencySec !== null && s.last_activity_at
-          && (nowSec - s.last_activity_at) > recencySec) {
-        return false;
-      }
-      if (cwdSel !== 'all' && s.decoded_cwd !== cwdSel) return false;
-      if (route !== 'all') {
-        const r = s.routing || 'local';
-        if (r !== route) return false;
-      }
-      if (status !== 'all' && s.status !== status) return false;
-      return true;
-    });
-  }
-
-  function applyRecencyDefault() {
-    if (recencyManuallySet || !filterRecencyEl) return;
-    filterRecencyEl.value = filterTerminalEl.checked ? '604800' : '1800';
-  }
-  applyRecencyDefault();
-
-  function routingLabel(routing) {
-    if (!routing || routing === 'local') return 'Local';
-    if (routing === 'claude_code' || routing === 'code') return 'Claude Code';
-    if (routing === 'codex') return 'Codex';
-    if (routing === 'remote') return 'Remote';  // #809: #cloud tag, not Anthropic
-    return 'Claude';
-  }
-
-  // Hex helper — lighten/darken/transparentize a color for terminal nodes
-  // so completed/failed sessions read as "done" without losing their status hue.
-  function hexWithAlpha(hex, alpha) {
-    const h = hex.replace('#', '');
-    const r = parseInt(h.slice(0, 2), 16);
-    const g = parseInt(h.slice(2, 4), 16);
-    const b = parseInt(h.slice(4, 6), 16);
-    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-  }
-
-  // Token-based sizing. Log scale so a 100k-token session is roughly 2x the
-  // size of a 1k-token session — not 100x. Capped at 56 so the canvas
-  // doesn't get dominated by one fat node.
-  function sizeForTokens(totalTokens) {
-    const t = Math.max(0, totalTokens || 0);
-    const grown = Math.log10(t + 10) * 6; // log10(10)=1 → +6; log10(100k)≈5 → +30
-    return Math.min(56, Math.max(14, 14 + grown));
-  }
-
-  // Node radius in viewBox units — used by collide force and shape sizing.
-  // Drives the visual size across all three shape types (circle / rect /
-  // diamond) so size still encodes token volume.
-  function nodeRadius(d) {
-    return sizeForTokens(
-      (d.total_input_tokens || 0)
-      + (d.total_output_tokens || 0)
-      + (d.total_cache_creation_tokens || 0)
-      + (d.total_cache_read_tokens || 0)
-    );
-  }
-
-  // Build the SVG content for a node group: shape + label. Shape varies by
-  // routing (circle / rounded rect / diamond) but the per-frame transform
-  // is handled by the simulation tick. Status color → fill; token volume →
-  // size; recent activity (<60s) → `.pulsing` class for CSS keyframe.
-  function nodeColors(d) {
-    const c = STATUS_COLORS[d.status] || '#6b7280';
-    const isTerm = TERMINAL.has(d.status);
-    return {
-      fill: isTerm ? hexWithAlpha(c, 0.35) : hexWithAlpha(c, 0.85),
-      stroke: c,
-      borderWidth: d.status === 'blocked' ? 4 : 2,
-    };
-  }
-
-  function nodeLabel(d) {
-    // Prefer the LLM-generated short label when we have one — it tells the
-    // operator what the session is actually about, which is far more useful
-    // than knowing it ran on Opus vs. Sonnet. Falls back to the model badge
-    // until the summary is fetched (lazy, on panel open).
-    // An operator-pinned manual label wins over everything else.
-    if (d.custom_label) return d.custom_label;
-    if (d.short_label) return d.short_label;
-    const isCli = d.source === 'claude_code' || d.source === 'codex';
-    let label = d.model_label || routingLabel(d.routing) || d.session_id.slice(0, 8);
-    // Generic CLI fallbacks aren't informative — replace with a placeholder.
-    if (isCli && (label === 'Claude Code' || label === 'Codex')) label = '?';
-    return label;
-  }
-
-  // --- Label wrapping ---------------------------------------------------
-  // SVG <text> never wraps on its own, so long session labels used to run
-  // off in a single line and overlap neighbouring nodes. We word-wrap into
-  // multiple <tspan> lines and cap at LABEL_MAX_LINES (excess truncated with
-  // an ellipsis). Widths are estimated from character counts rather than
-  // measured with getComputedTextLength — deterministic, cheap per render,
-  // and avoids the 0-width result you get when the tab is backgrounded.
-  const LABEL_CHAR_W = 6.6;   // approx px per char at the 12px label font
-  const LABEL_MAX_W = 132;    // max line width in viewBox units before wrapping
-  const LABEL_MAX_CHARS = Math.floor(LABEL_MAX_W / LABEL_CHAR_W);  // ~20
-  const LABEL_LINE_H = 13;    // line height in viewBox units
-  const LABEL_MAX_LINES = 3;
-  const LABEL_GAP = 14;       // gap between node edge and first label baseline
-
-  // Greedy word-wrap to a character budget. Words longer than the budget are
-  // hard-broken so a single long token (e.g. a hyphen-free slug) still wraps.
-  function wrapLabelText(str, maxChars) {
-    const words = String(str).split(/\s+/).filter(Boolean);
-    const lines = [];
-    let line = '';
-    for (let w of words) {
-      // Hard-break any single word that can't fit on its own line.
-      while (w.length > maxChars) {
-        if (line) { lines.push(line); line = ''; }
-        lines.push(w.slice(0, maxChars));
-        w = w.slice(maxChars);
-      }
-      const candidate = line ? line + ' ' + w : w;
-      if (candidate.length > maxChars) {
-        if (line) lines.push(line);
-        line = w;
-      } else {
-        line = candidate;
-      }
-    }
-    if (line) lines.push(line);
-    return lines.length ? lines : [''];
-  }
-
-  // Render a node's (possibly multi-line) label into its <text> element and
-  // stash the resulting line count / pixel width on the datum so the collide
-  // force can reserve room for it. `this` is the <text> element.
-  function renderNodeLabel(d) {
-    const textEl = d3.select(this);
-    let lines = wrapLabelText(nodeLabel(d), LABEL_MAX_CHARS);
-    if (lines.length > LABEL_MAX_LINES) {
-      lines = lines.slice(0, LABEL_MAX_LINES);
-      let last = lines[LABEL_MAX_LINES - 1];
-      if (last.length >= LABEL_MAX_CHARS) last = last.slice(0, LABEL_MAX_CHARS - 1);
-      lines[LABEL_MAX_LINES - 1] = last.replace(/\s+$/, '') + '…';
-    }
-    textEl.attr('y', nodeRadius(d) + LABEL_GAP).text(null);
-    lines.forEach((ln, i) => {
-      textEl.append('tspan')
-        .attr('x', 0)
-        .attr('dy', i === 0 ? 0 : LABEL_LINE_H)
-        .text(ln);
-    });
-    d._labelLines = lines.length;
-    d._labelW = Math.max(...lines.map(l => l.length)) * LABEL_CHAR_W;
-  }
-
-  // Collision radius that encloses both the node shape and its label block so
-  // neither shapes nor labels overlap once the simulation settles. The label
-  // sits centred below the node; the farthest point is a bottom corner of its
-  // bounding box, so we use the hypotenuse from node centre to that corner.
-  // Scaled down slightly (corners are conservative) to avoid over-sparsing.
-  function collideRadius(d) {
-    const r = nodeRadius(d);
-    const lines = d._labelLines || 1;
-    const halfW = Math.max(r, (d._labelW || 0) / 2) + 6;
-    const labelBottom = r + LABEL_GAP + (lines - 1) * LABEL_LINE_H + LABEL_LINE_H * 0.5;
-    const enclose = Math.hypot(halfW, labelBottom) * 0.85;
-    return Math.max(r + 14, enclose);
-  }
-
-  // Human-readable source label. Codex and Claude Code are both CLI surfaces;
-  // anything else is the LifeOS agent worker.
-  function sourceLabelFor(d) {
-    if (d.source === 'claude_code') return 'Claude Code CLI';
-    if (d.source === 'codex') return 'Codex CLI';
-    return 'LifeOS agent';
-  }
-
-  function nodeTitle(d) {
-    return [
-      d.label,
-      d.decoded_cwd ? `cwd: ${d.decoded_cwd}` : null,
-      `source: ${sourceLabelFor(d)}`,
-      `status: ${d.status}`,
-      `routing: ${routingLabel(d.routing)}`,
-      `tokens: ${d.total_input_tokens} in / ${d.total_output_tokens} out`,
-      `cost: $${(d.total_dollars || 0).toFixed(4)}`,
-      d.last_event_kind ? `last: ${d.last_event_kind}` : null,
-    ].filter(Boolean).join('\n');
-  }
-
-  function isActivelyWriting(d) {
-    const nowSec = Date.now() / 1000;
-    return d.status === 'running'
-      && d.last_activity_at
-      && (nowSec - d.last_activity_at) < 60;
-  }
-
-  function nodeShapeTag(d) {
-    // Shape encodes where the agent runs — applied uniformly to top-level
-    // sessions and subagents. CLI = rounded square (Claude Code OR Codex),
-    // local agent = diamond, cloud agent (Claude API) = circle. Mirrors
-    // routingLabel()'s buckets.
-    if (d.source === 'claude_code' || d.source === 'codex'
-        || d.routing === 'claude_code' || d.routing === 'codex') return 'rect';
-    if (!d.routing || d.routing === 'local') return 'polygon';  // local: diamond
-    return 'circle';                       // cloud (Claude): dot
-  }
-
-  // Set shape-specific attrs (radius/width/points). Called on enter+update.
-  function applyShapeAttrs(sel) {
-    sel.each(function(d) {
-      const el = d3.select(this);
-      const r = nodeRadius(d);
-      const colors = nodeColors(d);
-      el.attr('fill', colors.fill).attr('stroke', colors.stroke)
-        .attr('stroke-width', colors.borderWidth)
-        .classed('pulsing', isActivelyWriting(d));
-      if (this.tagName === 'circle') {
-        el.attr('r', r);
-      } else if (this.tagName === 'rect') {
-        const side = r * 1.8;
-        el.attr('x', -side / 2).attr('y', -side / 2)
-          .attr('width', side).attr('height', side)
-          .attr('rx', Math.min(side * 0.22, 12))
-          .attr('ry', Math.min(side * 0.22, 12));
-      } else if (this.tagName === 'polygon') {
-        // Diamond: 4 vertices, half-side = r * sqrt(2)/2 * 1.4
-        const h = r * 1.4;
-        el.attr('points', `0,${-h} ${h},0 0,${h} ${-h},0`);
-      }
-    });
-  }
-
-  // Incremental D3 join — nodes and links carry session_id and edge id as
-  // keys so positions persist across snapshot ticks. Simulation gets the
-  // updated array and `alpha(0.3).restart()` reflows new arrivals.
-  function renderGraph(sessions, snapshotEdges) {
-    const visible = applyFilters(sessions);
-    const visibleIds = new Set(visible.map(s => s.session_id));
-
-    // ----- Links (parent → subagent spawn edges) -----
-    const visibleLinks = (snapshotEdges || [])
-      .filter(e => visibleIds.has(e.from) && visibleIds.has(e.to))
-      .map(e => ({ id: `${e.from}->${e.to}`, source: e.from, target: e.to }));
-
-    linkLayer.selectAll('path.link')
-      .data(visibleLinks, d => d.id)
-      .join(
-        enter => enter.append('path').attr('class', 'link'),
-        update => update,
-        exit => exit.remove()
-      );
-
-    // ----- Nodes -----
-    // Preserve per-node positions across re-renders by reading them off the
-    // simulation's previous data, so a snapshot tick doesn't jitter the
-    // already-laid-out nodes.
-    const oldById = new Map();
-    nodeLayer.selectAll('.node').each(function(d) { oldById.set(d.session_id, d); });
-    const merged = visible.map(s => {
-      const prev = oldById.get(s.session_id);
-      if (prev) {
-        // Mutate prev in place (D3 forces hold the same object reference).
-        Object.assign(prev, s);
-        return prev;
-      }
-      // New node — seed at recency-x target so it doesn't fly in from (0, 0).
-      return Object.assign({ x: recencyTargetX(s), y: VIEW_H / 2 }, s);
-    });
-
-    const sel = nodeLayer.selectAll('.node')
-      .data(merged, d => d.session_id);
-
-    const entered = sel.enter().append('g')
-      .attr('class', 'node')
-      .style('cursor', 'grab')
-      .call(d3.drag()
-        .on('start', (event, d) => {
-          if (!event.active) simulation.alphaTarget(0.1).restart();
-          d.fx = d.x;
-          d.fy = d.y;
-        })
-        .on('drag', (event, d) => {
-          d.fx = event.x;
-          d.fy = event.y;
-        })
-        .on('end', (event, d) => {
-          if (!event.active) simulation.alphaTarget(0);
-          // Leave fx/fy set so the node stays where dropped (mirrors /crm/graph).
-        }))
-      .on('click', (event, d) => {
-        // Defer the panel toggle so a quick second click can cancel it
-        // and run the dblclick Go To instead. Single-click latency is
-        // ~220ms — noticeable but acceptable for a graph UI where
-        // dblclick is a first-class action.
-        if (_nodeClickTimer) clearTimeout(_nodeClickTimer);
-        _nodeClickTimer = setTimeout(() => {
-          _nodeClickTimer = null;
-          if (d.session_id === selectedSessionId) closePanel();
-          else openPanel(d.session_id);
-        }, 220);
-      })
-      .on('dblclick', (event, d) => {
-        // Double-click = Go To. Handled for both CLI sources (Claude Code
-        // and Codex) since /focus dispatches by prefix; for anything else,
-        // let the deferred single-click panel toggle run normally.
-        const isCli = d.source === 'claude_code' || d.source === 'codex';
-        if (!isCli || d.is_subagent) {
-          return;
-        }
-        event.preventDefault();
-        event.stopPropagation();  // suppress d3.zoom default dblclick zoom-in
-        if (_nodeClickTimer) {
-          clearTimeout(_nodeClickTimer);
-          _nodeClickTimer = null;
-        }
-        focusCcSession(d);
-      });
-    // One shape element per node, type chosen by routing (see nodeShapeTag).
-    entered.append(d => document.createElementNS('http://www.w3.org/2000/svg', nodeShapeTag(d)))
-      .attr('class', 'node-shape');
-    entered.append('title');
-    entered.append('text').attr('class', 'node-label');
-
-    const all = entered.merge(sel);
-    applyShapeAttrs(all.select('.node-shape'));
-    all.select('text.node-label').each(renderNodeLabel);
-    all.select('title').text(d => nodeTitle(d));
-
-    sel.exit().remove();
-
-    // Feed the merged node array + links into the simulation. Only re-energize
-    // alpha when the visible *set* actually changed (new ids appeared or old
-    // ones disappeared) — otherwise the 2s snapshot tick would keep nudging
-    // settled nodes for no structural reason, manifesting as periodic jitter.
-    // visibleCount feeds `recencyRailSpan()` so the rail compresses to center
-    // when few nodes are visible.
-    visibleCount = merged.length;
-    simulation.nodes(merged);
-    simulation.force('link').links(visibleLinks);
-    const visibleIdsKey = visible.map(s => s.session_id).sort().join('|');
-    if (visibleIdsKey !== _lastVisibleIdsKey) {
-      _lastVisibleIdsKey = visibleIdsKey;
-      simulation.alpha(0.3).restart();
-    }
-
-    emptyStateEl.style.display = visible.length === 0 ? '' : 'none';
-    updateChips(visible);
-    updateCwdOptions(allSessions);
-    applySelectionStyles();
-  }
-
-  // Pull session_id off a link endpoint regardless of whether the force-link
-  // pass has converted it from a string id into a node object yet.
-  function linkEndpoints(e) {
-    const s = (typeof e.source === 'object') ? e.source.session_id : e.source;
-    const t = (typeof e.target === 'object') ? e.target.session_id : e.target;
-    return [s, t];
-  }
-
-  // 1-hop parent/child set for the currently selected session.
-  function relatedTo(sessionId) {
-    const out = new Set();
-    if (!sessionId) return out;
-    linkLayer.selectAll('path.link').each(function(e) {
-      const [s, t] = linkEndpoints(e);
-      if (s === sessionId) out.add(t);
-      if (t === sessionId) out.add(s);
-    });
-    return out;
-  }
-
-  // Toggle .selected / .related / .dimmed across the visible nodes + edges
-  // based on `selectedSessionId`. Cheap to re-run on every render and panel
-  // open/close — no allocations per node beyond the related set.
-  function applySelectionStyles() {
-    const hasSelection = !!selectedSessionId;
-    const related = relatedTo(selectedSessionId);
-
-    nodeLayer.selectAll('.node-shape')
-      .classed('selected', d => hasSelection && d.session_id === selectedSessionId)
-      .classed('related',  d => hasSelection && related.has(d.session_id))
-      .classed('dimmed',   d => hasSelection && d.session_id !== selectedSessionId && !related.has(d.session_id));
-
-    nodeLayer.selectAll('text.node-label')
-      .classed('dimmed', d => hasSelection && d.session_id !== selectedSessionId && !related.has(d.session_id));
-
-    linkLayer.selectAll('path.link')
-      .classed('highlighted', e => {
-        if (!hasSelection) return false;
-        const [s, t] = linkEndpoints(e);
-        return s === selectedSessionId || t === selectedSessionId;
-      })
-      .classed('dimmed', e => {
-        if (!hasSelection) return false;
-        const [s, t] = linkEndpoints(e);
-        return s !== selectedSessionId && t !== selectedSessionId;
-      });
-  }
-
-  function updateChips(sessions) {
-    const running = sessions.filter(s => s.status === 'running').length;
-    const blocked = sessions.filter(s => s.status === 'blocked').length;
-    const recent = sessions.filter(s => s.status === 'completed').length;
-    // CLI-sourced sessions (both Claude Code and Codex) share the chip —
-    // both are subscription-billed surfaces sitting outside the LifeOS
-    // agent worker. Renaming the chip would be a bigger UI change; for
-    // now the count rolls them together.
-    const cli = sessions.filter(s => s.source === 'claude_code' || s.source === 'codex').length;
-    // API spend = LifeOS agent worker sessions only. Claude Code and Codex
-    // CLI both bill against flat subscriptions, not metered API tokens,
-    // so their dollar numbers would distort the chip's "real cost" intent.
-    const apiSpend = sessions
-      .filter(s => s.source !== 'claude_code' && s.source !== 'codex')
-      .reduce((acc, s) => acc + (s.total_dollars || 0), 0);
-    document.getElementById('chip-running').textContent = running;
-    document.getElementById('chip-blocked').textContent = blocked;
-    document.getElementById('chip-recent').textContent = recent;
-    document.getElementById('chip-cc').textContent = cli;
-    document.getElementById('chip-spend').textContent = '$' + apiSpend.toFixed(2);
-  }
-
-  function applySnapshot(snap) {
-    allSessions = snap.sessions || [];
-    allEdges = snap.edges || [];
-    renderGraph(allSessions, allEdges);
-    // Update the panel meta in place if the selected session is still around.
-    // Replacing innerHTML on every tick would wipe the events container and
-    // detach the live SSE renderer — the previous bug where the side panel
-    // blinked into view and then went blank.
-    if (selectedSessionId) {
-      const s = allSessions.find(x => x.session_id === selectedSessionId);
-      if (s) updatePanelMeta(s);
-    }
-  }
-
-  // --- Side panel ---
-  // Build the panel scaffold once per session selection. Subsequent snapshot
-  // ticks call updatePanelMeta() which only touches data-attributed spans —
-  // never the events container. This is what fixes the "click → blink → blank"
-  // bug where the SSE event list was getting destroyed every 2s.
-  function renderPanelHeader(s) {
-    const live = !TERMINAL.has(s.status);
-    const safeStatus = escapeAttr(s.status);
-    const isCli = (s.source === 'claude_code' || s.source === 'codex');
-    const isSubagent = !!s.is_subagent;
-    // No kill button for CLI sessions — we don't have a safe primitive to
-    // terminate them from outside the terminal.
-    const showKill = live && !isCli;
-    // Resume button: only for terminal-state CLI sessions (not subagents).
-    // Whether the backend will actually accept the click depends on
-    // LIFEOS_CC_RESUME_ENABLED / LIFEOS_CODEX_RESUME_ENABLED on the server;
-    // if disabled, click → toast error.
-    const showResume = isCli && !isSubagent && (TERMINAL.has(s.status) || s.status === 'inactive' || s.status === 'yielded');
-    // Go To button: any non-subagent CLI session, including live ones. The
-    // backend uses a stored mapping (set by Resume or by the SessionStart
-    // hook) and falls back to an FD probe so this works for sessions
-    // started organically in wezterm.
-    const showGoTo = isCli && !isSubagent;
-    const sourceLabel = sourceLabelFor(s);
-    const inferredHint = s.status_inferred ? ' (inferred)' : '';
-    panelEl.innerHTML = `
-      <div class="panel-header">
-        <button class="panel-close" aria-label="Close" id="panel-close">×</button>
-        ${showKill ? '<button class="panel-kill" id="panel-kill">Kill</button>' : ''}
-        ${showResume ? '<button class="panel-resume" id="panel-resume" title="Open a new wezterm tab and run claude --resume">Resume</button>' : ''}
-        ${showGoTo ? '<button class="panel-focus" id="panel-focus" title="Jump to the existing wezterm pane for this session (or run Resume if there isn\'t one). Double-clicking the node does the same. Wayland disallows cross-app window raise — click the wezterm dock icon to bring it forward; it will already be on the right pane.">Go To</button>' : ''}
-        <div class="label" data-field="label" title="Click to rename this session">${escapeHtml(s.custom_label || s.label || s.session_id)}</div>
-        <div class="cwd-hint" data-field="cwd-hint" style="font-size:0.7rem;color:var(--text-dim);margin-top:0.15rem;word-break:break-all">${s.decoded_cwd ? escapeHtml(s.decoded_cwd) : ''}</div>
-        <div class="meta" data-field="meta">
-          <span data-field="live-dot">${live ? '<span class="live-dot" title="live"></span>' : ''}</span>
-          <span class="badge status-${safeStatus}" data-field="status">${escapeHtml(s.status + inferredHint)}</span>
-          <span class="badge" data-field="source">${escapeHtml(sourceLabel)}</span>
-          <span class="badge" data-field="routing">${escapeHtml(routingLabel(s.routing))}</span>
-          <span class="badge" data-field="cost">$${(s.total_dollars || 0).toFixed(4)}</span>
-          <span class="badge" data-field="tokens">${s.total_input_tokens}↓ / ${s.total_output_tokens}↑</span>
-          <span data-field="depth">${s.spawn_depth ? `<span class="badge">depth ${s.spawn_depth}</span>` : ''}</span>
-        </div>
+    <label title="Include sessions that already finished — completed, failed, or budget-exceeded. Hidden by default so the graph focuses on what's live right now."><input type="checkbox" id="filter-terminal" /> include finished</label>
+    <label title="Hide sessions whose last activity is older than this. Default flips to 1 week when 'include finished' is on; 30min otherwise.">recency
+      <select id="filter-recency">
+        <option value="60">1 min</option>
+        <option value="1800" selected>30 min</option>
+        <option value="86400">24 h</option>
+        <option value="604800">1 wk</option>
+        <option value="all">all time</option>
+      </select>
+    </label>
+    <label title="Limit to sessions whose project working directory matches.">cwd
+      <select id="filter-cwd">
+        <option value="all">all</option>
+      </select>
+    </label>
+    <label title="Limit to sessions running on a specific machine.">host
+      <select id="filter-host">
+        <option value="all">all</option>
+      </select>
+    </label>
+    <label>route
+      <select id="filter-route">
+        <option value="all">all</option>
+        <option value="local">local</option>
+        <option value="remote">remote</option>
+        <option value="claude">claude</option>
+        <option value="claude_code">claude code</option>
+        <option value="codex">codex</option>
+      </select>
+    </label>
+    <label>status
+      <select id="filter-status">
+        <option value="all">all</option>
+        <option value="running">running</option>
+        <option value="claimed">claimed</option>
+        <option value="yielded">yielded</option>
+        <option value="inactive">inactive</option>
+        <option value="idle">idle</option>
+        <option value="blocked">blocked</option>
+        <option value="completed">completed</option>
+        <option value="ended">ended</option>
+        <option value="failed">failed</option>
+      </select>
+    </label>
+    <span style="margin-left:auto;color:var(--text-dim);font-size:0.75rem" id="connection-state">connecting…</span>
+  </div>
+  <main>
+    <section id="graph">
+      <svg id="graph-svg" preserveAspectRatio="xMidYMid meet"></svg>
+      <div class="empty-state" id="empty-state">
+        <div class="icon">🛠️</div>
+        <div class="label">No agent sessions yet</div>
+        <div class="hint">Sessions will appear here when an <code>#agent</code> task is claimed.</div>
       </div>
-      <div class="session-summary loading" id="session-summary">
-        <div class="ss-label">Summary</div>
-        <div class="ss-short" data-field="ss-short">${escapeHtml(s.short_label || '')}</div>
-        <div class="ss-body" data-field="ss-body">Summarizing…</div>
+    </section>
+    <aside class="panel" id="panel-outer">
+      <div class="panel-resizer" id="panel-resizer" title="Drag to resize"></div>
+      <div class="panel-content" id="panel">
+        <div class="panel-empty" id="panel-empty">Click a node to inspect its transcript.</div>
       </div>
-      <div class="events" id="events"></div>
-    `;
-    document.getElementById('panel-close').onclick = closePanel;
-    const labelEl = panelEl.querySelector('[data-field="label"]');
-    if (labelEl) labelEl.onclick = () => startLabelEdit(s);
-    if (showKill) {
-      document.getElementById('panel-kill').onclick = () => openKillModal(s);
-    }
-    if (showResume) {
-      document.getElementById('panel-resume').onclick = () => resumeCcSession(s);
-    }
-    if (showGoTo) {
-      document.getElementById('panel-focus').onclick = () => focusCcSession(s);
-    }
-  }
+    </aside>
+  </main>
+</div>
 
-  async function focusCcSession(s) {
-    // Called from both the panel Go To button AND the graph node dblclick.
-    // Button reference may be null if dblclick fires before the panel
-    // header rendered — handle gracefully.
-    const btn = document.getElementById('panel-focus');
-    if (btn) {
-      btn.disabled = true;
-      btn.textContent = 'Locating…';
-    }
-    try {
-      const r = await fetch(`/api/agents/sessions/${encodeURIComponent(s.session_id)}/focus`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-      });
-      if (!r.ok) {
-        const text = await r.text();
-        let msg = text;
-        try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) {}
-        // 404 = no cached mapping AND probe couldn't find a pane (session
-        // not running, or in a non-wezterm terminal). 410 = mapping existed
-        // and the pane is gone (typical: closed tab); a re-probe also failed.
-        if (r.status === 404) {
-          showToast(`Couldn't locate pane — session not running, wezterm unreachable, or SessionStart hook not installed.`, true);
-        } else if (r.status === 410) {
-          showToast(`Pane no longer exists. Click Resume to open a new one.`, true);
-        } else {
-          showToast(`Go To failed: ${msg}`, true);
-        }
-        return;
-      }
-      // Wayland disallows cross-client window raise, so the pane is selected
-      // inside wezterm but the window doesn't pop forward — set the
-      // expectation in the toast.
-      showToast(`Pane selected in wezterm. Click the wezterm dock icon to bring it forward.`, false);
-    } catch (err) {
-      showToast(`Go To failed: ${err.message}`, true);
-    } finally {
-      setTimeout(() => {
-        if (btn) {
-          btn.disabled = false;
-          btn.textContent = 'Go To';
-        }
-      }, 1500);
+<script type="module">
+  import { initBoard } from '/static/agents/board.js';
+  import { initGraph } from '/static/agents/graph.js';
+
+  const boardView = document.getElementById('board-view');
+  const graphView = document.getElementById('graph-view');
+  const graphChips = document.getElementById('graph-chips');
+  const tabButtons = document.querySelectorAll('.tab-btn');
+  let graphInitialized = false;
+
+  function activateTab(name) {
+    tabButtons.forEach(btn => btn.classList.toggle('active', btn.dataset.tab === name));
+    boardView.hidden = name !== 'board';
+    graphView.hidden = name !== 'graph';
+    graphChips.hidden = name !== 'graph';
+    if (name === 'graph' && !graphInitialized) {
+      graphInitialized = true;
+      initGraph();
     }
   }
 
-  async function resumeCcSession(s) {
-    const btn = document.getElementById('panel-resume');
-    if (btn) {
-      btn.disabled = true;
-      btn.textContent = 'Resuming…';
-    }
-    try {
-      const r = await fetch(`/api/agents/sessions/${encodeURIComponent(s.session_id)}/resume`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
-      });
-      if (!r.ok) {
-        const text = await r.text();
-        // FastAPI returns {"detail": "..."} on HTTPException — surface that.
-        let msg = text;
-        try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) {}
-        throw new Error(`HTTP ${r.status}: ${msg}`);
-      }
-      const result = await r.json();
-      // With the default wezterm launcher the inner command is already
-      // running inside the new tab — no paste needed. The server still
-      // copies it to the clipboard as a backup in case the operator has
-      // overridden cc_resume_cmd to a launcher that opens an empty
-      // terminal (e.g. legacy `warp://` flow).
-      let copied = !!result.clipboard_copied;
-      if (!copied && result.inner_command && navigator.clipboard && navigator.clipboard.writeText) {
-        try {
-          await navigator.clipboard.writeText(result.inner_command);
-          copied = true;
-        } catch (_) {
-          // ignore — toast will show the command for manual copy
-        }
-      }
-      if (result.pane_id != null) {
-        showToast(`Wezterm tab opened (pane ${result.pane_id}). Focus button will return here.`, false);
-      } else if (copied) {
-        showToast(`Tab opened. Resume command copied to clipboard — paste it.`, false);
-      } else if (result.inner_command) {
-        showToast(`Tab opened. Run: ${result.inner_command}`, false);
-      } else {
-        showToast(`Spawned (pid ${result.pid}) in ${result.cwd}`, false);
-      }
-    } catch (err) {
-      showToast(`Resume failed: ${err.message}`, true);
-    } finally {
-      // Re-enable after a beat so accidental double-click is harmless.
-      setTimeout(() => {
-        if (btn) {
-          btn.disabled = false;
-          btn.textContent = 'Resume';
-        }
-      }, 4000);
-    }
-  }
+  tabButtons.forEach(btn => btn.addEventListener('click', () => activateTab(btn.dataset.tab)));
 
-  // In-place metadata refresh — keeps the events container intact across
-  // snapshot ticks. Only updates fields by their data-field selectors.
-  function updatePanelMeta(s) {
-    if (!panelEl) return;
-    const setText = (sel, text) => {
-      const el = panelEl.querySelector(`[data-field="${sel}"]`);
-      if (el) el.textContent = text;
-    };
-    const setHtml = (sel, html) => {
-      const el = panelEl.querySelector(`[data-field="${sel}"]`);
-      if (el) el.innerHTML = html;
-    };
-    const inferredHint = s.status_inferred ? ' (inferred)' : '';
-    const sourceLabel = sourceLabelFor(s);
-    // Don't overwrite the title while the operator is mid-rename.
-    if (!panelEl.querySelector('#label-edit-input')) {
-      setText('label', s.custom_label || s.label || s.session_id);
-    }
-    setText('status', s.status + inferredHint);
-    setText('source', sourceLabel);
-    setText('routing', routingLabel(s.routing));
-    setText('cost', '$' + (s.total_dollars || 0).toFixed(4));
-    setText('tokens', `${s.total_input_tokens}↓ / ${s.total_output_tokens}↑`);
-    setText('cwd-hint', s.decoded_cwd || '');
-
-    // Status changed → swap the badge class so the color follows.
-    const statusBadge = panelEl.querySelector('[data-field="status"]');
-    if (statusBadge) {
-      statusBadge.className = `badge status-${escapeAttr(s.status)}`;
-    }
-
-    // Live dot + kill button visibility track terminal state.
-    const live = !TERMINAL.has(s.status);
-    setHtml('live-dot', live ? '<span class="live-dot" title="live"></span>' : '');
-    setHtml('depth', s.spawn_depth ? `<span class="badge">depth ${s.spawn_depth}</span>` : '');
-
-    const killBtn = document.getElementById('panel-kill');
-    if (live && !killBtn) {
-      // Add the kill button if the session just transitioned to non-terminal
-      // (rare; usually the other direction).
-      const header = panelEl.querySelector('.panel-header');
-      if (header) {
-        const closeBtn = header.querySelector('#panel-close');
-        const btn = document.createElement('button');
-        btn.className = 'panel-kill';
-        btn.id = 'panel-kill';
-        btn.textContent = 'Kill';
-        btn.onclick = () => openKillModal(s);
-        header.insertBefore(btn, closeBtn);
-      }
-    } else if (!live && killBtn) {
-      killBtn.remove();
-    }
-  }
-
-  function openKillModal(session) {
-    // BFS down parent_session_id so non-root targets only show *their* subtree,
-    // matching the backend cascade scope. (Filtering by root_session_id would
-    // wrongly include unrelated peers under the same root.)
-    const childrenOf = new Map();
-    for (const x of allSessions) {
-      if (!x.parent_session_id) continue;
-      if (!childrenOf.has(x.parent_session_id)) childrenOf.set(x.parent_session_id, []);
-      childrenOf.get(x.parent_session_id).push(x);
-    }
-    const descendants = [];
-    const queue = [session.session_id];
-    const seen = new Set([session.session_id]);
-    while (queue.length) {
-      const sid = queue.shift();
-      for (const child of (childrenOf.get(sid) || [])) {
-        if (seen.has(child.session_id)) continue;
-        seen.add(child.session_id);
-        if (!TERMINAL.has(child.status)) descendants.push(child);
-        queue.push(child.session_id);
-      }
-    }
-    const backdrop = document.createElement('div');
-    backdrop.className = 'modal-backdrop';
-    backdrop.innerHTML = `
-      <div class="modal" role="dialog" aria-labelledby="kill-title">
-        <h2 id="kill-title">Kill agent session?</h2>
-        <div class="target">${escapeHtml(session.label || session.session_id)}</div>
-        ${descendants.length > 0 ? `
-          <div class="descendants">
-            Will also kill ${descendants.length} descendant${descendants.length === 1 ? '' : 's'}:
-            ${descendants.slice(0, 5).map(d =>
-              `<div>• ${escapeHtml(d.label || d.session_id)}</div>`
-            ).join('')}
-            ${descendants.length > 5 ? `<div>…and ${descendants.length - 5} more</div>` : ''}
-          </div>
-        ` : ''}
-        <label style="font-size:0.75rem;color:var(--text-secondary)">Reason (optional)</label>
-        <textarea id="kill-reason" placeholder="Why are you killing this?"></textarea>
-        <div class="actions">
-          <button id="kill-cancel">Cancel</button>
-          <button class="danger" id="kill-confirm">Kill</button>
-        </div>
-      </div>
-    `;
-    document.body.appendChild(backdrop);
-    const cleanup = () => { if (backdrop.parentNode) backdrop.parentNode.removeChild(backdrop); };
-    backdrop.addEventListener('click', e => { if (e.target === backdrop) cleanup(); });
-    document.getElementById('kill-cancel').onclick = cleanup;
-    document.getElementById('kill-confirm').onclick = async () => {
-      const reason = document.getElementById('kill-reason').value || '';
-      const confirmBtn = document.getElementById('kill-confirm');
-      confirmBtn.disabled = true;
-      confirmBtn.textContent = 'Killing…';
-      try {
-        const r = await fetch(`/api/agents/sessions/${encodeURIComponent(session.session_id)}/kill`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ reason }),
-        });
-        if (!r.ok) {
-          const text = await r.text();
-          throw new Error(`HTTP ${r.status}: ${text}`);
-        }
-        const result = await r.json();
-        const failures = result.failures || [];
-        const killed = result.killed || [];
-        if (killed.length === 0 && result.reason) {
-          showToast(`Already ${result.reason}`, false);
-        } else if (failures.length === 0) {
-          showToast(`Killed ${killed.length} session${killed.length === 1 ? '' : 's'}`, false);
-        } else {
-          showToast(`Killed ${killed.length}; ${failures.length} remote failure(s)`, true);
-        }
-        cleanup();
-      } catch (err) {
-        showToast(`Kill failed: ${err.message}`, true);
-        confirmBtn.disabled = false;
-        confirmBtn.textContent = 'Kill';
-      }
-    };
-  }
-
-  function showToast(message, isError) {
-    const t = document.createElement('div');
-    t.className = 'toast' + (isError ? ' error' : '');
-    t.textContent = message;
-    document.body.appendChild(t);
-    setTimeout(() => { if (t.parentNode) t.parentNode.removeChild(t); }, 3500);
-  }
-
-  function closePanel() {
-    selectedSessionId = null;
-    eventKindFilter = null;
-    if (transcriptES) { transcriptES.close(); transcriptES = null; }
-    panelEl.innerHTML = '<div class="panel-empty" id="panel-empty">Click a node to inspect its transcript.</div>';
-    applySelectionStyles();
-  }
-
-  function openPanel(sessionId) {
-    if (transcriptES) { transcriptES.close(); transcriptES = null; }
-    // Reset filter when switching sessions — kinds are session-scoped.
-    eventKindFilter = null;
-    selectedSessionId = sessionId;
-    applySelectionStyles();
-    const s = allSessions.find(x => x.session_id === sessionId);
-    if (!s) return;
-    renderPanelHeader(s);
-    fetchSessionSummary(sessionId);
-    loadSessionEvents(sessionId, 0);
-  }
-
-  // Backfill the transcript, then open the live SSE tail. The backfill is a
-  // one-shot fetch, so a transient failure — most often the server being
-  // bounced by another agent's commit/deploy hook — would otherwise leave a
-  // dead panel ("Failed to load events") until the operator re-clicks the
-  // node. Retry a few times with backoff to ride through a restart window,
-  // then fall back to a manual Retry link (mirrors the summary's recovery).
-  // The live SSE (opened only after a successful backfill) auto-reconnects on
-  // its own, so once the server is back the feed self-heals.
-  const _EVENTS_RETRY_DELAYS = [800, 1600, 3200];  // ms; ~5.6s before giving up
-  function loadSessionEvents(sessionId, attempt) {
-    fetch(`/api/agents/sessions/${encodeURIComponent(sessionId)}/events?limit=200`)
-      .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
-      .then(payload => {
-        // Bail if the operator switched sessions while we were loading.
-        if (sessionId !== selectedSessionId) return;
-        const events = payload.events || [];
-        // Default kind-filter to user_message when any exist — most of the
-        // time the operator just wants to skim the user prompts. If there
-        // are none (e.g. a freshly-spawned subagent), no filter is applied.
-        if (events.some(ev => (ev.kind || '') === 'user_message')) {
-          eventKindFilter = 'user_message';
-        }
-        const container = document.getElementById('events');
-        if (container) container.innerHTML = '';  // clear any reconnect/error notice
-        events.forEach(ev => appendEvent(ev, false));
-        applyEventFilter();
-        // Now open live SSE.
-        const es = new EventSource(`/api/agents/sessions/${encodeURIComponent(sessionId)}/stream?backfill=0`);
-        transcriptES = es;
-        es.addEventListener('transcript_event', e => {
-          try { appendEvent(JSON.parse(e.data), true); } catch (_) {}
-        });
-        es.addEventListener('closed', () => { es.close(); });
-        es.onerror = () => {}; // browser auto-retries
-      })
-      .catch(err => {
-        // Stale — the operator moved to another session; let that load win.
-        if (sessionId !== selectedSessionId) return;
-        const container = document.getElementById('events');
-        if (!container) return;
-        if (attempt < _EVENTS_RETRY_DELAYS.length) {
-          container.innerHTML = '<div class="event">Loading events… (reconnecting)</div>';
-          setTimeout(() => {
-            if (sessionId === selectedSessionId) loadSessionEvents(sessionId, attempt + 1);
-          }, _EVENTS_RETRY_DELAYS[attempt]);
-        } else {
-          container.innerHTML = `<div class="event">Failed to load events: ${escapeHtml(String(err))} <a href="#" data-action="retry-events" style="color:var(--accent)">Retry</a></div>`;
-          const retry = container.querySelector('[data-action="retry-events"]');
-          if (retry) retry.addEventListener('click', ev => {
-            ev.preventDefault();
-            container.innerHTML = '<div class="event">Loading events…</div>';
-            loadSessionEvents(sessionId, 0);
-          });
-        }
-      });
-  }
-
-  // Track the in-flight summary fetch so a new openPanel can abort the old
-  // one — otherwise stale long-running fetches pile up behind Gemma.
-  let summaryAbort = null;
-
-  // Turn the panel title into an inline text box prepopulated with the
-  // current label. Enter (or blur) saves, Escape cancels. An empty save
-  // clears the override and reverts the node to auto-naming.
-  function startLabelEdit(s) {
-    if (!panelEl) return;
-    const labelEl = panelEl.querySelector('[data-field="label"]');
-    if (!labelEl || labelEl.querySelector('#label-edit-input')) return;
-    const current = s.custom_label || s.label || '';
-    const input = document.createElement('input');
-    input.id = 'label-edit-input';
-    input.type = 'text';
-    input.maxLength = 120;
-    input.value = current;
-    input.style.cssText =
-      'width:100%;box-sizing:border-box;font:inherit;font-weight:600;' +
-      'color:var(--text-primary,#fff);background:var(--bg-elev);' +
-      'border:1px solid var(--accent);border-radius:4px;padding:2px 6px';
-    labelEl.textContent = '';
-    labelEl.appendChild(input);
-    input.focus();
-    input.select();
-
-    let done = false;
-    const finish = (save) => {
-      if (done) return;
-      done = true;
-      if (save) {
-        saveLabelEdit(s, input.value);
-      } else {
-        labelEl.textContent = s.custom_label || s.label || s.session_id;
-      }
-    };
-    input.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') { e.preventDefault(); finish(true); }
-      else if (e.key === 'Escape') { e.preventDefault(); finish(false); }
-    });
-    input.addEventListener('blur', () => finish(true));
-  }
-
-  // Persist a manual label (durably, server-side) and reflect it immediately
-  // on the open panel and the graph node so the operator doesn't wait for the
-  // next snapshot tick.
-  async function saveLabelEdit(s, rawValue) {
-    const labelEl = panelEl ? panelEl.querySelector('[data-field="label"]') : null;
-    const fallback = () => { if (labelEl) labelEl.textContent = s.custom_label || s.label || s.session_id; };
-    try {
-      const r = await fetch(
-        `/api/agents/sessions/${encodeURIComponent(s.session_id)}/label`,
-        {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ label: (rawValue || '').trim() }),
-        },
-      );
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const data = await r.json();
-      const custom = data.custom_label || null;
-      s.custom_label = custom;
-      // Keep the canonical in-memory copy in sync so snapshot ticks agree.
-      const canonical = allSessions.find(x => x.session_id === s.session_id);
-      if (canonical) canonical.custom_label = custom;
-      if (labelEl) labelEl.textContent = custom || s.label || s.session_id;
-      // Nudge the node label immediately (custom_label || short_label || …).
-      nodeLayer.selectAll('.node')
-        .filter(d => d.session_id === s.session_id)
-        .each(function(d) { d.custom_label = custom; })
-        .select('text.node-label')
-        .text(d => nodeLabel(d));
-    } catch (err) {
-      console.warn('label save failed', err);
-      fallback();
-    }
-  }
-
-  // Fetch and render the LLM-generated session summary. Decoupled from the
-  // event stream — slow LLM calls won't block transcript display. The panel
-  // header shows "Summarizing…" until this resolves.
-  async function fetchSessionSummary(sessionId) {
-    if (summaryAbort) summaryAbort.abort();
-    const ac = new AbortController();
-    summaryAbort = ac;
-    // 5 minutes — covers worst-case Gemma queueing (a big CC session behind
-    // the agent worker can easily push past 60s). The browser will return
-    // an AbortError if the LLM is genuinely stuck so the user can retry.
-    const timeoutId = setTimeout(() => ac.abort(), 5 * 60 * 1000);
-    try {
-      const r = await fetch(
-        `/api/agents/sessions/${encodeURIComponent(sessionId)}/summary`,
-        { signal: ac.signal },
-      );
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const data = await r.json();
-      // Bail if the operator moved on to a different session while we waited.
-      if (sessionId !== selectedSessionId) return;
-      const wrap = document.getElementById('session-summary');
-      if (!wrap) return;
-      wrap.classList.remove('loading');
-      const shortEl = wrap.querySelector('[data-field="ss-short"]');
-      const bodyEl = wrap.querySelector('[data-field="ss-body"]');
-      if (shortEl) shortEl.textContent = data.short_label || '';
-      if (bodyEl) bodyEl.innerHTML = renderSummaryBody(data.summary || '');
-      // Patch the in-memory session so subsequent snapshot ticks pick up the
-      // short label. Also nudge the corresponding node immediately so the
-      // operator doesn't wait up to 2s for the next tick.
-      const s = allSessions.find(x => x.session_id === sessionId);
-      if (s && data.short_label) {
-        s.short_label = data.short_label;
-        nodeLayer.selectAll('.node')
-          .filter(d => d.session_id === sessionId)
-          .each(function(d) { d.short_label = data.short_label; })
-          .select('text.node-label')
-          .text(d => nodeLabel(d));
-      }
-    } catch (err) {
-      // AbortError from a panel switch is expected — just bail silently.
-      if (err.name === 'AbortError' && sessionId !== selectedSessionId) return;
-      if (sessionId !== selectedSessionId) return;
-      const bodyEl = document.querySelector('#session-summary [data-field="ss-body"]');
-      if (!bodyEl) return;
-      const friendly = err.name === 'AbortError'
-        ? 'Timed out — Gemma may be busy.'
-        : `Summary unavailable: ${err.message}.`;
-      bodyEl.innerHTML = `${escapeHtml(friendly)} <a href="#" data-action="retry-summary" style="color:var(--accent)">Retry</a>`;
-      const retry = bodyEl.querySelector('[data-action="retry-summary"]');
-      if (retry) {
-        retry.addEventListener('click', e => {
-          e.preventDefault();
-          bodyEl.textContent = 'Summarizing…';
-          document.getElementById('session-summary')?.classList.add('loading');
-          fetchSessionSummary(sessionId);
-        });
-      }
-    } finally {
-      clearTimeout(timeoutId);
-      if (summaryAbort === ac) summaryAbort = null;
-    }
-  }
-
-  // Minimal markdown — only converts leading `- ` lines into a <ul>. Anything
-  // else is rendered as escaped text with line breaks preserved. We control
-  // the Gemma prompt so the only expected formatting is bullets vs. paragraph.
-  function renderSummaryBody(text) {
-    const lines = (text || '').split(/\r?\n/);
-    const isBullet = l => /^\s*[-*]\s+/.test(l);
-    if (lines.some(isBullet)) {
-      const items = lines.filter(isBullet).map(l => {
-        const content = l.replace(/^\s*[-*]\s+/, '');
-        return `<li>${escapeHtml(content)}</li>`;
-      });
-      return `<ul>${items.join('')}</ul>`;
-    }
-    return escapeHtml(text);
-  }
-
-  // Kind filter state for the side-panel feed. null = show all; otherwise
-  // only events whose kind matches the filter are visible. Clicking the same
-  // kind label twice toggles back to "show all".
-  let eventKindFilter = null;
-
-  // Format a unix-epoch timestamp as "MM/DD h:mm:ssa ET" — explicit Eastern
-  // tz so it matches the rest of LifeOS (timezone='America/New_York' in
-  // settings.py) regardless of the browser machine's locale.
-  function formatTs(ts) {
-    if (!ts) return '';
-    const d = new Date(ts * 1000);
-    const date = d.toLocaleDateString('en-US', {
-      timeZone: 'America/New_York',
-      month: 'numeric',
-      day: 'numeric',
-    });
-    const time = d.toLocaleTimeString('en-US', {
-      timeZone: 'America/New_York',
-      hour: 'numeric',
-      minute: '2-digit',
-      second: '2-digit',
-      hour12: true,
-    });
-    return `${date} ${time} ET`;
-  }
-
-  // Compact 1.3k / 500k / 1.2M for token counts and similar.
-  function formatNumCompact(n) {
-    const x = Number(n);
-    if (!isFinite(x)) return String(n);
-    if (Math.abs(x) >= 1_000_000) return (x / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M';
-    if (Math.abs(x) >= 1_000)     return (x / 1_000).toFixed(1).replace(/\.0$/, '') + 'k';
-    return String(x);
-  }
-
-  // Field-aware payload renderer. Maps the most common transcript-event
-  // shapes (model responses, routing decisions, tool calls, errors, etc.)
-  // to compact human-readable HTML. Anything unrecognized falls through to
-  // a generic key/value tail, and the full raw JSON is always available
-  // via click-to-expand for diagnostics.
-  const NOISE_FIELDS = new Set([
-    'iterations', 'inference_geo', 'server_tool_use', 'cache_creation',
-    'ephemeral_1h_input_tokens', 'ephemeral_5m_input_tokens',
-    'thinking_chars',  // surfaced separately when nonzero
-  ]);
-  const SECONDARY_BADGES = ['model', 'task_id', 'expected_output', 'speed', 'service_tier', 'source', 'parent_session_id', 'child_session_id'];
-
-  function prettyPayload(payload) {
-    if (payload == null) return '';
-    if (typeof payload !== 'object') {
-      return `<div class="pp-text">${escapeHtml(String(payload))}</div>`;
-    }
-    const parts = [];
-
-    // Routing decision (routing_resolved et al.)
-    if (payload.routing) {
-      let s = `<div class="pp-routing">→ <span class="pp-target">${escapeHtml(String(payload.routing))}</span>`;
-      if (payload.routing_reason) s += ` <span class="pp-reason">· ${escapeHtml(payload.routing_reason)}</span>`;
-      s += `</div>`;
-      parts.push(s);
-    }
-
-    // Primary text body. `text` empty + `tool_uses` present is the common
-    // assistant-called-tools case — surface that explicitly.
-    if (typeof payload.text === 'string' && payload.text.trim()) {
-      parts.push(`<div class="pp-text">${escapeHtml(payload.text)}</div>`);
-    } else if (payload.text === '' && Array.isArray(payload.tool_uses) && payload.tool_uses.length) {
-      parts.push(`<div class="pp-text muted">(no text — called tools)</div>`);
-    }
-
-    // Tool uses → pills with name + arg keys.
-    if (Array.isArray(payload.tool_uses) && payload.tool_uses.length) {
-      const tools = payload.tool_uses.map(t => {
-        const name = t && t.name ? String(t.name) : 'tool';
-        const argKeys = Array.isArray(t && t.input_keys)
-          ? t.input_keys
-          : (t && t.input && typeof t.input === 'object' ? Object.keys(t.input) : []);
-        const argStr = argKeys.length ? `<span class="pp-tool-args">(${escapeHtml(argKeys.join(', '))})</span>` : '';
-        return `<span class="pp-tool"><span class="pp-tool-name">${escapeHtml(name)}</span>${argStr}</span>`;
-      }).join('');
-      parts.push(`<div class="pp-tools">${tools}</div>`);
-    }
-
-    // Labeled freeform fields — render in this order so the reader sees the
-    // semantically most useful info first.
-    const TEXT_FIELDS = [
-      ['question', 'question'],
-      ['answer', 'answer'],
-      ['prompt', 'prompt'],
-      ['reason', 'reason'],
-      ['ambiguity', 'ambiguity'],
-      ['sane_reason', 'sane reason'],
-      ['description', 'description'],
-      ['label', 'label'],
-    ];
-    for (const [field, label] of TEXT_FIELDS) {
-      const v = payload[field];
-      if (typeof v === 'string' && v.trim()) {
-        parts.push(`<div class="pp-field"><span class="pp-label">${escapeHtml(label)}</span><span class="pp-value">${escapeHtml(v)}</span></div>`);
-      }
-    }
-
-    // Budget — compact "90s · $0.30 · 500k tok"
-    if (payload.budget && typeof payload.budget === 'object') {
-      const b = payload.budget;
-      const bits = [];
-      if (b.wall_seconds != null)  bits.push(`${b.wall_seconds}s`);
-      if (b.max_dollars != null)   bits.push(`$${Number(b.max_dollars).toFixed(2)}`);
-      if (b.max_tokens != null)    bits.push(`${formatNumCompact(b.max_tokens)} tok`);
-      if (bits.length) parts.push(`<div class="pp-budget"><span class="pp-label">budget</span>${escapeHtml(bits.join(' · '))}</div>`);
-    }
-
-    // Usage — compact "↓ 1 in · ↑ 1.3k out · cache 400k read / 199 create"
-    if (payload.usage && typeof payload.usage === 'object') {
-      const u = payload.usage;
-      const bits = [];
-      if (u.input_tokens != null)  bits.push(`↓ ${formatNumCompact(u.input_tokens)} in`);
-      if (u.output_tokens != null) bits.push(`↑ ${formatNumCompact(u.output_tokens)} out`);
-      const cacheR = u.cache_read_input_tokens;
-      const cacheC = u.cache_creation_input_tokens;
-      if (cacheR || cacheC) {
-        const cb = [];
-        if (cacheR) cb.push(`${formatNumCompact(cacheR)} read`);
-        if (cacheC) cb.push(`${formatNumCompact(cacheC)} create`);
-        bits.push(`cache ${cb.join(' / ')}`);
-      }
-      if (bits.length) parts.push(`<div class="pp-usage"><span class="pp-label">usage</span>${escapeHtml(bits.join(' · '))}</div>`);
-    }
-
-    // Thinking chars (only if nonzero — when zero it's pure noise).
-    if (typeof payload.thinking_chars === 'number' && payload.thinking_chars > 0) {
-      parts.push(`<div class="pp-field"><span class="pp-label">thinking</span><span class="pp-value">${formatNumCompact(payload.thinking_chars)} chars</span></div>`);
-    }
-
-    // Scalar badges (model, task_id, etc.)
-    const badges = [];
-    for (const f of SECONDARY_BADGES) {
-      const v = payload[f];
-      if (v != null && typeof v !== 'object') {
-        badges.push(`<span class="pp-badge"><span class="pp-label">${escapeHtml(f.replace(/_/g, ' '))}</span>${escapeHtml(String(v))}</span>`);
-      }
-    }
-    if (payload.sane === false) {
-      badges.push(`<span class="pp-badge pp-warn">not sane</span>`);
-    }
-    if (badges.length) parts.push(`<div class="pp-badges">${badges.join('')}</div>`);
-
-    // Anything else (scalar tail) — fields we didn't explicitly handle.
-    const handled = new Set([
-      'routing', 'routing_reason', 'text', 'tool_uses',
-      ...TEXT_FIELDS.map(t => t[0]),
-      'budget', 'usage', 'thinking_chars',
-      ...SECONDARY_BADGES, 'sane',
-      ...NOISE_FIELDS,
-    ]);
-    const remainder = Object.entries(payload).filter(([k, v]) =>
-      !handled.has(k) && v != null
-      && (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')
-    );
-    if (remainder.length) {
-      const items = remainder.map(([k, v]) =>
-        `<span class="pp-kv"><span class="pp-label">${escapeHtml(k.replace(/_/g, ' '))}</span>${escapeHtml(String(v))}</span>`
-      ).join('');
-      parts.push(`<div class="pp-extra">${items}</div>`);
-    }
-
-    return parts.length ? parts.join('') : `<div class="pp-empty">(no fields)</div>`;
-  }
-
-  // appendEvent always renders newest-on-top so backfill and live additions
-  // share the same visual order. Backfill is delivered oldest-first, so we
-  // prepend each one as it arrives, leaving the chronologically-newest event
-  // at the top by the time live tail begins.
-  function appendEvent(ev, _live) {
-    const container = document.getElementById('events');
-    if (!container) return;
-    const kind = String(ev.kind || '');
-    const ts = formatTs(ev.ts);
-    const payload = ev.payload || null;
-    const prettyHtml = payload ? prettyPayload(payload) : '';
-    const rawJson = payload ? JSON.stringify(payload, null, 2) : '';
-    const div = document.createElement('div');
-    // classList.add validates token shape — defense-in-depth even though
-    // `kind` is server-controlled today.
-    div.classList.add('event');
-    if (kind) {
-      const safeKind = kind.replace(/[^a-zA-Z0-9_-]/g, '_');
-      div.classList.add(`kind-${safeKind}`);
-      div.dataset.kind = kind;
-    }
-    div.innerHTML = `
-      <div><span class="kind" role="button" tabindex="0" title="Click to filter to this event type">${escapeHtml(kind)}</span><span class="ts">${escapeHtml(ts)}</span></div>
-      ${prettyHtml ? `<div class="payload" title="Click to expand">${prettyHtml}</div>` : ''}
-      ${rawJson ? `<pre class="payload-raw">${escapeHtml(rawJson)}</pre>` : ''}
-    `;
-    // Hide the event up front if a filter is active and doesn't match.
-    if (eventKindFilter && kind !== eventKindFilter) {
-      div.style.display = 'none';
-    }
-    // Click on the kind label → toggle filter on this kind.
-    const kindEl = div.querySelector('.kind');
-    if (kindEl && kind) {
-      kindEl.addEventListener('click', e => {
-        e.stopPropagation();
-        toggleKindFilter(kind);
-      });
-      kindEl.addEventListener('keydown', e => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          toggleKindFilter(kind);
-        }
-      });
-    }
-    // Click anywhere else on the event → toggle expanded (reveals raw JSON).
-    div.addEventListener('click', e => {
-      if (e.target.closest('.kind')) return;
-      div.classList.toggle('expanded');
-    });
-    container.prepend(div);
-  }
-
-  function toggleKindFilter(kind) {
-    eventKindFilter = (eventKindFilter === kind) ? null : kind;
-    applyEventFilter();
-  }
-
-  function applyEventFilter() {
-    const container = document.getElementById('events');
-    if (!container) return;
-    const events = container.querySelectorAll('.event');
-    events.forEach(el => {
-      const k = el.dataset.kind;
-      if (!eventKindFilter || k === eventKindFilter) {
-        el.style.display = '';
-      } else {
-        el.style.display = 'none';
-      }
-    });
-    // Visually mark filtered state on every visible kind label.
-    container.querySelectorAll('.kind').forEach(el => {
-      const k = el.parentElement?.parentElement?.dataset?.kind;
-      if (eventKindFilter && k === eventKindFilter) {
-        el.classList.add('kind-active-filter');
-      } else {
-        el.classList.remove('kind-active-filter');
-      }
-    });
-  }
-
-  function escapeHtml(s) {
-    return String(s)
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-  }
-
-  // For values that go into HTML attribute positions via template strings.
-  // Restricts to a known-safe charset so attribute-context injection is
-  // structurally impossible.
-  function escapeAttr(s) {
-    return String(s).replace(/[^a-zA-Z0-9_-]/g, '_');
-  }
-
-  // --- Filters ---
-  // Release any drag-pinned positions so the new visible set lays out from
-  // the recency rail / center forces instead of frozen drop points.
-  function releasePins() {
-    nodeLayer.selectAll('.node').each(function(d) { d.fx = null; d.fy = null; });
-  }
-  function onFilterChange() {
-    releasePins();
-    // Reset the pan/zoom transform so the new visible set lays out at the
-    // natural scale + position. Without this, an operator who had zoomed
-    // into a corner would see the freshly-filtered set still anchored
-    // there — usually empty space — even though the simulation correctly
-    // re-centered around the recency rail + center-y forces.
-    svg.transition().duration(300).call(zoom.transform, d3.zoomIdentity);
-    renderGraph(allSessions, allEdges);
-    // Keep the search dropdown's visible/hidden split in sync with the filters.
-    if (searchQuery.trim()) renderSearchResults();
-  }
-  filterTerminalEl.addEventListener('change', () => {
-    applyRecencyDefault();
-    onFilterChange();
-  });
-  if (filterRecencyEl) {
-    filterRecencyEl.addEventListener('change', () => {
-      recencyManuallySet = true;
-      onFilterChange();
-    });
-  }
-  [filterRouteEl, filterStatusEl, filterCwdEl].filter(Boolean).forEach(el =>
-    el.addEventListener('change', onFilterChange)
-  );
-
-  // --- Search (issue #252) ---
-  // A live, ranked dropdown over session names + cached summaries. The label
-  // tier is matched client-side (every session carries a label); the summary
-  // tiers (short_label / paragraph summary) come from /api/agents/search,
-  // which reads only the cached-summary DB so a keystroke never costs an LLM
-  // call. Results rank visible-before-hidden, then label > short_label >
-  // summary. Clicking a result highlights the node (reusing openPanel +
-  // applySelectionStyles) and pans to it; a filtered-out result first relaxes
-  // only the filter predicates that were hiding it.
-  const searchInputEl = document.getElementById('search-input');
-  const searchResultsEl = document.getElementById('search-results');
-  const searchWrapEl = document.getElementById('search-wrap');
-  let searchQuery = '';
-  let summaryMatches = new Map();   // session_id -> { field, snippet } from backend
-  let searchSeq = 0;                // guards against out-of-order fetch responses
-  let searchActiveIndex = -1;       // keyboard-highlighted row
-  let searchDebounceTimer = null;
-
-  const SEARCH_TIER = { label: 0, short_label: 1, summary: 2 };
-  // Distinct badge per matched field so the operator can tell which tier hit:
-  // the task name, the node's short label, or the paragraph summary.
-  const SEARCH_BADGE = { label: 'name', short_label: 'label', summary: 'summary' };
-
-  function sessionDisplayName(s) {
-    return s.custom_label || s.short_label || s.label || s.session_id.slice(0, 8);
-  }
-
-  // Escape, then wrap the first case-insensitive occurrence of `q` in <mark>.
-  function highlightMatch(text, q) {
-    const t = String(text || '');
-    if (!q) return escapeHtml(t);
-    const idx = t.toLowerCase().indexOf(q.toLowerCase());
-    if (idx < 0) return escapeHtml(t);
-    return escapeHtml(t.slice(0, idx))
-      + '<mark>' + escapeHtml(t.slice(idx, idx + q.length)) + '</mark>'
-      + escapeHtml(t.slice(idx + q.length));
-  }
-
-  // Merge the local label matches with the backend summary matches into a
-  // single ranked list. Each session appears once at its best (lowest) tier.
-  function buildSearchResults() {
-    const q = searchQuery.trim().toLowerCase();
-    if (!q) return [];
-    const visibleIds = new Set(applyFilters(allSessions).map(s => s.session_id));
-    const byId = new Map(allSessions.map(s => [s.session_id, s]));
-    const entries = new Map();
-
-    function consider(sessionId, field, snippet) {
-      const s = byId.get(sessionId);
-      if (!s) return;  // a summary match for a session no longer in the snapshot
-      const prev = entries.get(sessionId);
-      if (prev && SEARCH_TIER[prev.field] <= SEARCH_TIER[field]) return;
-      entries.set(sessionId, { session: s, field, snippet, visible: visibleIds.has(sessionId) });
-    }
-
-    // Tier 0: label — client-side, covers every session. Matches the
-    // displayed name, so an operator-pinned custom label is findable too.
-    for (const s of allSessions) {
-      const name = s.custom_label || s.label || '';
-      if (name.toLowerCase().includes(q)) consider(s.session_id, 'label', name);
-    }
-    // Tiers 1/2: short_label / paragraph summary — from the backend.
-    for (const [sid, m] of summaryMatches) consider(sid, m.field, m.snippet);
-
-    return [...entries.values()].sort((a, b) => {
-      if (a.visible !== b.visible) return a.visible ? -1 : 1;
-      if (SEARCH_TIER[a.field] !== SEARCH_TIER[b.field]) return SEARCH_TIER[a.field] - SEARCH_TIER[b.field];
-      return sessionDisplayName(a.session).localeCompare(sessionDisplayName(b.session));
-    });
-  }
-
-  function renderSearchResults() {
-    const q = searchQuery.trim();
-    if (!q) { hideSearchResults(); return; }
-    searchActiveIndex = -1;
-    const results = buildSearchResults();
-    if (results.length === 0) {
-      searchResultsEl.innerHTML = '<div class="search-empty">No matches</div>';
-      searchResultsEl.hidden = false;
-      return;
-    }
-    const visible = results.filter(r => r.visible);
-    const hidden = results.filter(r => !r.visible);
-    let html = '';
-    const renderGroup = (items, groupClass, labelText) => {
-      if (items.length === 0) return;
-      if (labelText) html += `<div class="search-group-label">${labelText}</div>`;
-      html += `<div class="search-group ${groupClass}">`;
-      for (const r of items) {
-        // Title shows the text where the match actually landed so the
-        // highlighted query is always visible: the label for a label hit, the
-        // short label for a short_label hit, else the session's display name.
-        const titleText = r.field === 'label' ? (r.session.label || sessionDisplayName(r.session))
-          : r.field === 'short_label' ? (r.session.short_label || sessionDisplayName(r.session))
-          : sessionDisplayName(r.session);
-        // A summary hit's query lives in the paragraph, not the title — surface
-        // it in the snippet line. Title/short_label hits are self-evident.
-        const snippetHtml = r.field === 'summary'
-          ? `<div class="sr-snippet">${highlightMatch(r.snippet, q)}</div>`
-          : '';
-        html += `<button class="search-result" type="button" data-session="${escapeHtml(r.session.session_id)}">`
-          + `<div class="sr-title"><span class="sr-name">${highlightMatch(titleText, q)}</span>`
-          + `<span class="sr-badge">${SEARCH_BADGE[r.field]}</span></div>`
-          + snippetHtml + `</button>`;
-      }
-      html += `</div>`;
-    };
-    renderGroup(visible, 'visible-group', null);
-    renderGroup(hidden, 'hidden-group', 'Hidden by filters');
-    searchResultsEl.innerHTML = html;
-    searchResultsEl.hidden = false;
-  }
-
-  function hideSearchResults() {
-    searchResultsEl.hidden = true;
-    searchResultsEl.innerHTML = '';
-    searchActiveIndex = -1;
-  }
-
-  // Flip only the filter controls that currently exclude `s`, so a hidden
-  // search hit can be revealed with the least disruption to the operator's
-  // other filter choices.
-  function relaxFiltersFor(s) {
-    const nowSec = Date.now() / 1000;
-    if (!filterTerminalEl.checked && TERMINAL.has(s.status)) filterTerminalEl.checked = true;
-    if (filterRecencyEl && filterRecencyEl.value !== 'all' && s.last_activity_at) {
-      const age = nowSec - s.last_activity_at;
-      if (age > Number(filterRecencyEl.value)) {
-        // Smallest recency window that still includes this session (options are
-        // ordered ascending in the DOM; 'all' is the catch-all at the end).
-        const fit = [...filterRecencyEl.options]
-          .map(o => o.value)
-          .find(v => v === 'all' || age <= Number(v));
-        filterRecencyEl.value = fit || 'all';
-        recencyManuallySet = true;
-      }
-    }
-    if (filterCwdEl && filterCwdEl.value !== 'all' && s.decoded_cwd !== filterCwdEl.value) {
-      filterCwdEl.value = 'all';
-    }
-    if (filterRouteEl.value !== 'all' && (s.routing || 'local') !== filterRouteEl.value) {
-      filterRouteEl.value = 'all';
-    }
-    if (filterStatusEl.value !== 'all' && s.status !== filterStatusEl.value) {
-      filterStatusEl.value = 'all';
-    }
-  }
-
-  // Center the viewport on a node, preserving the current zoom scale (min 1x).
-  // `delay` lets a just-revealed node's simulation settle before we pan.
-  function panToNode(sessionId, delay) {
-    const run = () => {
-      let target = null;
-      nodeLayer.selectAll('.node').each(function(d) { if (d.session_id === sessionId) target = d; });
-      if (!target || target.x == null || target.y == null) return;
-      const k = Math.max(d3.zoomTransform(svg.node()).k, 1);
-      const tx = VIEW_W / 2 - k * target.x;
-      const ty = VIEW_H / 2 - k * target.y;
-      svg.transition().duration(450)
-        .call(zoom.transform, d3.zoomIdentity.translate(tx, ty).scale(k));
-    };
-    if (delay) setTimeout(run, delay); else run();
-  }
-
-  function selectSearchResult(sessionId) {
-    const s = allSessions.find(x => x.session_id === sessionId);
-    if (!s) return;
-    const visibleIds = new Set(applyFilters(allSessions).map(x => x.session_id));
-    const wasHidden = !visibleIds.has(sessionId);
-    if (wasHidden) {
-      relaxFiltersFor(s);
-      releasePins();
-      renderGraph(allSessions, allEdges);
-    }
-    hideSearchResults();
-    openPanel(sessionId);  // sets selectedSessionId → applySelectionStyles highlights it
-    panToNode(sessionId, wasHidden ? 400 : 0);
-  }
-
-  async function fetchSummaryMatches(q) {
-    const seq = ++searchSeq;
-    try {
-      const r = await fetch('/api/agents/search?q=' + encodeURIComponent(q));
-      if (!r.ok) return;
-      const data = await r.json();
-      // Drop stale responses: a newer keystroke fired, or the box moved on.
-      if (seq !== searchSeq || searchQuery.trim() !== q) return;
-      summaryMatches = new Map((data.matches || []).map(m => [m.session_id, m]));
-      renderSearchResults();
-    } catch (_) { /* network blip — the label tier still works offline */ }
-  }
-
-  function onSearchInput() {
-    searchQuery = searchInputEl.value;
-    const q = searchQuery.trim();
-    clearTimeout(searchDebounceTimer);
-    // Invalidate prior summary matches; the debounced fetch refills them. The
-    // label tier renders instantly below regardless.
-    summaryMatches = new Map();
-    if (q.length >= 2) {
-      searchDebounceTimer = setTimeout(() => fetchSummaryMatches(q), 180);
-    }
-    renderSearchResults();
-  }
-
-  if (searchInputEl) {
-    searchInputEl.addEventListener('input', onSearchInput);
-    searchInputEl.addEventListener('focus', () => { if (searchQuery.trim()) renderSearchResults(); });
-    searchInputEl.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') {
-        searchInputEl.value = ''; searchQuery = ''; summaryMatches = new Map();
-        hideSearchResults(); searchInputEl.blur();
-        return;
-      }
-      const btns = [...searchResultsEl.querySelectorAll('.search-result')];
-      if (!btns.length) return;
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        searchActiveIndex = Math.min(searchActiveIndex + 1, btns.length - 1);
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        searchActiveIndex = Math.max(searchActiveIndex - 1, 0);
-      } else if (e.key === 'Enter') {
-        e.preventDefault();
-        const pick = searchActiveIndex >= 0 ? btns[searchActiveIndex] : btns[0];
-        if (pick) selectSearchResult(pick.dataset.session);
-        return;
-      } else {
-        return;
-      }
-      btns.forEach((b, i) => b.classList.toggle('active', i === searchActiveIndex));
-      if (searchActiveIndex >= 0) btns[searchActiveIndex].scrollIntoView({ block: 'nearest' });
-    });
-    searchResultsEl.addEventListener('click', (e) => {
-      const btn = e.target.closest('.search-result');
-      if (btn) selectSearchResult(btn.dataset.session);
-    });
-    document.addEventListener('click', (e) => {
-      if (searchWrapEl && !searchWrapEl.contains(e.target)) hideSearchResults();
-    });
-  }
-
-  // --- Side panel resize ---
-  // Drag handle on the left edge of aside.panel resizes the panel width.
-  // Persists in localStorage so the operator's chosen width survives reload.
-  // CSS var `--panel-width` drives the grid layout; updating it shifts the
-  // graph column automatically. The SVG-based D3 graph uses viewBox sizing
-  // so it scales with its container — no explicit redraw needed.
-  (function setupPanelResizer() {
-    if (!panelResizerEl || !panelOuterEl) return;
-    const STORAGE_KEY = 'lifeos.agents.panelWidth';
-    const MIN_WIDTH = 280;
-    const MAX_RATIO = 0.7;
-    const setWidth = (px) => {
-      const max = Math.floor(window.innerWidth * MAX_RATIO);
-      const clamped = Math.max(MIN_WIDTH, Math.min(max, Math.round(px)));
-      document.documentElement.style.setProperty('--panel-width', clamped + 'px');
-      return clamped;
-    };
-    // Restore last width if present.
-    try {
-      const saved = parseInt(localStorage.getItem(STORAGE_KEY) || '', 10);
-      if (saved && !isNaN(saved)) setWidth(saved);
-    } catch (_) {}
-
-    let dragging = false;
-    let startX = 0;
-    let startWidth = 0;
-    panelResizerEl.addEventListener('mousedown', (e) => {
-      dragging = true;
-      startX = e.clientX;
-      startWidth = panelOuterEl.getBoundingClientRect().width;
-      panelResizerEl.classList.add('dragging');
-      document.body.style.cursor = 'col-resize';
-      document.body.style.userSelect = 'none';
-      e.preventDefault();
-    });
-    window.addEventListener('mousemove', (e) => {
-      if (!dragging) return;
-      // Dragging left increases panel width (delta = startX - clientX).
-      const newWidth = setWidth(startWidth + (startX - e.clientX));
-      try { localStorage.setItem(STORAGE_KEY, String(newWidth)); } catch (_) {}
-    });
-    window.addEventListener('mouseup', () => {
-      if (!dragging) return;
-      dragging = false;
-      panelResizerEl.classList.remove('dragging');
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-      // SVG viewBox auto-scales; nudge the simulation so collision can
-      // settle if any node ended up partly out of view after the resize.
-      try { simulation.alpha(0.1).restart(); } catch (_) {}
-    });
-  })();
-
-  // --- Initial load + stream ---
-  fetch('/api/agents/snapshot')
-    .then(r => r.json())
-    .then(applySnapshot)
-    .catch(err => { connStateEl.textContent = 'failed: ' + err; });
-
-  const snapshotES = new EventSource('/api/agents/stream');
-  snapshotES.onopen = () => { connStateEl.textContent = 'live'; };
-  snapshotES.onerror = () => { connStateEl.textContent = 'reconnecting…'; };
-  snapshotES.addEventListener('snapshot', e => {
-    try { applySnapshot(JSON.parse(e.data)); } catch (_) {}
-  });
-})();
+  // Board is the primary view — boots immediately. The Graph tab's snapshot
+  // fetch + SSE stream only start once the operator opens it.
+  initBoard();
 </script>
 </body>
 </html>

--- a/web/agents/assignment.js
+++ b/web/agents/assignment.js
@@ -1,0 +1,235 @@
+// web/agents/assignment.js
+//
+// Card-assignment pickers (#851): engine, model, effort, and host — for a
+// board card's drawer. Isolated module rather than a patch to
+// web/agents/board.js because the Kanban board UI (#850) hadn't merged
+// when this landed (see this PR's description) — hooking it in is a
+// one-line `import { renderAssignmentPickers } from './assignment.js'`
+// plus one call inside board.js's `renderDrawer()` once it does. Matches
+// that branch's card/drawer shapes exactly (verified against its
+// `git show feat/kanban-board:web/agents/board.js`):
+//   - card: {id, title, notes, tags, assignee, fields, session, ...}
+//     `fields` is the task's `[key:: value]` inline-field map (#853);
+//     `session` (when a session exists) carries `host`/`model`/`effort`
+//     — "what actually ran", read-only, distinct from the assignment.
+//   - `PUT /api/tasks/{id}` with `{fields: {...}}` patches inline fields;
+//     a field value of `null` clears it (#853's fields API contract).
+//   - `GET /api/agents/models` returns
+//     `{engines: {claude: [...], codex: [...], local: [...], hermes: [...]},
+//     refreshed_at, stale}`, each entry `{id, label, pricing}` — the
+//     source for the model picker's options.
+//
+// No build step, no framework — plain DOM, matching every other file in
+// this directory.
+
+const ENGINES = ['claude', 'codex', 'local', 'hermes'];
+const EFFORTS = ['low', 'medium', 'high', 'max'];
+
+// Engines whose executor actually reads a `model` field (claude_code_executor
+// / codex_executor's `--model` flag — see api/services/agent_worker/
+// assignment.py). Local and Hermes never take a model override: local
+// always runs the on-box model, Hermes reports whatever model it served a
+// turn with (model_readout.py) rather than accepting a request for one.
+const ENGINES_WITH_MODEL_PICKER = new Set(['claude', 'codex']);
+// Engines whose executor reads an `effort` field. Hermes has no effort
+// override (see assignment.py's module docstring).
+const ENGINES_WITH_EFFORT_PICKER = new Set(['claude', 'codex', 'local']);
+// Engines a `host` field can steer over ssh (api/services/agent_worker/
+// remote_spawn.py) — local/Hermes always run wherever the API process does.
+const ENGINES_WITH_HOST_PICKER = new Set(['claude', 'codex']);
+
+function escapeHtml(s) {
+  return String(s ?? '').replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[c]));
+}
+
+function fieldValue(card, key) {
+  return (card && card.fields && card.fields[key]) || '';
+}
+
+// Fetches the model catalog once per page load and caches it — every card
+// drawer opened afterward reuses the same list rather than re-fetching.
+// A fetch failure degrades to an empty catalog (the model picker still
+// renders, just with no options besides "let the engine choose").
+let _catalogPromise = null;
+function loadModelCatalog(fetchImpl = fetch) {
+  if (!_catalogPromise) {
+    _catalogPromise = fetchImpl('/api/agents/models')
+      .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
+      .catch(() => ({ engines: { claude: [], codex: [], local: [], hermes: [] } }));
+  }
+  return _catalogPromise;
+}
+
+/**
+ * Render the four assignment pickers into `container` for `card`.
+ *
+ * @param {HTMLElement} container - emptied and populated with the pickers.
+ * @param {object} card - the board card (see this file's header comment).
+ * @param {object} [opts]
+ * @param {(id: string, patch: object) => Promise} [opts.putTask] - PUT
+ *   /api/tasks/{id} caller; defaults to a real fetch. Tests inject a fake.
+ * @param {(fetchImpl?: Function) => Promise} [opts.loadCatalog] - override
+ *   for tests; defaults to the module's cached `loadModelCatalog`.
+ * @param {Function} [opts.fetchImpl] - fetch override for the default
+ *   catalog loader, when `opts.loadCatalog` isn't given.
+ * @param {() => void} [opts.onSaved] - called after a successful PUT.
+ * @param {(message: string) => void} [opts.onError] - called with an error
+ *   message on a failed PUT; defaults to a no-op (the caller — board.js's
+ *   showToast in the eventual hookup — decides how to surface it).
+ */
+export function renderAssignmentPickers(container, card, opts = {}) {
+  const putTask = opts.putTask || defaultPutTask;
+  const loadCatalog = opts.loadCatalog || (() => loadModelCatalog(opts.fetchImpl));
+  const onSaved = opts.onSaved || (() => {});
+  const onError = opts.onError || (() => {});
+
+  const currentEngine = (card.assignee || '').toLowerCase();
+  const currentModel = fieldValue(card, 'model');
+  const currentEffort = fieldValue(card, 'effort');
+  const currentHost = fieldValue(card, 'host');
+  const ran = card.session || null;
+
+  container.innerHTML = `
+    <div class="assignment-row" data-row="engine">
+      <label class="assignment-label">Engine</label>
+      <select class="assignment-engine" data-field="assignee">
+        <option value="">unassigned</option>
+        ${ENGINES.map(e => `<option value="${e}" ${currentEngine === e ? 'selected' : ''}>${e}</option>`).join('')}
+      </select>
+    </div>
+    <div class="assignment-row" data-row="model" hidden>
+      <label class="assignment-label">Model</label>
+      <select class="assignment-model" data-field="model">
+        <option value="">engine default</option>
+      </select>
+    </div>
+    <div class="assignment-row" data-row="effort" hidden>
+      <label class="assignment-label">Effort</label>
+      <select class="assignment-effort" data-field="effort">
+        <option value="">default</option>
+        ${EFFORTS.map(e => `<option value="${e}" ${currentEffort === e ? 'selected' : ''}>${e}</option>`).join('')}
+      </select>
+    </div>
+    <div class="assignment-row" data-row="host" hidden>
+      <label class="assignment-label">Host</label>
+      <input class="assignment-host" data-field="host" type="text"
+             value="${escapeHtml(currentHost)}" placeholder="this machine" />
+    </div>
+    <div class="assignment-ran" data-field="ran"></div>
+    <div class="assignment-error" data-field="error" hidden></div>
+  `;
+
+  const engineEl = container.querySelector('[data-field="assignee"]');
+  const modelRow = container.querySelector('[data-row="model"]');
+  const modelEl = container.querySelector('[data-field="model"]');
+  const effortRow = container.querySelector('[data-row="effort"]');
+  const effortEl = container.querySelector('[data-field="effort"]');
+  const hostRow = container.querySelector('[data-row="host"]');
+  const hostEl = container.querySelector('[data-field="host"]');
+  const ranEl = container.querySelector('[data-field="ran"]');
+  const errorEl = container.querySelector('[data-field="error"]');
+
+  function renderRan() {
+    if (!ran || (!ran.model && !ran.effort && !ran.host)) {
+      ranEl.textContent = '';
+      return;
+    }
+    const parts = [];
+    if (ran.model) parts.push(`model ${ran.model}`);
+    if (ran.effort) parts.push(`effort ${ran.effort}`);
+    if (ran.host) parts.push(`host ${ran.host}`);
+    ranEl.textContent = `Actually ran: ${parts.join(', ')}`;
+  }
+  renderRan();
+
+  function updateVisibility() {
+    const engine = engineEl.value;
+    modelRow.hidden = !ENGINES_WITH_MODEL_PICKER.has(engine);
+    effortRow.hidden = !ENGINES_WITH_EFFORT_PICKER.has(engine);
+    hostRow.hidden = !ENGINES_WITH_HOST_PICKER.has(engine);
+  }
+  updateVisibility();
+
+  let catalogReady = false;
+  function populateModelOptions(catalog) {
+    const engine = engineEl.value;
+    const models = (catalog.engines && catalog.engines[engine]) || [];
+    modelEl.innerHTML = '<option value="">engine default</option>'
+      + models.map(m => `<option value="${escapeHtml(m.id)}" ${currentModel === m.id ? 'selected' : ''}>${escapeHtml(m.label || m.id)}</option>`).join('');
+    catalogReady = true;
+  }
+  loadCatalog().then(populateModelOptions);
+
+  function showError(message) {
+    if (message) {
+      errorEl.textContent = message;
+      errorEl.hidden = false;
+    } else {
+      errorEl.hidden = true;
+      errorEl.textContent = '';
+    }
+    onError(message);
+  }
+
+  // Every picker writes the SAME shape: the assignee tag (if it's the
+  // engine picker changing) plus the three inline fields, always stamping
+  // `assigned_by: "board"` — that's what keeps preflight's routing
+  // corroboration from ever second-guessing a board assignment (see
+  // api/services/agent_worker/preflight.py's `_apply_route_corroboration`
+  // and assignment.py's module docstring). The `model` field is the one
+  // exception: it's omitted (not nulled) until the model catalog has
+  // populated the select. Before that, `modelEl.value` is always '' —
+  // regardless of what the card has saved — so sending `model: null` would
+  // wipe a previously saved model on the very first effort/host change of
+  // a page load, before `GET /api/agents/models` has resolved (#861).
+  async function save(extra = {}) {
+    const { tags, ...extraFields } = extra;  // `tags` is a top-level PUT key, not a field
+    const fields = {
+      effort: effortEl.value || null,
+      host: hostEl.value.trim() || null,
+      assigned_by: 'board',
+      ...extraFields,
+    };
+    if (catalogReady) fields.model = modelEl.value || null;
+    const patch = { fields };
+    if (tags) patch.tags = tags;
+    try {
+      await putTask(card.id, patch);
+      showError('');
+      onSaved();
+    } catch (err) {
+      showError(err && err.message ? err.message : String(err));
+    }
+  }
+
+  engineEl.addEventListener('change', () => {
+    updateVisibility();
+    loadCatalog().then(populateModelOptions);
+    const engine = engineEl.value;
+    const nonAssigneeTags = (card.tags || []).filter(t => !ENGINES.includes((t || '').toLowerCase()));
+    const tags = engine ? [engine, ...nonAssigneeTags] : nonAssigneeTags;
+    save({ tags });
+  });
+  modelEl.addEventListener('change', () => save());
+  effortEl.addEventListener('change', () => save());
+  hostEl.addEventListener('change', () => save());
+
+  return { engineEl, modelEl, effortEl, hostEl };
+}
+
+async function defaultPutTask(taskId, patch) {
+  const r = await fetch(`/api/tasks/${encodeURIComponent(taskId)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  if (!r.ok) {
+    const text = await r.text();
+    let msg = text;
+    try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) { /* not JSON */ }
+    throw new Error(msg || `HTTP ${r.status}`);
+  }
+  return r.json();
+}

--- a/web/agents/board.js
+++ b/web/agents/board.js
@@ -1,0 +1,878 @@
+// web/agents/board.js
+//
+// The Kanban board (#850) — the primary /agents view. Backed by the vault
+// task store via GET/PUT /api/agents/board*, with a card drawer that reuses
+// the shared SessionPanel (./panel.js) for the linked session's transcript,
+// exactly like the Graph tab's side panel does.
+//
+// No card reordering within a lane (file order is lane order, per the
+// issue) — drag only ever changes which lane a card is in.
+
+import {
+  TERMINAL, routingLabel, sourceLabelFor, escapeHtml, showToast, SessionPanel,
+} from './panel.js';
+import { renderAssignmentPickers } from './assignment.js';
+
+const LANES = [
+  { id: 'unassigned',  label: 'Unassigned' },
+  { id: 'assigned',    label: 'Assigned' },
+  { id: 'in_progress', label: 'In progress' },
+  { id: 'human_queue', label: 'Human queue' },
+  { id: 'scheduled',   label: 'Scheduled' },
+  { id: 'review',      label: 'Review' },
+  { id: 'done',        label: 'Done' },
+];
+
+const ASSIGNEES = ['me', 'claude', 'codex', 'hermes', 'local'];
+
+// Card fields the drawer renders as editable inputs — used to decide
+// whether an SSE tick needs to rebuild the drawer at all (#850 finding 2).
+const DRAWER_EDITABLE_FIELDS = [
+  'title', 'notes', 'tags', 'context', 'assignee', 'lane',
+  // Scheduled-card fields, editable in the drawer since #850 finding 4.
+  'name', 'message_content', 'enabled',
+];
+
+export function initBoard() {
+  const lanesEl = document.getElementById('board-lanes');
+  const searchEl = document.getElementById('board-search');
+  const laneFilterEl = document.getElementById('board-filter-lane');
+  const assigneeFilterEl = document.getElementById('board-filter-assignee');
+  const hostFilterEl = document.getElementById('board-filter-host');
+  const tagFilterEl = document.getElementById('board-filter-tag');
+  const contextFilterEl = document.getElementById('board-filter-context');
+  const recencyFilterEl = document.getElementById('board-filter-recency');
+  const includeDoneEl = document.getElementById('board-filter-done');
+  const newCardBtn = document.getElementById('board-new-card');
+  const connStateEl = document.getElementById('board-connection-state');
+  const drawerBackdrop = document.getElementById('board-drawer-backdrop');
+  const drawerEl = document.getElementById('board-drawer');
+
+  let board = { lanes: Object.fromEntries(LANES.map(l => [l.id, []])) };
+  let openCardId = null;
+  let openCardLane = null;
+  let openCardSnapshot = null;  // last card object the drawer was fully rendered from
+  let panel = null;  // SessionPanel for the drawer's linked-session transcript
+
+  // ------------------------------------------------------------------
+  // Data load + live updates
+  // ------------------------------------------------------------------
+
+  function allCards() {
+    const out = [];
+    for (const lane of LANES) {
+      for (const card of (board.lanes[lane.id] || [])) out.push({ ...card, lane: lane.id });
+    }
+    return out;
+  }
+
+  function findCard(id) {
+    return allCards().find(c => c.id === id) || null;
+  }
+
+  function applyBoard(next) {
+    board = next;
+    updateFilterOptions();
+    render();
+    if (openCardId) {
+      const fresh = findCard(openCardId);
+      if (!fresh) { closeDrawer(); return; }
+      updateOpenDrawer(fresh);
+    }
+  }
+
+  // A board tick (SSE, ~every 0.75s) reaches here even when nothing about
+  // the open card changed. Rebuilding the drawer via innerHTML every time
+  // drops unsaved edits mid-keystroke, re-opens the linked session's
+  // transcript EventSource, and re-fires GET /sessions/{id}/summary (an LLM
+  // call) on every tick (#850 finding 2). So: refresh the linked session in
+  // place via panel.updateMeta when its id hasn't changed, and only rebuild
+  // the editable field block when a field actually changed and the operator
+  // isn't mid-edit in the drawer.
+  function updateOpenDrawer(fresh) {
+    const prev = openCardSnapshot;
+    const prevSessionId = (prev && prev.session && prev.session.session_id) || null;
+    const freshSessionId = (fresh.session && fresh.session.session_id) || null;
+    const sessionUnchanged = prevSessionId === freshSessionId;
+
+    if (sessionUnchanged && panel && freshSessionId) {
+      panel.updateMeta(fresh.session);
+    }
+
+    // Beyond the editable fields, also watch pending_question and the
+    // linked session's status — neither drives an input, but both drive
+    // which action buttons the drawer shows (Answer, Kill). Without this,
+    // answering from the drawer or a session reaching a terminal state
+    // leaves a stale button behind: a second "Answer" click 404s, and
+    // "Kill" survives a session that already exited (#850 round-2 finding 3).
+    const prevPendingId = (prev && prev.pending_question && prev.pending_question.id) ?? null;
+    const freshPendingId = (fresh.pending_question && fresh.pending_question.id) ?? null;
+    const prevSessionStatus = (prev && prev.session && prev.session.status) ?? null;
+    const freshSessionStatus = (fresh.session && fresh.session.status) ?? null;
+
+    const fieldsChanged = !prev || DRAWER_EDITABLE_FIELDS.some(
+      f => JSON.stringify(prev[f]) !== JSON.stringify(fresh[f])
+    ) || prevPendingId !== freshPendingId || prevSessionStatus !== freshSessionStatus;
+    const focused = !!(drawerEl && drawerEl.contains(document.activeElement));
+    if ((fieldsChanged || !sessionUnchanged) && !focused) {
+      renderDrawer(fresh);
+      // Only advance the snapshot on the branch that actually rendered —
+      // otherwise a frame skipped because the drawer had focus is treated
+      // as "no change" forever, and a later change gets silently dropped
+      // too because it's diffed against this stale snapshot instead of the
+      // last card the drawer actually shows (#850 round-2 finding 4).
+      openCardSnapshot = fresh;
+    }
+  }
+
+  function fetchBoard() {
+    return fetch('/api/agents/board')
+      .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
+      .then(applyBoard)
+      .catch(err => { if (connStateEl) connStateEl.textContent = 'failed: ' + err; });
+  }
+
+  function connectStream() {
+    const es = new EventSource('/api/agents/board/stream');
+    es.onopen = () => { if (connStateEl) connStateEl.textContent = 'live'; };
+    es.onerror = () => { if (connStateEl) connStateEl.textContent = 'reconnecting…'; };
+    es.addEventListener('board', e => {
+      try { applyBoard(JSON.parse(e.data)); } catch (_) {}
+    });
+    return es;
+  }
+
+  // ------------------------------------------------------------------
+  // Filters
+  // ------------------------------------------------------------------
+
+  let _lastHostKey = '';
+  let _lastContextKey = '';
+  function updateFilterOptions() {
+    const hosts = [...new Set(
+      allCards().map(c => c.session && c.session.host).filter(Boolean)
+    )].sort();
+    const hostKey = hosts.join('|');
+    if (hostFilterEl && hostKey !== _lastHostKey) {
+      _lastHostKey = hostKey;
+      const current = hostFilterEl.value;
+      hostFilterEl.innerHTML = '<option value="all">all hosts</option>'
+        + hosts.map(h => `<option value="${escapeHtml(h)}">${escapeHtml(h)}</option>`).join('');
+      if (current && (current === 'all' || hosts.includes(current))) hostFilterEl.value = current;
+    }
+
+    const contexts = [...new Set(
+      allCards().filter(c => c.kind === 'task').map(c => c.context).filter(Boolean)
+    )].sort();
+    const contextKey = contexts.join('|');
+    if (contextFilterEl && contextKey !== _lastContextKey) {
+      _lastContextKey = contextKey;
+      const current = contextFilterEl.value;
+      contextFilterEl.innerHTML = '<option value="all">all contexts</option>'
+        + contexts.map(c => `<option value="${escapeHtml(c)}">${escapeHtml(c)}</option>`).join('');
+      if (current && (current === 'all' || contexts.includes(current))) contextFilterEl.value = current;
+    }
+  }
+
+  function cardMatchesFilters(card) {
+    const search = (searchEl?.value || '').trim().toLowerCase();
+    if (search) {
+      const haystack = card.kind === 'schedule'
+        ? (card.name || '')
+        : `${card.title || ''} ${card.notes || ''}`;
+      if (!haystack.toLowerCase().includes(search)) return false;
+    }
+
+    const laneSel = laneFilterEl?.value || 'all';
+    if (laneSel !== 'all' && card.lane !== laneSel) return false;
+
+    const assigneeSel = assigneeFilterEl?.value || 'all';
+    if (assigneeSel !== 'all') {
+      if (card.kind !== 'task') return false;
+      if (assigneeSel === 'unassigned') {
+        if (card.assignee) return false;
+      } else if (card.assignee !== assigneeSel) {
+        return false;
+      }
+    }
+
+    const hostSel = hostFilterEl?.value || 'all';
+    if (hostSel !== 'all') {
+      const host = card.session && card.session.host;
+      if (host !== hostSel) return false;
+    }
+
+    const tagQuery = (tagFilterEl?.value || '').trim().toLowerCase().replace(/^#/, '');
+    if (tagQuery) {
+      if (card.kind !== 'task') return false;
+      if (!(card.tags || []).some(t => t.toLowerCase().includes(tagQuery))) return false;
+    }
+
+    const contextSel = contextFilterEl?.value || 'all';
+    if (contextSel !== 'all') {
+      if (card.kind !== 'task' || card.context !== contextSel) return false;
+    }
+
+    const recencyRaw = recencyFilterEl?.value || 'all';
+    if (recencyRaw !== 'all') {
+      const recencySec = Number(recencyRaw);
+      const stamp = card.kind === 'schedule' ? card.next_fire_at : card.updated_at;
+      if (stamp) {
+        const ageSec = (Date.now() - new Date(stamp).getTime()) / 1000;
+        if (ageSec > recencySec) return false;
+      }
+    }
+
+    // Only cancelled task cards are behind this filter — the Done lane
+    // itself (finished tasks, retired/fired schedules) always stays visible
+    // (#850 finding 3).
+    if (!includeDoneEl?.checked && card.kind === 'task' && card.status === 'cancelled') return false;
+
+    return true;
+  }
+
+  // ------------------------------------------------------------------
+  // Rendering
+  // ------------------------------------------------------------------
+
+  function cardChips(card) {
+    const chips = [];
+    if (card.assignee) chips.push(`<span class="board-chip board-chip-assignee">${escapeHtml(card.assignee)}</span>`);
+    if (card.fields && card.fields.model) chips.push(`<span class="board-chip">${escapeHtml(card.fields.model)}</span>`);
+    if (card.fields && card.fields.effort) chips.push(`<span class="board-chip">${escapeHtml(card.fields.effort)}</span>`);
+    if (card.session && card.session.host) chips.push(`<span class="board-chip board-chip-host">${escapeHtml(card.session.host)}</span>`);
+    for (const t of (card.tags || [])) {
+      if (ASSIGNEES.includes(t.toLowerCase())) continue;  // already shown as the assignee chip
+      chips.push(`<span class="board-chip board-chip-tag">#${escapeHtml(t)}</span>`);
+    }
+    return chips.join('');
+  }
+
+  function renderTaskCard(card) {
+    const live = !!(card.session && !TERMINAL.has(card.session.status));
+    const div = document.createElement('div');
+    div.className = 'board-card';
+    div.dataset.cardId = card.id;
+    div.dataset.lane = card.lane;
+    div.innerHTML = `
+      <div class="board-card-title">${live ? '<span class="live-dot" title="live"></span>' : ''}${escapeHtml(card.title || '(untitled)')}</div>
+      ${card.pending_question ? `<div class="board-card-question">❓ ${escapeHtml(card.pending_question.question)}</div>` : ''}
+      <div class="board-card-chips">${cardChips(card)}</div>
+    `;
+    div.addEventListener('click', () => {
+      if (suppressNextClick === card.id) { suppressNextClick = null; return; }
+      openDrawer(card.id);
+    });
+    div.addEventListener('mousedown', (e) => onCardMouseDown(e, card));
+    return div;
+  }
+
+  function renderScheduleCard(card) {
+    const div = document.createElement('div');
+    div.className = 'board-card board-card-schedule';
+    div.dataset.cardId = card.id;
+    div.dataset.lane = card.lane;
+    const nextFire = card.next_fire_at ? new Date(card.next_fire_at).toLocaleString() : '—';
+    div.innerHTML = `
+      <div class="board-card-title">${escapeHtml(card.name || '(schedule)')}</div>
+      <div class="board-card-chips">
+        ${card.recurring ? '<span class="board-chip">recurring</span>' : '<span class="board-chip">one-off</span>'}
+        <span class="board-chip">next: ${escapeHtml(nextFire)}</span>
+      </div>
+      ${card.last_run ? `<div class="board-card-lastrun">${escapeHtml(card.last_run.outcome || '')} · ${escapeHtml(card.last_run.snippet || '')}</div>` : ''}
+    `;
+    // Scheduled cards open the drawer (name/message/enabled are editable
+    // there — #850 finding 4) but never drag between lanes: their lane is
+    // derived from the scheduler entry's own enabled/next-fire state, not
+    // settable by dropping a card.
+    div.addEventListener('click', () => openDrawer(card.id));
+    return div;
+  }
+
+  function render() {
+    // A drop's re-render replaces every card node, so the trailing click
+    // that `suppressNextClick` was set to swallow often never reaches a
+    // card's own click handler (mouseup can land on a different lane's
+    // element, whose click event never bubbles through the original card).
+    // Clear it here instead of waiting for a click that may not arrive —
+    // otherwise it lingers and eats the operator's next genuine click on
+    // that same card id (#850 verify-1 finding 3).
+    suppressNextClick = null;
+    lanesEl.innerHTML = '';
+    for (const lane of LANES) {
+      const column = document.createElement('div');
+      column.className = 'board-lane';
+      column.dataset.lane = lane.id;
+
+      const cards = (board.lanes[lane.id] || [])
+        .map(c => ({ ...c, lane: lane.id }))
+        .filter(cardMatchesFilters);
+
+      column.innerHTML = `<div class="board-lane-header">${escapeHtml(lane.label)} <span class="board-lane-count">${cards.length}</span></div>`;
+      const cardsEl = document.createElement('div');
+      cardsEl.className = 'board-lane-cards';
+      for (const card of cards) {
+        cardsEl.appendChild(card.kind === 'schedule' ? renderScheduleCard(card) : renderTaskCard(card));
+      }
+      column.appendChild(cardsEl);
+      lanesEl.appendChild(column);
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Drag and drop — pointer-based (mousedown/mousemove/mouseup), not the
+  // native HTML5 Drag and Drop API. draggable="true" + dragstart/drop only
+  // fires through the browser's OS-level drag gesture, which synthetic
+  // mouse events (Playwright included) can't reliably trigger — a plain
+  // pointer drag works the same in real use and is what the server-free
+  // browser test drives.
+  // ------------------------------------------------------------------
+
+  let dragState = null;   // { cardId, sourceLane, cardEl, ghost, startX, startY, moved }
+  let suppressNextClick = null;  // card id whose trailing click (after a real drag) should be swallowed
+
+  function onCardMouseDown(e, card) {
+    if (e.button !== 0) return;
+    dragState = {
+      cardId: card.id, sourceLane: card.lane, cardEl: e.currentTarget,
+      startX: e.clientX, startY: e.clientY, moved: false, ghost: null,
+    };
+    document.addEventListener('mousemove', onDragMove);
+    document.addEventListener('mouseup', onDragUp);
+  }
+
+  function onDragMove(e) {
+    if (!dragState) return;
+    const dx = e.clientX - dragState.startX;
+    const dy = e.clientY - dragState.startY;
+    if (!dragState.moved && Math.hypot(dx, dy) < 4) return;
+    if (!dragState.moved) {
+      dragState.moved = true;
+      dragState.cardEl.classList.add('dragging-source');
+      const rect = dragState.cardEl.getBoundingClientRect();
+      const ghost = dragState.cardEl.cloneNode(true);
+      ghost.classList.add('board-card-ghost');
+      ghost.style.position = 'fixed';
+      ghost.style.pointerEvents = 'none';
+      ghost.style.width = rect.width + 'px';
+      ghost.style.zIndex = '200';
+      document.body.appendChild(ghost);
+      dragState.ghost = ghost;
+    }
+    dragState.ghost.style.left = (e.clientX + 12) + 'px';
+    dragState.ghost.style.top = (e.clientY + 12) + 'px';
+    document.querySelectorAll('.board-lane.drag-over').forEach(el => el.classList.remove('drag-over'));
+    const laneEl = document.elementFromPoint(e.clientX, e.clientY)?.closest('.board-lane');
+    if (laneEl) laneEl.classList.add('drag-over');
+  }
+
+  function onDragUp(e) {
+    document.removeEventListener('mousemove', onDragMove);
+    document.removeEventListener('mouseup', onDragUp);
+    if (!dragState) return;
+    const { cardId, sourceLane, moved, ghost, cardEl } = dragState;
+    document.querySelectorAll('.board-lane.drag-over').forEach(el => el.classList.remove('drag-over'));
+    if (ghost && ghost.parentNode) ghost.parentNode.removeChild(ghost);
+    if (cardEl) cardEl.classList.remove('dragging-source');
+    if (moved) {
+      const laneEl = document.elementFromPoint(e.clientX, e.clientY)?.closest('.board-lane');
+      const targetLane = laneEl && laneEl.dataset.lane;
+      if (targetLane && targetLane !== sourceLane) {
+        suppressNextClick = cardId;  // the mouseup will also fire a click — swallow it
+        onCardDropped(cardId, targetLane);
+      }
+    }
+    dragState = null;
+  }
+
+  function onCardDropped(cardId, targetLane) {
+    const card = findCard(cardId);
+    if (!card || card.kind !== 'task') return;
+    let assignee;
+    if (targetLane === 'assigned') {
+      // No mid-drag assignee picker with plain HTML5 DnD — default to "me"
+      // (the common case: an operator claiming a card for themself) unless
+      // the card already has one, which the lane endpoint keeps as-is only
+      // when we pass it through explicitly.
+      assignee = card.assignee || 'me';
+    }
+    // moveCard already toasts and re-renders on failure — nothing more to
+    // do here, just avoid an unhandled rejection now that it re-throws.
+    moveCard(cardId, targetLane, assignee).catch(() => {});
+  }
+
+  function laneLabel(laneId) {
+    const lane = LANES.find(l => l.id === laneId);
+    return lane ? lane.label : laneId;
+  }
+
+  function moveCard(cardId, targetLane, assignee) {
+    const body = { lane: targetLane };
+    if (assignee) body.assignee = assignee;
+    return fetch(`/api/agents/board/cards/${encodeURIComponent(cardId)}/lane`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+      .then(async (r) => {
+        if (!r.ok) {
+          const text = await r.text();
+          let msg = text;
+          try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) {}
+          throw new Error(msg || `HTTP ${r.status}`);
+        }
+        return r.json();
+      })
+      .then((data) => {
+        // The server-landed lane can differ from what was requested for the
+        // tags-only assigned/unassigned moves (e.g. a Human-queue card
+        // assigned to someone stays in Human queue) — surface that instead
+        // of leaving the operator to notice the card "snapped back" on its
+        // own (#850 round-2 finding 2b).
+        if (data && data.lane && data.lane !== targetLane) {
+          showToast(`Card landed in ${laneLabel(data.lane)}, not ${laneLabel(targetLane)}.`, false);
+        }
+        return fetchBoard();
+      })
+      .catch(err => {
+        showToast(`Couldn't move card: ${err.message}`, true);
+        // Nothing was mutated client-side before the request resolved, so
+        // the card is already still in its original lane — just re-render
+        // in case a stray class (drag-over) was left behind.
+        render();
+        // Re-throw so a caller mid-edit (e.g. the drawer's assignee select)
+        // can revert its own unsaved UI state instead of leaving a value
+        // that was never actually persisted (#850 finding 9).
+        throw err;
+      });
+  }
+
+  // ------------------------------------------------------------------
+  // New-card composer
+  // ------------------------------------------------------------------
+
+  function openNewCardForm() {
+    const backdrop = document.createElement('div');
+    backdrop.className = 'modal-backdrop';
+    backdrop.innerHTML = `
+      <div class="modal" role="dialog" aria-labelledby="new-card-title">
+        <h2 id="new-card-title">New card</h2>
+        <label style="font-size:0.75rem;color:var(--text-secondary)">Title</label>
+        <input id="new-card-desc" type="text" style="width:100%;box-sizing:border-box;margin:0.35rem 0;padding:0.4rem;background:var(--bg-elev);color:var(--text-primary);border:1px solid var(--border);border-radius:6px" />
+        <label style="font-size:0.75rem;color:var(--text-secondary)">Notes (optional)</label>
+        <textarea id="new-card-notes" placeholder="Notes…"></textarea>
+        <label style="font-size:0.75rem;color:var(--text-secondary)">Assignee</label>
+        <select id="new-card-assignee" style="width:100%;margin:0.35rem 0;padding:0.4rem;background:var(--bg-elev);color:var(--text-primary);border:1px solid var(--border);border-radius:6px">
+          <option value="">unassigned</option>
+          ${ASSIGNEES.map(a => `<option value="${a}">${a}</option>`).join('')}
+        </select>
+        <div class="actions">
+          <button id="new-card-cancel">Cancel</button>
+          <button class="danger" id="new-card-create">Create</button>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(backdrop);
+    const cleanup = () => { if (backdrop.parentNode) backdrop.parentNode.removeChild(backdrop); };
+    backdrop.addEventListener('click', e => { if (e.target === backdrop) cleanup(); });
+    backdrop.querySelector('#new-card-cancel').onclick = cleanup;
+    backdrop.querySelector('#new-card-create').onclick = async () => {
+      const desc = backdrop.querySelector('#new-card-desc').value.trim();
+      if (!desc) return;
+      const notes = backdrop.querySelector('#new-card-notes').value.trim();
+      const assignee = backdrop.querySelector('#new-card-assignee').value;
+      const btn = backdrop.querySelector('#new-card-create');
+      btn.disabled = true;
+      btn.textContent = 'Creating…';
+      try {
+        const r = await fetch('/api/tasks', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            description: desc,
+            notes: notes || undefined,
+            tags: assignee ? [assignee] : undefined,
+          }),
+        });
+        if (!r.ok) {
+          const text = await r.text();
+          throw new Error(text);
+        }
+        cleanup();
+        fetchBoard();
+      } catch (err) {
+        showToast(`Couldn't create card: ${err.message}`, true);
+        btn.disabled = false;
+        btn.textContent = 'Create';
+      }
+    };
+  }
+
+  if (newCardBtn) newCardBtn.addEventListener('click', openNewCardForm);
+
+  // ------------------------------------------------------------------
+  // Drawer
+  // ------------------------------------------------------------------
+
+  function closeDrawer() {
+    openCardId = null;
+    openCardLane = null;
+    openCardSnapshot = null;
+    if (panel) { panel.close(); panel = null; }
+    if (drawerBackdrop) drawerBackdrop.hidden = true;
+    if (drawerEl) drawerEl.innerHTML = '';
+  }
+
+  function openDrawer(cardId) {
+    const card = findCard(cardId);
+    if (!card) return;
+    openCardId = cardId;
+    openCardLane = card.lane;
+    openCardSnapshot = card;
+    if (drawerBackdrop) drawerBackdrop.hidden = false;
+    renderDrawer(card);
+  }
+
+  async function putTask(taskId, patch) {
+    const r = await fetch(`/api/tasks/${encodeURIComponent(taskId)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    });
+    if (!r.ok) {
+      const text = await r.text();
+      let msg = text;
+      try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) {}
+      throw new Error(msg || `HTTP ${r.status}`);
+    }
+    return r.json();
+  }
+
+  async function putSchedule(scheduleId, patch) {
+    const r = await fetch(`/api/scheduler/${encodeURIComponent(scheduleId)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    });
+    if (!r.ok) {
+      const text = await r.text();
+      let msg = text;
+      try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) {}
+      throw new Error(msg || `HTTP ${r.status}`);
+    }
+    return r.json();
+  }
+
+  function renderDrawer(card) {
+    if (!drawerEl) return;
+    const isTask = card.kind === 'task';
+    const nonAssigneeTags = (card.tags || []).filter(t => !ASSIGNEES.includes(t.toLowerCase()));
+    const titleValue = isTask ? (card.title || '') : (card.name || '');
+    drawerEl.innerHTML = `
+      <div class="drawer-header">
+        <button class="panel-close" data-action="drawer-close">×</button>
+        <input class="drawer-title" data-field="title" value="${escapeHtml(titleValue)}" />
+      </div>
+      ${isTask ? `
+      <label class="drawer-label">Notes</label>
+      <textarea class="drawer-notes" data-field="notes" placeholder="Notes…">${escapeHtml(card.notes || '')}</textarea>
+      <div class="drawer-row">
+        <div>
+          <label class="drawer-label">Assignee</label>
+          <select class="drawer-assignee" data-field="assignee">
+            <option value="">unassigned</option>
+            ${ASSIGNEES.map(a => `<option value="${a}" ${card.assignee === a ? 'selected' : ''}>${a}</option>`).join('')}
+          </select>
+        </div>
+        <div>
+          <label class="drawer-label">Context</label>
+          <input class="drawer-context" data-field="context" value="${escapeHtml(card.context || '')}" />
+        </div>
+      </div>
+      <label class="drawer-label">Tags</label>
+      <input class="drawer-tags" data-field="tags" value="${escapeHtml(nonAssigneeTags.join(' '))}" placeholder="space-separated tags" />
+      <div class="drawer-assignment" data-field="assignment"></div>
+      <div class="drawer-actions" data-field="actions"></div>
+      <div class="drawer-session" data-field="session-panel"></div>
+      ` : `
+      <label class="drawer-label">Message</label>
+      <textarea class="drawer-notes" data-field="message-content" placeholder="Message…">${escapeHtml(card.message_content || '')}</textarea>
+      <label class="drawer-label"><input type="checkbox" data-field="enabled" ${card.enabled ? 'checked' : ''} /> Enabled</label>
+      <div class="drawer-schedule-hint">Name, message, and enabled save here through the scheduler API — for schedule type, timing, or executor, use the existing scheduler UI.</div>
+      `}
+    `;
+    drawerEl.querySelector('[data-action="drawer-close"]').onclick = closeDrawer;
+
+    const titleEl = drawerEl.querySelector('[data-field="title"]');
+    titleEl.addEventListener('blur', async () => {
+      const value = titleEl.value.trim();
+      if (!value || value === titleValue) return;
+      try {
+        if (isTask) await putTask(card.id, { description: value });
+        else await putSchedule(card.id, { name: value });
+        await fetchBoard();
+      } catch (err) {
+        showToast(`Couldn't save title: ${err.message}`, true);
+        titleEl.value = titleValue;
+      }
+    });
+
+    if (!isTask) {
+      const msgEl = drawerEl.querySelector('[data-field="message-content"]');
+      msgEl.addEventListener('blur', async () => {
+        const value = msgEl.value;
+        if (value === (card.message_content || '')) return;
+        try { await putSchedule(card.id, { message_content: value }); await fetchBoard(); }
+        catch (err) { showToast(`Couldn't save message: ${err.message}`, true); msgEl.value = card.message_content || ''; }
+      });
+      const enabledEl = drawerEl.querySelector('[data-field="enabled"]');
+      enabledEl.addEventListener('change', async () => {
+        try { await putSchedule(card.id, { enabled: enabledEl.checked }); await fetchBoard(); }
+        catch (err) { showToast(`Couldn't update enabled: ${err.message}`, true); enabledEl.checked = !!card.enabled; }
+      });
+      return;
+    }
+
+    const notesEl = drawerEl.querySelector('[data-field="notes"]');
+    notesEl.addEventListener('blur', async () => {
+      const value = notesEl.value;
+      if (value === (card.notes || '')) return;
+      try { await putTask(card.id, { notes: value }); await fetchBoard(); }
+      catch (err) { showToast(`Couldn't save notes: ${err.message}`, true); notesEl.value = card.notes || ''; }
+    });
+
+    const assigneeEl = drawerEl.querySelector('[data-field="assignee"]');
+    assigneeEl.addEventListener('change', async () => {
+      const value = assigneeEl.value;
+      try {
+        await moveCard(card.id, value ? 'assigned' : 'unassigned', value || undefined);
+        // moveCard already awaited fetchBoard(), so the board's own state is
+        // current — but updateOpenDrawer's `!focused` check skips the
+        // rebuild while the select (inside the drawer) still holds focus,
+        // which a native <select> keeps after a change event. Re-render
+        // explicitly so the model/effort/host pickers and the Open button
+        // reflect the new assignee immediately, not only once focus leaves
+        // the drawer (#859 review round 1 finding 1).
+        const fresh = findCard(card.id);
+        if (fresh) { renderDrawer(fresh); openCardSnapshot = fresh; }
+      } catch (err) {
+        // moveCard already toasted the failure and nothing was persisted —
+        // re-render the drawer from the still-current card so the select
+        // snaps back to the actual assignee instead of showing the
+        // rejected choice (#850 finding 9).
+        const fresh = findCard(card.id);
+        if (fresh) renderDrawer(fresh);
+      }
+    });
+
+    const contextEl = drawerEl.querySelector('[data-field="context"]');
+    contextEl.addEventListener('blur', async () => {
+      const value = contextEl.value.trim();
+      if (!value || value === card.context) return;
+      try { await putTask(card.id, { context: value }); await fetchBoard(); }
+      catch (err) { showToast(`Couldn't save context: ${err.message}`, true); contextEl.value = card.context || ''; }
+    });
+
+    const tagsEl = drawerEl.querySelector('[data-field="tags"]');
+    const VALID_TAG = /^[\w-]+$/;
+    tagsEl.addEventListener('blur', async () => {
+      const tokens = tagsEl.value.split(/\s+/).map(t => t.replace(/^#/, '')).filter(Boolean);
+      // Free text here writes straight to the task store — reject anything
+      // that isn't a plain word/hyphen token (blocks a vault-comment
+      // injection like `<!--id:...-->` stealing another task's id) and drop
+      // any assignee-name token (the assignee comes from the select above,
+      // not this field) rather than letting it silently double up as a tag
+      // (#850 finding 8).
+      const parsed = [];
+      const rejected = [];
+      for (const t of tokens) {
+        if (VALID_TAG.test(t) && !ASSIGNEES.includes(t.toLowerCase())) parsed.push(t);
+        else rejected.push(t);
+      }
+      if (rejected.length) {
+        showToast(`Ignored invalid tag${rejected.length > 1 ? 's' : ''}: ${rejected.join(', ')}`, true);
+      }
+      tagsEl.value = parsed.join(' ');
+      const assigneeTag = card.assignee ? [card.assignee] : [];
+      try { await putTask(card.id, { tags: [...assigneeTag, ...parsed] }); await fetchBoard(); }
+      catch (err) { showToast(`Couldn't save tags: ${err.message}`, true); tagsEl.value = nonAssigneeTags.join(' '); }
+    });
+
+    // The drawer's own Assignee select above is the one assignee writer —
+    // it already writes exactly one assignee tag through the lane endpoint
+    // and supports `me`, which the module's own engine select can't
+    // represent. So mount the model/effort/host pickers but hide the
+    // module's engine row to avoid a second, conflicting assignee control.
+    const assignmentEl = drawerEl.querySelector('[data-field="assignment"]');
+    if (assignmentEl) {
+      renderAssignmentPickers(assignmentEl, card, {
+        putTask,
+        onSaved: () => fetchBoard(),
+        onError: (message) => showToast(`Couldn't save assignment: ${message}`, true),
+      });
+      const engineRow = assignmentEl.querySelector('[data-row="engine"]');
+      if (engineRow) engineRow.hidden = true;
+    }
+
+    renderDrawerActions(card);
+    renderDrawerSession(card);
+  }
+
+  function renderDrawerActions(card) {
+    const actionsEl = drawerEl.querySelector('[data-field="actions"]');
+    if (!actionsEl) return;
+    const buttons = [];
+
+    if (card.lane === 'assigned' && (card.assignee === 'claude' || card.assignee === 'codex')) {
+      buttons.push(['Open', async () => {
+        try {
+          const r = await fetch(`/api/agents/board/cards/${encodeURIComponent(card.id)}/open`, { method: 'POST' });
+          if (!r.ok) {
+            const text = await r.text();
+            let msg = text;
+            try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) {}
+            throw new Error(msg || `HTTP ${r.status}`);
+          }
+          showToast('Opened.', false);
+          fetchBoard();
+        } catch (err) { showToast(`Open failed: ${err.message}`, true); }
+      }]);
+    }
+
+    if (card.session && (card.session.source === 'claude_code' || card.session.source === 'codex')) {
+      buttons.push(['Focus', async () => {
+        try {
+          const r = await fetch(`/api/agents/sessions/${encodeURIComponent(card.session.session_id)}/focus`, { method: 'POST' });
+          if (!r.ok) throw new Error(await r.text());
+          showToast('Pane selected in wezterm.', false);
+        } catch (err) { showToast(`Focus failed: ${err.message}`, true); }
+      }]);
+    }
+    if (card.session && !TERMINAL.has(card.session.status)) {
+      buttons.push(['Kill', async () => {
+        try {
+          const r = await fetch(`/api/agents/sessions/${encodeURIComponent(card.session.session_id)}/kill`, {
+            method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ reason: '' }),
+          });
+          if (!r.ok) throw new Error(await r.text());
+          showToast('Session killed.', false);
+          fetchBoard();
+        } catch (err) { showToast(`Kill failed: ${err.message}`, true); }
+      }]);
+    }
+    if (card.pending_question) {
+      buttons.push(['Answer', () => openAnswerPrompt(card)]);
+    }
+    if (card.lane === 'review') {
+      buttons.push(['Accept', async () => {
+        try {
+          const r = await fetch(`/api/agents/board/cards/${encodeURIComponent(card.id)}/accept`, { method: 'POST' });
+          if (!r.ok) throw new Error(await r.text());
+          showToast('Accepted.', false);
+          fetchBoard();
+        } catch (err) { showToast(`Accept failed: ${err.message}`, true); }
+      }]);
+    }
+    if (card.lane === 'human_queue' && !card.pending_question) {
+      // A manually-filed #human card with no agent question behind it —
+      // "Resolve" is the operator saying they've handled it by hand.
+      buttons.push(['Resolve', async () => { await moveCard(card.id, 'done').catch(() => {}); }]);
+    }
+
+    for (const [label, handler] of buttons) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'drawer-action';
+      btn.textContent = label;
+      btn.onclick = handler;
+      actionsEl.appendChild(btn);
+    }
+  }
+
+  function openAnswerPrompt(card) {
+    const backdrop = document.createElement('div');
+    backdrop.className = 'modal-backdrop';
+    backdrop.innerHTML = `
+      <div class="modal" role="dialog" aria-labelledby="answer-title">
+        <h2 id="answer-title">Answer</h2>
+        <div class="target">${escapeHtml(card.pending_question.question)}</div>
+        <textarea id="answer-text" placeholder="Your answer…"></textarea>
+        <div class="actions">
+          <button id="answer-cancel">Cancel</button>
+          <button class="danger" id="answer-send">Send</button>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(backdrop);
+    const cleanup = () => { if (backdrop.parentNode) backdrop.parentNode.removeChild(backdrop); };
+    backdrop.addEventListener('click', e => { if (e.target === backdrop) cleanup(); });
+    backdrop.querySelector('#answer-cancel').onclick = cleanup;
+    backdrop.querySelector('#answer-send').onclick = async () => {
+      const answer = backdrop.querySelector('#answer-text').value.trim();
+      if (!answer) return;
+      const btn = backdrop.querySelector('#answer-send');
+      btn.disabled = true;
+      btn.textContent = 'Sending…';
+      try {
+        const r = await fetch(`/api/agents/pending-questions/${encodeURIComponent(card.pending_question.id)}/answer`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ answer }),
+        });
+        if (!r.ok) throw new Error(await r.text());
+        showToast('Answer sent.', false);
+        cleanup();
+        fetchBoard();
+      } catch (err) {
+        showToast(`Couldn't send answer: ${err.message}`, true);
+        btn.disabled = false;
+        btn.textContent = 'Send';
+      }
+    };
+  }
+
+  function renderDrawerSession(card) {
+    const sessionWrap = drawerEl.querySelector('[data-field="session-panel"]');
+    if (!sessionWrap) return;
+    if (panel) { panel.close(); panel = null; }
+    if (!card.session) {
+      sessionWrap.innerHTML = '<div class="panel-empty">No linked session yet.</div>';
+      return;
+    }
+    panel = new SessionPanel({ container: sessionWrap });
+    panel.open(card.session);
+  }
+
+  // A change that arrived while the drawer had focus is deferred by
+  // updateOpenDrawer's `!focused` check — flush it as soon as the operator
+  // leaves the field, using the latest board already applied by applyBoard
+  // (#850 round-2 finding 4).
+  if (drawerEl) {
+    drawerEl.addEventListener('focusout', (e) => {
+      // focusout fires before focus lands on the next element, so a move
+      // WITHIN the drawer (e.g. Tab between fields, or a mousedown on an
+      // action button before its mouseup) still sees `activeElement` as
+      // <body> for an instant. relatedTarget is the element receiving
+      // focus — populated for an intra-drawer move, null when blur() sends
+      // focus to <body> — so only flush once focus has actually left the
+      // drawer (#850 round-3 finding 1).
+      if (e.relatedTarget && drawerEl.contains(e.relatedTarget)) return;
+      if (!openCardId) return;
+      const fresh = findCard(openCardId);
+      if (fresh) updateOpenDrawer(fresh);
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // Wire filters + boot
+  // ------------------------------------------------------------------
+
+  [searchEl, laneFilterEl, assigneeFilterEl, hostFilterEl, tagFilterEl,
+   contextFilterEl, recencyFilterEl, includeDoneEl].filter(Boolean).forEach(el => {
+    const evt = (el.tagName === 'SELECT' || el.type === 'checkbox') ? 'change' : 'input';
+    el.addEventListener(evt, () => render());
+  });
+
+  fetchBoard();
+  connectStream();
+}

--- a/web/agents/graph.js
+++ b/web/agents/graph.js
@@ -1,0 +1,866 @@
+// web/agents/graph.js
+//
+// The Graph tab (#850) — the force-directed session graph that used to be
+// the whole /agents page. Node rendering, simulation, filters, chips, and
+// search are unchanged from the pre-#850 single-file web/agents.html; the
+// only structural change is that the side panel's rendering, event feed,
+// label edit, and summary fetch now come from the shared
+// `SessionPanel` in ./panel.js (also used by the Board tab's drawer)
+// instead of being duplicated inline.
+//
+// `initGraph()` is called once, lazily, the first time the operator opens
+// the Graph tab (see web/agents.html) — the graph's own snapshot fetch + SSE
+// stream only start then, so loading the board (the primary view) doesn't
+// also open a second live connection nobody is looking at.
+
+import {
+  STATUS_COLORS, TERMINAL, routingLabel, sourceLabelFor,
+  escapeHtml, showToast, SessionPanel,
+} from './panel.js';
+
+export function initGraph() {
+  const filterTerminalEl = document.getElementById('filter-terminal');
+  const filterRouteEl = document.getElementById('filter-route');
+  const filterStatusEl = document.getElementById('filter-status');
+  const filterRecencyEl = document.getElementById('filter-recency');
+  const filterCwdEl = document.getElementById('filter-cwd');
+  const filterHostEl = document.getElementById('filter-host');
+  const connStateEl = document.getElementById('connection-state');
+  const emptyStateEl = document.getElementById('empty-state');
+  const panelEl = document.getElementById('panel');
+  const panelOuterEl = document.getElementById('panel-outer');
+  const panelResizerEl = document.getElementById('panel-resizer');
+  // Operator chooses recency manually → don't auto-flip on include-finished toggle.
+  let recencyManuallySet = false;
+
+  let allSessions = [];
+  let allEdges = [];
+  let selectedSessionId = null;
+
+  // 1-hop descendants (via parent_session_id) for the kill-modal preview.
+  function descendantsOf(session) {
+    const childrenOf = new Map();
+    for (const x of allSessions) {
+      if (!x.parent_session_id) continue;
+      if (!childrenOf.has(x.parent_session_id)) childrenOf.set(x.parent_session_id, []);
+      childrenOf.get(x.parent_session_id).push(x);
+    }
+    const out = [];
+    const queue = [session.session_id];
+    const seen = new Set([session.session_id]);
+    while (queue.length) {
+      const sid = queue.shift();
+      for (const child of (childrenOf.get(sid) || [])) {
+        if (seen.has(child.session_id)) continue;
+        seen.add(child.session_id);
+        out.push(child);
+        queue.push(child.session_id);
+      }
+    }
+    return out;
+  }
+
+  const panel = new SessionPanel({
+    container: panelEl,
+    getDescendants: descendantsOf,
+    onLabelSaved: (sessionId, customLabel) => {
+      const canonical = allSessions.find(x => x.session_id === sessionId);
+      if (canonical) canonical.custom_label = customLabel;
+      nodeLayer.selectAll('.node')
+        .filter(d => d.session_id === sessionId)
+        .each(function(d) { d.custom_label = customLabel; })
+        .select('text.node-label')
+        .text(d => nodeLabel(d));
+    },
+    onSummaryFetched: (sessionId, shortLabel) => {
+      const s = allSessions.find(x => x.session_id === sessionId);
+      if (s) s.short_label = shortLabel;
+      nodeLayer.selectAll('.node')
+        .filter(d => d.session_id === sessionId)
+        .each(function(d) { d.short_label = shortLabel; })
+        .select('text.node-label')
+        .text(d => nodeLabel(d));
+    },
+  });
+
+  function closePanel() {
+    selectedSessionId = null;
+    panel.close();
+    panelEl.innerHTML = '<div class="panel-empty" id="panel-empty">Click a node to inspect its transcript.</div>';
+    applySelectionStyles();
+  }
+
+  function openPanel(sessionId) {
+    const s = allSessions.find(x => x.session_id === sessionId);
+    if (!s) return;
+    selectedSessionId = sessionId;
+    applySelectionStyles();
+    panel.open(s);
+  }
+
+  // Standalone Go To for the node dblclick handler — fires regardless of
+  // whether the side panel is currently open for this session (SessionPanel's
+  // own focus button only exists once its panel is rendered).
+  async function focusSessionQuick(s) {
+    try {
+      const r = await fetch(`/api/agents/sessions/${encodeURIComponent(s.session_id)}/focus`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+      });
+      if (!r.ok) {
+        const text = await r.text();
+        let msg = text;
+        try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) {}
+        if (r.status === 404) {
+          showToast(`Couldn't locate pane — session not running, wezterm unreachable, or SessionStart hook not installed.`, true);
+        } else if (r.status === 410) {
+          showToast(`Pane no longer exists. Click Resume to open a new one.`, true);
+        } else {
+          showToast(`Go To failed: ${msg}`, true);
+        }
+        return;
+      }
+      showToast(`Pane selected in wezterm. Click the wezterm dock icon to bring it forward.`, false);
+    } catch (err) {
+      showToast(`Go To failed: ${err.message}`, true);
+    }
+  }
+
+  // -------------------------------------------------------------------
+  // D3 force-directed graph (mirrors /crm/graph patterns).
+  // -------------------------------------------------------------------
+  const svg = d3.select('#graph-svg');
+  const VIEW_W = 1600;
+  const VIEW_H = 1100;
+  svg.attr('viewBox', `0 0 ${VIEW_W} ${VIEW_H}`);
+  svg.style('overflow', 'visible');
+  const viewport = svg.append('g').attr('class', 'viewport');
+  const linkLayer = viewport.append('g').attr('class', 'links');
+  const nodeLayer = viewport.append('g').attr('class', 'nodes');
+
+  const zoom = d3.zoom()
+    .scaleExtent([0.2, 5])
+    .on('zoom', (event) => { viewport.attr('transform', event.transform); });
+  svg.call(zoom);
+  svg.style('cursor', 'grab');
+  svg.on('mousedown.cursor', () => svg.style('cursor', 'grabbing'));
+  svg.on('mouseup.cursor',   () => svg.style('cursor', 'grab'));
+
+  svg.on('click', (event) => {
+    if (event.target === svg.node() && selectedSessionId) closePanel();
+  });
+
+  let visibleCount = 0;
+  let _lastVisibleIdsKey = '';
+  let _nodeClickTimer = null;
+  function recencyRailSpan() {
+    if (visibleCount <= 1) return 0;
+    return Math.min(0.84, 0.15 + 0.15 * Math.log2(visibleCount));
+  }
+
+  function recencyTargetX(s) {
+    const span = recencyRailSpan();
+    const nowSec = Date.now() / 1000;
+    const ageSec = Math.max(0, nowSec - (s.last_activity_at || nowSec));
+    const ageNorm = Math.min(ageSec, 86400) / 86400;
+    return VIEW_W * (0.5 + span / 2 - ageNorm * span);
+  }
+
+  const simulation = d3.forceSimulation()
+    .force('link', d3.forceLink().id(d => d.session_id).distance(80).strength(0.04))
+    .force('charge', d3.forceManyBody().strength(-220).distanceMax(600))
+    .force('center-y', d3.forceY(VIEW_H / 2).strength(0.12))
+    .force('recency-x', d3.forceX(recencyTargetX).strength(0.18))
+    .force('collide', d3.forceCollide().radius(d => collideRadius(d)).strength(0.9))
+    .alphaDecay(0.025)
+    .alphaMin(0.001)
+    .velocityDecay(0.45);
+
+  setTimeout(() => simulation.alpha(0).stop(), 8000);
+
+  simulation.on('tick', () => {
+    nodeLayer.selectAll('.node').attr('transform', d => `translate(${d.x},${d.y})`);
+    linkLayer.selectAll('.link').attr('d', d => {
+      const sx = d.source.x, sy = d.source.y;
+      const tx = d.target.x, ty = d.target.y;
+      const dx = tx - sx, dy = ty - sy;
+      const dr = Math.sqrt(dx * dx + dy * dy) * 1.6 || 1;
+      return `M${sx},${sy}A${dr},${dr} 0 0,1 ${tx},${ty}`;
+    });
+  });
+
+  function shortenCwd(p) {
+    if (!p) return p;
+    const m = p.match(/^\/(home|Users)\/[^/]+(\/.*)?$/);
+    if (m) return m[2] || '/';
+    return p;
+  }
+
+  let _lastCwdOptionKey = '';
+  function updateCwdOptions(sessions) {
+    if (!filterCwdEl) return;
+    const cwds = [...new Set(sessions.map(s => s.decoded_cwd).filter(Boolean))].sort();
+    const key = cwds.join('|');
+    if (key === _lastCwdOptionKey) return;
+    _lastCwdOptionKey = key;
+    const current = filterCwdEl.value;
+    filterCwdEl.innerHTML = '<option value="all">all</option>'
+      + cwds.map(c => `<option value="${escapeHtml(c)}">${escapeHtml(shortenCwd(c))}</option>`).join('');
+    if (current && (current === 'all' || cwds.includes(current))) {
+      filterCwdEl.value = current;
+    }
+    const wrap = filterCwdEl.closest('label');
+    if (wrap) wrap.style.display = cwds.length > 0 ? '' : 'none';
+  }
+
+  // Host filter (#849) — same pattern as cwd above: options derive from
+  // whatever hosts are present in the current snapshot (local + any
+  // cross-machine cli_sessions rows), hidden entirely on a single-host
+  // deployment where the filter has nothing to distinguish.
+  let _lastHostOptionKey = '';
+  function updateHostOptions(sessions) {
+    if (!filterHostEl) return;
+    const hosts = [...new Set(sessions.map(s => s.host).filter(Boolean))].sort();
+    const key = hosts.join('|');
+    if (key === _lastHostOptionKey) return;
+    _lastHostOptionKey = key;
+    const current = filterHostEl.value;
+    filterHostEl.innerHTML = '<option value="all">all</option>'
+      + hosts.map(h => `<option value="${escapeHtml(h)}">${escapeHtml(h)}</option>`).join('');
+    if (current && (current === 'all' || hosts.includes(current))) {
+      filterHostEl.value = current;
+    }
+    const wrap = filterHostEl.closest('label');
+    if (wrap) wrap.style.display = hosts.length > 1 ? '' : 'none';
+  }
+
+  function applyFilters(sessions) {
+    const showTerm = filterTerminalEl.checked;
+    const route = filterRouteEl.value;
+    const status = filterStatusEl.value;
+    const recencyRaw = filterRecencyEl ? filterRecencyEl.value : 'all';
+    const recencySec = (recencyRaw === 'all') ? null : Number(recencyRaw);
+    const cwdSel = filterCwdEl ? filterCwdEl.value : 'all';
+    const hostSel = filterHostEl ? filterHostEl.value : 'all';
+    const nowSec = Date.now() / 1000;
+    return sessions.filter(s => {
+      if (!showTerm && TERMINAL.has(s.status)) return false;
+      if (recencySec !== null && s.last_activity_at
+          && (nowSec - s.last_activity_at) > recencySec) {
+        return false;
+      }
+      if (cwdSel !== 'all' && s.decoded_cwd !== cwdSel) return false;
+      if (hostSel !== 'all' && s.host !== hostSel) return false;
+      if (route !== 'all') {
+        const r = s.routing || 'local';
+        if (r !== route) return false;
+      }
+      if (status !== 'all' && s.status !== status) return false;
+      return true;
+    });
+  }
+
+  function applyRecencyDefault() {
+    if (recencyManuallySet || !filterRecencyEl) return;
+    filterRecencyEl.value = filterTerminalEl.checked ? '604800' : '1800';
+  }
+  applyRecencyDefault();
+
+  function hexWithAlpha(hex, alpha) {
+    const h = hex.replace('#', '');
+    const r = parseInt(h.slice(0, 2), 16);
+    const g = parseInt(h.slice(2, 4), 16);
+    const b = parseInt(h.slice(4, 6), 16);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  function sizeForTokens(totalTokens) {
+    const t = Math.max(0, totalTokens || 0);
+    const grown = Math.log10(t + 10) * 6;
+    return Math.min(56, Math.max(14, 14 + grown));
+  }
+
+  function nodeRadius(d) {
+    return sizeForTokens(
+      (d.total_input_tokens || 0)
+      + (d.total_output_tokens || 0)
+      + (d.total_cache_creation_tokens || 0)
+      + (d.total_cache_read_tokens || 0)
+    );
+  }
+
+  function nodeColors(d) {
+    const c = STATUS_COLORS[d.status] || '#6b7280';
+    const isTerm = TERMINAL.has(d.status);
+    return {
+      fill: isTerm ? hexWithAlpha(c, 0.35) : hexWithAlpha(c, 0.85),
+      stroke: c,
+      borderWidth: d.status === 'blocked' ? 4 : 2,
+    };
+  }
+
+  function nodeLabel(d) {
+    if (d.custom_label) return d.custom_label;
+    if (d.short_label) return d.short_label;
+    const isCli = d.source === 'claude_code' || d.source === 'codex';
+    let label = d.model_label || routingLabel(d.routing) || d.session_id.slice(0, 8);
+    if (isCli && (label === 'Claude Code' || label === 'Codex')) label = '?';
+    return label;
+  }
+
+  const LABEL_CHAR_W = 6.6;
+  const LABEL_MAX_W = 132;
+  const LABEL_MAX_CHARS = Math.floor(LABEL_MAX_W / LABEL_CHAR_W);
+  const LABEL_LINE_H = 13;
+  const LABEL_MAX_LINES = 3;
+  const LABEL_GAP = 14;
+
+  function wrapLabelText(str, maxChars) {
+    const words = String(str).split(/\s+/).filter(Boolean);
+    const lines = [];
+    let line = '';
+    for (let w of words) {
+      while (w.length > maxChars) {
+        if (line) { lines.push(line); line = ''; }
+        lines.push(w.slice(0, maxChars));
+        w = w.slice(maxChars);
+      }
+      const candidate = line ? line + ' ' + w : w;
+      if (candidate.length > maxChars) {
+        if (line) lines.push(line);
+        line = w;
+      } else {
+        line = candidate;
+      }
+    }
+    if (line) lines.push(line);
+    return lines.length ? lines : [''];
+  }
+
+  function renderNodeLabel(d) {
+    const textEl = d3.select(this);
+    let lines = wrapLabelText(nodeLabel(d), LABEL_MAX_CHARS);
+    if (lines.length > LABEL_MAX_LINES) {
+      lines = lines.slice(0, LABEL_MAX_LINES);
+      let last = lines[LABEL_MAX_LINES - 1];
+      if (last.length >= LABEL_MAX_CHARS) last = last.slice(0, LABEL_MAX_CHARS - 1);
+      lines[LABEL_MAX_LINES - 1] = last.replace(/\s+$/, '') + '…';
+    }
+    textEl.attr('y', nodeRadius(d) + LABEL_GAP).text(null);
+    lines.forEach((ln, i) => {
+      textEl.append('tspan')
+        .attr('x', 0)
+        .attr('dy', i === 0 ? 0 : LABEL_LINE_H)
+        .text(ln);
+    });
+    d._labelLines = lines.length;
+    d._labelW = Math.max(...lines.map(l => l.length)) * LABEL_CHAR_W;
+  }
+
+  function collideRadius(d) {
+    const r = nodeRadius(d);
+    const lines = d._labelLines || 1;
+    const halfW = Math.max(r, (d._labelW || 0) / 2) + 6;
+    const labelBottom = r + LABEL_GAP + (lines - 1) * LABEL_LINE_H + LABEL_LINE_H * 0.5;
+    const enclose = Math.hypot(halfW, labelBottom) * 0.85;
+    return Math.max(r + 14, enclose);
+  }
+
+  function nodeTitle(d) {
+    return [
+      d.label,
+      d.decoded_cwd ? `cwd: ${d.decoded_cwd}` : null,
+      `source: ${sourceLabelFor(d)}`,
+      `status: ${d.status}`,
+      `routing: ${routingLabel(d.routing)}`,
+      `tokens: ${d.total_input_tokens} in / ${d.total_output_tokens} out`,
+      `cost: $${(d.total_dollars || 0).toFixed(4)}`,
+      d.last_event_kind ? `last: ${d.last_event_kind}` : null,
+    ].filter(Boolean).join('\n');
+  }
+
+  function isActivelyWriting(d) {
+    const nowSec = Date.now() / 1000;
+    return d.status === 'running'
+      && d.last_activity_at
+      && (nowSec - d.last_activity_at) < 60;
+  }
+
+  function nodeShapeTag(d) {
+    if (d.source === 'claude_code' || d.source === 'codex'
+        || d.routing === 'claude_code' || d.routing === 'codex') return 'rect';
+    if (!d.routing || d.routing === 'local') return 'polygon';
+    return 'circle';
+  }
+
+  function applyShapeAttrs(sel) {
+    sel.each(function(d) {
+      const el = d3.select(this);
+      const r = nodeRadius(d);
+      const colors = nodeColors(d);
+      el.attr('fill', colors.fill).attr('stroke', colors.stroke)
+        .attr('stroke-width', colors.borderWidth)
+        .classed('pulsing', isActivelyWriting(d));
+      if (this.tagName === 'circle') {
+        el.attr('r', r);
+      } else if (this.tagName === 'rect') {
+        const side = r * 1.8;
+        el.attr('x', -side / 2).attr('y', -side / 2)
+          .attr('width', side).attr('height', side)
+          .attr('rx', Math.min(side * 0.22, 12))
+          .attr('ry', Math.min(side * 0.22, 12));
+      } else if (this.tagName === 'polygon') {
+        const h = r * 1.4;
+        el.attr('points', `0,${-h} ${h},0 0,${h} ${-h},0`);
+      }
+    });
+  }
+
+  function renderGraph(sessions, snapshotEdges) {
+    const visible = applyFilters(sessions);
+    const visibleIds = new Set(visible.map(s => s.session_id));
+
+    const visibleLinks = (snapshotEdges || [])
+      .filter(e => visibleIds.has(e.from) && visibleIds.has(e.to))
+      .map(e => ({ id: `${e.from}->${e.to}`, source: e.from, target: e.to }));
+
+    linkLayer.selectAll('path.link')
+      .data(visibleLinks, d => d.id)
+      .join(
+        enter => enter.append('path').attr('class', 'link'),
+        update => update,
+        exit => exit.remove()
+      );
+
+    const oldById = new Map();
+    nodeLayer.selectAll('.node').each(function(d) { oldById.set(d.session_id, d); });
+    const merged = visible.map(s => {
+      const prev = oldById.get(s.session_id);
+      if (prev) {
+        Object.assign(prev, s);
+        return prev;
+      }
+      return Object.assign({ x: recencyTargetX(s), y: VIEW_H / 2 }, s);
+    });
+
+    const sel = nodeLayer.selectAll('.node')
+      .data(merged, d => d.session_id);
+
+    const entered = sel.enter().append('g')
+      .attr('class', 'node')
+      .style('cursor', 'grab')
+      .call(d3.drag()
+        .on('start', (event, d) => {
+          if (!event.active) simulation.alphaTarget(0.1).restart();
+          d.fx = d.x;
+          d.fy = d.y;
+        })
+        .on('drag', (event, d) => {
+          d.fx = event.x;
+          d.fy = event.y;
+        })
+        .on('end', (event, d) => {
+          if (!event.active) simulation.alphaTarget(0);
+        }))
+      .on('click', (event, d) => {
+        if (_nodeClickTimer) clearTimeout(_nodeClickTimer);
+        _nodeClickTimer = setTimeout(() => {
+          _nodeClickTimer = null;
+          if (d.session_id === selectedSessionId) closePanel();
+          else openPanel(d.session_id);
+        }, 220);
+      })
+      .on('dblclick', (event, d) => {
+        const isCli = d.source === 'claude_code' || d.source === 'codex';
+        if (!isCli || d.is_subagent) return;
+        event.preventDefault();
+        event.stopPropagation();
+        if (_nodeClickTimer) { clearTimeout(_nodeClickTimer); _nodeClickTimer = null; }
+        focusSessionQuick(d);
+      });
+    entered.append(d => document.createElementNS('http://www.w3.org/2000/svg', nodeShapeTag(d)))
+      .attr('class', 'node-shape');
+    entered.append('title');
+    entered.append('text').attr('class', 'node-label');
+
+    const all = entered.merge(sel);
+    applyShapeAttrs(all.select('.node-shape'));
+    all.select('text.node-label').each(renderNodeLabel);
+    all.select('title').text(d => nodeTitle(d));
+
+    sel.exit().remove();
+
+    visibleCount = merged.length;
+    simulation.nodes(merged);
+    simulation.force('link').links(visibleLinks);
+    const visibleIdsKey = visible.map(s => s.session_id).sort().join('|');
+    if (visibleIdsKey !== _lastVisibleIdsKey) {
+      _lastVisibleIdsKey = visibleIdsKey;
+      simulation.alpha(0.3).restart();
+    }
+
+    emptyStateEl.style.display = visible.length === 0 ? '' : 'none';
+    updateChips(visible);
+    updateCwdOptions(allSessions);
+    updateHostOptions(allSessions);
+    applySelectionStyles();
+  }
+
+  function linkEndpoints(e) {
+    const s = (typeof e.source === 'object') ? e.source.session_id : e.source;
+    const t = (typeof e.target === 'object') ? e.target.session_id : e.target;
+    return [s, t];
+  }
+
+  function relatedTo(sessionId) {
+    const out = new Set();
+    if (!sessionId) return out;
+    linkLayer.selectAll('path.link').each(function(e) {
+      const [s, t] = linkEndpoints(e);
+      if (s === sessionId) out.add(t);
+      if (t === sessionId) out.add(s);
+    });
+    return out;
+  }
+
+  function applySelectionStyles() {
+    const hasSelection = !!selectedSessionId;
+    const related = relatedTo(selectedSessionId);
+
+    nodeLayer.selectAll('.node-shape')
+      .classed('selected', d => hasSelection && d.session_id === selectedSessionId)
+      .classed('related',  d => hasSelection && related.has(d.session_id))
+      .classed('dimmed',   d => hasSelection && d.session_id !== selectedSessionId && !related.has(d.session_id));
+
+    nodeLayer.selectAll('text.node-label')
+      .classed('dimmed', d => hasSelection && d.session_id !== selectedSessionId && !related.has(d.session_id));
+
+    linkLayer.selectAll('path.link')
+      .classed('highlighted', e => {
+        if (!hasSelection) return false;
+        const [s, t] = linkEndpoints(e);
+        return s === selectedSessionId || t === selectedSessionId;
+      })
+      .classed('dimmed', e => {
+        if (!hasSelection) return false;
+        const [s, t] = linkEndpoints(e);
+        return s !== selectedSessionId && t !== selectedSessionId;
+      });
+  }
+
+  function updateChips(sessions) {
+    const running = sessions.filter(s => s.status === 'running').length;
+    const blocked = sessions.filter(s => s.status === 'blocked').length;
+    const recent = sessions.filter(s => s.status === 'completed').length;
+    const cli = sessions.filter(s => s.source === 'claude_code' || s.source === 'codex').length;
+    const apiSpend = sessions
+      .filter(s => s.source !== 'claude_code' && s.source !== 'codex')
+      .reduce((acc, s) => acc + (s.total_dollars || 0), 0);
+    document.getElementById('chip-running').textContent = running;
+    document.getElementById('chip-blocked').textContent = blocked;
+    document.getElementById('chip-recent').textContent = recent;
+    document.getElementById('chip-cc').textContent = cli;
+    document.getElementById('chip-spend').textContent = '$' + apiSpend.toFixed(2);
+  }
+
+  function applySnapshot(snap) {
+    allSessions = snap.sessions || [];
+    allEdges = snap.edges || [];
+    renderGraph(allSessions, allEdges);
+    if (selectedSessionId) {
+      const s = allSessions.find(x => x.session_id === selectedSessionId);
+      if (s) panel.updateMeta(s);
+    }
+  }
+
+  // --- Filters ---
+  function releasePins() {
+    nodeLayer.selectAll('.node').each(function(d) { d.fx = null; d.fy = null; });
+  }
+  function onFilterChange() {
+    releasePins();
+    svg.transition().duration(300).call(zoom.transform, d3.zoomIdentity);
+    renderGraph(allSessions, allEdges);
+    if (searchQuery.trim()) renderSearchResults();
+  }
+  filterTerminalEl.addEventListener('change', () => {
+    applyRecencyDefault();
+    onFilterChange();
+  });
+  if (filterRecencyEl) {
+    filterRecencyEl.addEventListener('change', () => {
+      recencyManuallySet = true;
+      onFilterChange();
+    });
+  }
+  [filterRouteEl, filterStatusEl, filterCwdEl, filterHostEl].filter(Boolean).forEach(el =>
+    el.addEventListener('change', onFilterChange)
+  );
+
+  // --- Search (issue #252) ---
+  const searchInputEl = document.getElementById('search-input');
+  const searchResultsEl = document.getElementById('search-results');
+  const searchWrapEl = document.getElementById('search-wrap');
+  let searchQuery = '';
+  let summaryMatches = new Map();
+  let searchSeq = 0;
+  let searchActiveIndex = -1;
+  let searchDebounceTimer = null;
+
+  const SEARCH_TIER = { label: 0, short_label: 1, summary: 2 };
+  const SEARCH_BADGE = { label: 'name', short_label: 'label', summary: 'summary' };
+
+  function sessionDisplayName(s) {
+    return s.custom_label || s.short_label || s.label || s.session_id.slice(0, 8);
+  }
+
+  function highlightMatch(text, q) {
+    const t = String(text || '');
+    if (!q) return escapeHtml(t);
+    const idx = t.toLowerCase().indexOf(q.toLowerCase());
+    if (idx < 0) return escapeHtml(t);
+    return escapeHtml(t.slice(0, idx))
+      + '<mark>' + escapeHtml(t.slice(idx, idx + q.length)) + '</mark>'
+      + escapeHtml(t.slice(idx + q.length));
+  }
+
+  function buildSearchResults() {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return [];
+    const visibleIds = new Set(applyFilters(allSessions).map(s => s.session_id));
+    const byId = new Map(allSessions.map(s => [s.session_id, s]));
+    const entries = new Map();
+
+    function consider(sessionId, field, snippet) {
+      const s = byId.get(sessionId);
+      if (!s) return;
+      const prev = entries.get(sessionId);
+      if (prev && SEARCH_TIER[prev.field] <= SEARCH_TIER[field]) return;
+      entries.set(sessionId, { session: s, field, snippet, visible: visibleIds.has(sessionId) });
+    }
+
+    for (const s of allSessions) {
+      const name = s.custom_label || s.label || '';
+      if (name.toLowerCase().includes(q)) consider(s.session_id, 'label', name);
+    }
+    for (const [sid, m] of summaryMatches) consider(sid, m.field, m.snippet);
+
+    return [...entries.values()].sort((a, b) => {
+      if (a.visible !== b.visible) return a.visible ? -1 : 1;
+      if (SEARCH_TIER[a.field] !== SEARCH_TIER[b.field]) return SEARCH_TIER[a.field] - SEARCH_TIER[b.field];
+      return sessionDisplayName(a.session).localeCompare(sessionDisplayName(b.session));
+    });
+  }
+
+  function renderSearchResults() {
+    const q = searchQuery.trim();
+    if (!q) { hideSearchResults(); return; }
+    searchActiveIndex = -1;
+    const results = buildSearchResults();
+    if (results.length === 0) {
+      searchResultsEl.innerHTML = '<div class="search-empty">No matches</div>';
+      searchResultsEl.hidden = false;
+      return;
+    }
+    const visible = results.filter(r => r.visible);
+    const hidden = results.filter(r => !r.visible);
+    let html = '';
+    const renderGroup = (items, groupClass, labelText) => {
+      if (items.length === 0) return;
+      if (labelText) html += `<div class="search-group-label">${labelText}</div>`;
+      html += `<div class="search-group ${groupClass}">`;
+      for (const r of items) {
+        const titleText = r.field === 'label' ? (r.session.label || sessionDisplayName(r.session))
+          : r.field === 'short_label' ? (r.session.short_label || sessionDisplayName(r.session))
+          : sessionDisplayName(r.session);
+        const snippetHtml = r.field === 'summary'
+          ? `<div class="sr-snippet">${highlightMatch(r.snippet, q)}</div>`
+          : '';
+        html += `<button class="search-result" type="button" data-session="${escapeHtml(r.session.session_id)}">`
+          + `<div class="sr-title"><span class="sr-name">${highlightMatch(titleText, q)}</span>`
+          + `<span class="sr-badge">${SEARCH_BADGE[r.field]}</span></div>`
+          + snippetHtml + `</button>`;
+      }
+      html += `</div>`;
+    };
+    renderGroup(visible, 'visible-group', null);
+    renderGroup(hidden, 'hidden-group', 'Hidden by filters');
+    searchResultsEl.innerHTML = html;
+    searchResultsEl.hidden = false;
+  }
+
+  function hideSearchResults() {
+    searchResultsEl.hidden = true;
+    searchResultsEl.innerHTML = '';
+    searchActiveIndex = -1;
+  }
+
+  function relaxFiltersFor(s) {
+    const nowSec = Date.now() / 1000;
+    if (!filterTerminalEl.checked && TERMINAL.has(s.status)) filterTerminalEl.checked = true;
+    if (filterRecencyEl && filterRecencyEl.value !== 'all' && s.last_activity_at) {
+      const age = nowSec - s.last_activity_at;
+      if (age > Number(filterRecencyEl.value)) {
+        const fit = [...filterRecencyEl.options]
+          .map(o => o.value)
+          .find(v => v === 'all' || age <= Number(v));
+        filterRecencyEl.value = fit || 'all';
+        recencyManuallySet = true;
+      }
+    }
+    if (filterCwdEl && filterCwdEl.value !== 'all' && s.decoded_cwd !== filterCwdEl.value) {
+      filterCwdEl.value = 'all';
+    }
+    if (filterRouteEl.value !== 'all' && (s.routing || 'local') !== filterRouteEl.value) {
+      filterRouteEl.value = 'all';
+    }
+    if (filterStatusEl.value !== 'all' && s.status !== filterStatusEl.value) {
+      filterStatusEl.value = 'all';
+    }
+  }
+
+  function panToNode(sessionId, delay) {
+    const run = () => {
+      let target = null;
+      nodeLayer.selectAll('.node').each(function(d) { if (d.session_id === sessionId) target = d; });
+      if (!target || target.x == null || target.y == null) return;
+      const k = Math.max(d3.zoomTransform(svg.node()).k, 1);
+      const tx = VIEW_W / 2 - k * target.x;
+      const ty = VIEW_H / 2 - k * target.y;
+      svg.transition().duration(450)
+        .call(zoom.transform, d3.zoomIdentity.translate(tx, ty).scale(k));
+    };
+    if (delay) setTimeout(run, delay); else run();
+  }
+
+  function selectSearchResult(sessionId) {
+    const s = allSessions.find(x => x.session_id === sessionId);
+    if (!s) return;
+    const visibleIds = new Set(applyFilters(allSessions).map(x => x.session_id));
+    const wasHidden = !visibleIds.has(sessionId);
+    if (wasHidden) {
+      relaxFiltersFor(s);
+      releasePins();
+      renderGraph(allSessions, allEdges);
+    }
+    hideSearchResults();
+    openPanel(sessionId);
+    panToNode(sessionId, wasHidden ? 400 : 0);
+  }
+
+  async function fetchSummaryMatches(q) {
+    const seq = ++searchSeq;
+    try {
+      const r = await fetch('/api/agents/search?q=' + encodeURIComponent(q));
+      if (!r.ok) return;
+      const data = await r.json();
+      if (seq !== searchSeq || searchQuery.trim() !== q) return;
+      summaryMatches = new Map((data.matches || []).map(m => [m.session_id, m]));
+      renderSearchResults();
+    } catch (_) { /* network blip — the label tier still works offline */ }
+  }
+
+  function onSearchInput() {
+    searchQuery = searchInputEl.value;
+    const q = searchQuery.trim();
+    clearTimeout(searchDebounceTimer);
+    summaryMatches = new Map();
+    if (q.length >= 2) {
+      searchDebounceTimer = setTimeout(() => fetchSummaryMatches(q), 180);
+    }
+    renderSearchResults();
+  }
+
+  if (searchInputEl) {
+    searchInputEl.addEventListener('input', onSearchInput);
+    searchInputEl.addEventListener('focus', () => { if (searchQuery.trim()) renderSearchResults(); });
+    searchInputEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        searchInputEl.value = ''; searchQuery = ''; summaryMatches = new Map();
+        hideSearchResults(); searchInputEl.blur();
+        return;
+      }
+      const btns = [...searchResultsEl.querySelectorAll('.search-result')];
+      if (!btns.length) return;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        searchActiveIndex = Math.min(searchActiveIndex + 1, btns.length - 1);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        searchActiveIndex = Math.max(searchActiveIndex - 1, 0);
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        const pick = searchActiveIndex >= 0 ? btns[searchActiveIndex] : btns[0];
+        if (pick) selectSearchResult(pick.dataset.session);
+        return;
+      } else {
+        return;
+      }
+      btns.forEach((b, i) => b.classList.toggle('active', i === searchActiveIndex));
+      if (searchActiveIndex >= 0) btns[searchActiveIndex].scrollIntoView({ block: 'nearest' });
+    });
+    searchResultsEl.addEventListener('click', (e) => {
+      const btn = e.target.closest('.search-result');
+      if (btn) selectSearchResult(btn.dataset.session);
+    });
+    document.addEventListener('click', (e) => {
+      if (searchWrapEl && !searchWrapEl.contains(e.target)) hideSearchResults();
+    });
+  }
+
+  // --- Side panel resize ---
+  (function setupPanelResizer() {
+    if (!panelResizerEl || !panelOuterEl) return;
+    const STORAGE_KEY = 'lifeos.agents.panelWidth';
+    const MIN_WIDTH = 280;
+    const MAX_RATIO = 0.7;
+    const setWidth = (px) => {
+      const max = Math.floor(window.innerWidth * MAX_RATIO);
+      const clamped = Math.max(MIN_WIDTH, Math.min(max, Math.round(px)));
+      document.documentElement.style.setProperty('--panel-width', clamped + 'px');
+      return clamped;
+    };
+    try {
+      const saved = parseInt(localStorage.getItem(STORAGE_KEY) || '', 10);
+      if (saved && !isNaN(saved)) setWidth(saved);
+    } catch (_) {}
+
+    let dragging = false;
+    let startX = 0;
+    let startWidth = 0;
+    panelResizerEl.addEventListener('mousedown', (e) => {
+      dragging = true;
+      startX = e.clientX;
+      startWidth = panelOuterEl.getBoundingClientRect().width;
+      panelResizerEl.classList.add('dragging');
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      e.preventDefault();
+    });
+    window.addEventListener('mousemove', (e) => {
+      if (!dragging) return;
+      const newWidth = setWidth(startWidth + (startX - e.clientX));
+      try { localStorage.setItem(STORAGE_KEY, String(newWidth)); } catch (_) {}
+    });
+    window.addEventListener('mouseup', () => {
+      if (!dragging) return;
+      dragging = false;
+      panelResizerEl.classList.remove('dragging');
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      try { simulation.alpha(0.1).restart(); } catch (_) {}
+    });
+  })();
+
+  // --- Initial load + stream ---
+  fetch('/api/agents/snapshot')
+    .then(r => r.json())
+    .then(applySnapshot)
+    .catch(err => { connStateEl.textContent = 'failed: ' + err; });
+
+  const snapshotES = new EventSource('/api/agents/stream');
+  snapshotES.onopen = () => { connStateEl.textContent = 'live'; };
+  snapshotES.onerror = () => { connStateEl.textContent = 'reconnecting…'; };
+  snapshotES.addEventListener('snapshot', e => {
+    try { applySnapshot(JSON.parse(e.data)); } catch (_) {}
+  });
+}

--- a/web/agents/panel.js
+++ b/web/agents/panel.js
@@ -1,0 +1,697 @@
+// web/agents/panel.js
+//
+// Shared session-detail panel (#850): header render, inline label edit,
+// backfill + live SSE transcript tail, LLM summary fetch, and the
+// kill/resume/focus operator actions. Used by BOTH the Graph tab's side
+// panel (web/agents/graph.js) and the Board tab's card drawer
+// (web/agents/board.js), following the web/chat/ module split from #360.
+//
+// This is the pre-#850 web/agents.html panel code (renderPanelHeader,
+// updatePanelMeta, openPanel/closePanel, loadSessionEvents, appendEvent,
+// startLabelEdit, fetchSessionSummary, focusCcSession, resumeCcSession,
+// openKillModal) with one structural change: every DOM lookup is scoped to
+// a `container` passed in at construction instead of a single global
+// `#panel` element and `document.getElementById`, so a Graph-tab panel and
+// a Board-tab drawer can each hold their own instance without id collisions.
+// Rendering/behavior is otherwise unchanged.
+
+export const STATUS_COLORS = {
+  running:   '#34d399',
+  claimed:   '#60a5fa',
+  yielded:   '#fbbf24',  // agent worker — paused waiting on children
+  inactive:  '#fbbf24',  // claude code — paused, resumable
+  idle:      '#fbbf24',  // cli session — event-driven, waiting for input (not terminal)
+  blocked:   '#fb923c',
+  completed: '#6b7280',
+  ended:     '#6b7280',  // cli session — event-driven, session ended
+  failed:    '#f87171',
+  budget_exceeded: '#f87171',
+};
+
+// NOTE: 'idle' is a live cli session waiting for input — it must NOT be
+// treated as terminal. Only 'ended' (an explicit SessionEnd event) is.
+export const TERMINAL = new Set(['completed', 'failed', 'budget_exceeded', 'ended']);
+
+export function routingLabel(routing) {
+  if (!routing || routing === 'local') return 'Local';
+  if (routing === 'claude_code' || routing === 'code') return 'Claude Code';
+  if (routing === 'codex') return 'Codex';
+  if (routing === 'remote') return 'Remote';  // #809: #cloud tag, not Anthropic
+  if (routing === 'hermes') return 'Hermes';  // #850: was falling through to 'Claude'
+  return 'Claude';
+}
+
+export function sourceLabelFor(d) {
+  if (d.source === 'claude_code') return 'Claude Code CLI';
+  if (d.source === 'codex') return 'Codex CLI';
+  return 'LifeOS agent';
+}
+
+export function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// For values that go into HTML attribute positions via template strings.
+// Restricts to a known-safe charset so attribute-context injection is
+// structurally impossible.
+export function escapeAttr(s) {
+  return String(s).replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+export function showToast(message, isError) {
+  const t = document.createElement('div');
+  t.className = 'toast' + (isError ? ' error' : '');
+  t.textContent = message;
+  document.body.appendChild(t);
+  setTimeout(() => { if (t.parentNode) t.parentNode.removeChild(t); }, 3500);
+}
+
+// Format a unix-epoch timestamp as "MM/DD h:mm:ssa ET" — explicit Eastern
+// tz so it matches the rest of LifeOS (timezone='America/New_York' in
+// settings.py) regardless of the browser machine's locale.
+export function formatTs(ts) {
+  if (!ts) return '';
+  const d = new Date(ts * 1000);
+  const date = d.toLocaleDateString('en-US', {
+    timeZone: 'America/New_York', month: 'numeric', day: 'numeric',
+  });
+  const time = d.toLocaleTimeString('en-US', {
+    timeZone: 'America/New_York', hour: 'numeric', minute: '2-digit',
+    second: '2-digit', hour12: true,
+  });
+  return `${date} ${time} ET`;
+}
+
+// Compact 1.3k / 500k / 1.2M for token counts and similar.
+export function formatNumCompact(n) {
+  const x = Number(n);
+  if (!isFinite(x)) return String(n);
+  if (Math.abs(x) >= 1_000_000) return (x / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M';
+  if (Math.abs(x) >= 1_000)     return (x / 1_000).toFixed(1).replace(/\.0$/, '') + 'k';
+  return String(x);
+}
+
+// Minimal markdown — only converts leading `- ` lines into a <ul>. Anything
+// else is rendered as escaped text. The Gemma summary prompt only ever
+// produces bullets vs. paragraph.
+export function renderSummaryBody(text) {
+  const lines = (text || '').split(/\r?\n/);
+  const isBullet = l => /^\s*[-*]\s+/.test(l);
+  if (lines.some(isBullet)) {
+    const items = lines.filter(isBullet).map(l => {
+      const content = l.replace(/^\s*[-*]\s+/, '');
+      return `<li>${escapeHtml(content)}</li>`;
+    });
+    return `<ul>${items.join('')}</ul>`;
+  }
+  return escapeHtml(text);
+}
+
+// Field-aware payload renderer — maps common transcript-event payload shapes
+// to compact human-readable HTML. Anything unrecognized falls through to a
+// generic key/value tail; the full raw JSON is always available via
+// click-to-expand for diagnostics.
+const NOISE_FIELDS = new Set([
+  'iterations', 'inference_geo', 'server_tool_use', 'cache_creation',
+  'ephemeral_1h_input_tokens', 'ephemeral_5m_input_tokens',
+  'thinking_chars',  // surfaced separately when nonzero
+]);
+const SECONDARY_BADGES = ['model', 'task_id', 'expected_output', 'speed', 'service_tier', 'source', 'parent_session_id', 'child_session_id'];
+
+export function prettyPayload(payload) {
+  if (payload == null) return '';
+  if (typeof payload !== 'object') {
+    return `<div class="pp-text">${escapeHtml(String(payload))}</div>`;
+  }
+  const parts = [];
+
+  if (payload.routing) {
+    let s = `<div class="pp-routing">→ <span class="pp-target">${escapeHtml(String(payload.routing))}</span>`;
+    if (payload.routing_reason) s += ` <span class="pp-reason">· ${escapeHtml(payload.routing_reason)}</span>`;
+    s += `</div>`;
+    parts.push(s);
+  }
+
+  if (typeof payload.text === 'string' && payload.text.trim()) {
+    parts.push(`<div class="pp-text">${escapeHtml(payload.text)}</div>`);
+  } else if (payload.text === '' && Array.isArray(payload.tool_uses) && payload.tool_uses.length) {
+    parts.push(`<div class="pp-text muted">(no text — called tools)</div>`);
+  }
+
+  if (Array.isArray(payload.tool_uses) && payload.tool_uses.length) {
+    const tools = payload.tool_uses.map(t => {
+      const name = t && t.name ? String(t.name) : 'tool';
+      const argKeys = Array.isArray(t && t.input_keys)
+        ? t.input_keys
+        : (t && t.input && typeof t.input === 'object' ? Object.keys(t.input) : []);
+      const argStr = argKeys.length ? `<span class="pp-tool-args">(${escapeHtml(argKeys.join(', '))})</span>` : '';
+      return `<span class="pp-tool"><span class="pp-tool-name">${escapeHtml(name)}</span>${argStr}</span>`;
+    }).join('');
+    parts.push(`<div class="pp-tools">${tools}</div>`);
+  }
+
+  const TEXT_FIELDS = [
+    ['question', 'question'], ['answer', 'answer'], ['prompt', 'prompt'],
+    ['reason', 'reason'], ['ambiguity', 'ambiguity'], ['sane_reason', 'sane reason'],
+    ['description', 'description'], ['label', 'label'],
+  ];
+  for (const [field, label] of TEXT_FIELDS) {
+    const v = payload[field];
+    if (typeof v === 'string' && v.trim()) {
+      parts.push(`<div class="pp-field"><span class="pp-label">${escapeHtml(label)}</span><span class="pp-value">${escapeHtml(v)}</span></div>`);
+    }
+  }
+
+  if (payload.budget && typeof payload.budget === 'object') {
+    const b = payload.budget;
+    const bits = [];
+    if (b.wall_seconds != null)  bits.push(`${b.wall_seconds}s`);
+    if (b.max_dollars != null)   bits.push(`$${Number(b.max_dollars).toFixed(2)}`);
+    if (b.max_tokens != null)    bits.push(`${formatNumCompact(b.max_tokens)} tok`);
+    if (bits.length) parts.push(`<div class="pp-budget"><span class="pp-label">budget</span>${escapeHtml(bits.join(' · '))}</div>`);
+  }
+
+  if (payload.usage && typeof payload.usage === 'object') {
+    const u = payload.usage;
+    const bits = [];
+    if (u.input_tokens != null)  bits.push(`↓ ${formatNumCompact(u.input_tokens)} in`);
+    if (u.output_tokens != null) bits.push(`↑ ${formatNumCompact(u.output_tokens)} out`);
+    const cacheR = u.cache_read_input_tokens;
+    const cacheC = u.cache_creation_input_tokens;
+    if (cacheR || cacheC) {
+      const cb = [];
+      if (cacheR) cb.push(`${formatNumCompact(cacheR)} read`);
+      if (cacheC) cb.push(`${formatNumCompact(cacheC)} create`);
+      bits.push(`cache ${cb.join(' / ')}`);
+    }
+    if (bits.length) parts.push(`<div class="pp-usage"><span class="pp-label">usage</span>${escapeHtml(bits.join(' · '))}</div>`);
+  }
+
+  if (typeof payload.thinking_chars === 'number' && payload.thinking_chars > 0) {
+    parts.push(`<div class="pp-field"><span class="pp-label">thinking</span><span class="pp-value">${formatNumCompact(payload.thinking_chars)} chars</span></div>`);
+  }
+
+  const badges = [];
+  for (const f of SECONDARY_BADGES) {
+    const v = payload[f];
+    if (v != null && typeof v !== 'object') {
+      badges.push(`<span class="pp-badge"><span class="pp-label">${escapeHtml(f.replace(/_/g, ' '))}</span>${escapeHtml(String(v))}</span>`);
+    }
+  }
+  if (payload.sane === false) {
+    badges.push(`<span class="pp-badge pp-warn">not sane</span>`);
+  }
+  if (badges.length) parts.push(`<div class="pp-badges">${badges.join('')}</div>`);
+
+  const handled = new Set([
+    'routing', 'routing_reason', 'text', 'tool_uses',
+    ...TEXT_FIELDS.map(t => t[0]),
+    'budget', 'usage', 'thinking_chars',
+    ...SECONDARY_BADGES, 'sane',
+    ...NOISE_FIELDS,
+  ]);
+  const remainder = Object.entries(payload).filter(([k, v]) =>
+    !handled.has(k) && v != null
+    && (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')
+  );
+  if (remainder.length) {
+    const items = remainder.map(([k, v]) =>
+      `<span class="pp-kv"><span class="pp-label">${escapeHtml(k.replace(/_/g, ' '))}</span>${escapeHtml(String(v))}</span>`
+    ).join('');
+    parts.push(`<div class="pp-extra">${items}</div>`);
+  }
+
+  return parts.length ? parts.join('') : `<div class="pp-empty">(no fields)</div>`;
+}
+
+const _EVENTS_RETRY_DELAYS = [800, 1600, 3200];  // ms; ~5.6s before giving up
+
+/**
+ * A self-contained session-detail panel mounted into `container`.
+ *
+ * Options:
+ *   container      — element the panel renders into (required)
+ *   onLabelSaved(sessionId, customLabel) — called after a label edit saves,
+ *                    so a caller with its own session list (the graph) can
+ *                    nudge a node's displayed label immediately
+ *   onSummaryFetched(sessionId, shortLabel) — same, for the LLM short label
+ *   getDescendants(session) -> Session[] — non-terminal descendants to list
+ *                    in the kill confirmation modal (graph-only; board
+ *                    passes none)
+ */
+export class SessionPanel {
+  constructor(opts = {}) {
+    this.container = opts.container || null;
+    this.onLabelSaved = opts.onLabelSaved || (() => {});
+    this.onSummaryFetched = opts.onSummaryFetched || (() => {});
+    this.getDescendants = opts.getDescendants || (() => []);
+    this.sessionId = null;
+    this.session = null;
+    this.transcriptES = null;
+    this.eventKindFilter = null;
+    this.summaryAbort = null;
+  }
+
+  isOpenFor(sessionId) {
+    return this.sessionId === sessionId;
+  }
+
+  close() {
+    this.sessionId = null;
+    this.session = null;
+    this.eventKindFilter = null;
+    if (this.transcriptES) { this.transcriptES.close(); this.transcriptES = null; }
+    if (this.summaryAbort) { this.summaryAbort.abort(); this.summaryAbort = null; }
+    if (this.container) this.container.innerHTML = '';
+  }
+
+  open(session) {
+    if (!this.container || !session) return;
+    if (this.transcriptES) { this.transcriptES.close(); this.transcriptES = null; }
+    this.eventKindFilter = null;
+    this.sessionId = session.session_id;
+    this.session = session;
+    this._renderHeader(session);
+    this._fetchSummary(session.session_id);
+    this._loadEvents(session.session_id, 0);
+  }
+
+  // In-place metadata refresh — keeps the events container intact across
+  // polling ticks (snapshot / board). Only updates fields by data-field.
+  updateMeta(s) {
+    const root = this.container;
+    if (!root || this.sessionId !== s.session_id) return;
+    const setText = (sel, text) => {
+      const el = root.querySelector(`[data-field="${sel}"]`);
+      if (el) el.textContent = text;
+    };
+    const setHtml = (sel, html) => {
+      const el = root.querySelector(`[data-field="${sel}"]`);
+      if (el) el.innerHTML = html;
+    };
+    const inferredHint = s.status_inferred ? ' (inferred)' : '';
+    const sourceLabel = sourceLabelFor(s);
+    if (!root.querySelector('#label-edit-input')) {
+      setText('label', s.custom_label || s.label || s.session_id);
+    }
+    setText('status', s.status + inferredHint);
+    setText('source', sourceLabel);
+    setText('routing', routingLabel(s.routing));
+    setText('cost', '$' + (s.total_dollars || 0).toFixed(4));
+    setText('tokens', `${s.total_input_tokens || 0}↓ / ${s.total_output_tokens || 0}↑`);
+    setText('cwd-hint', s.decoded_cwd || '');
+
+    const statusBadge = root.querySelector('[data-field="status"]');
+    if (statusBadge) statusBadge.className = `badge status-${escapeAttr(s.status)}`;
+
+    const live = !TERMINAL.has(s.status);
+    setHtml('live-dot', live ? '<span class="live-dot" title="live"></span>' : '');
+    setHtml('depth', s.spawn_depth ? `<span class="badge">depth ${s.spawn_depth}</span>` : '');
+
+    const killBtn = root.querySelector('[data-action="kill"]');
+    const isCli = (s.source === 'claude_code' || s.source === 'codex');
+    if (live && !isCli && !killBtn) {
+      const header = root.querySelector('.panel-header');
+      if (header) {
+        const closeBtn = header.querySelector('[data-action="close"]');
+        const btn = document.createElement('button');
+        btn.className = 'panel-kill';
+        btn.dataset.action = 'kill';
+        btn.textContent = 'Kill';
+        btn.onclick = () => this.openKillModal(s);
+        header.insertBefore(btn, closeBtn);
+      }
+    } else if ((!live || isCli) && killBtn) {
+      killBtn.remove();
+    }
+    this.session = s;
+  }
+
+  _renderHeader(s) {
+    const root = this.container;
+    const live = !TERMINAL.has(s.status);
+    const safeStatus = escapeAttr(s.status);
+    const isCli = (s.source === 'claude_code' || s.source === 'codex');
+    const isSubagent = !!s.is_subagent;
+    const showKill = live && !isCli;
+    const showResume = isCli && !isSubagent && (TERMINAL.has(s.status) || s.status === 'inactive' || s.status === 'yielded');
+    const showGoTo = isCli && !isSubagent;
+    const sourceLabel = sourceLabelFor(s);
+    const inferredHint = s.status_inferred ? ' (inferred)' : '';
+    root.innerHTML = `
+      <div class="panel-header">
+        <button class="panel-close" aria-label="Close" data-action="close">×</button>
+        ${showKill ? '<button class="panel-kill" data-action="kill">Kill</button>' : ''}
+        ${showResume ? '<button class="panel-resume" data-action="resume" title="Open a new wezterm tab and run claude --resume">Resume</button>' : ''}
+        ${showGoTo ? '<button class="panel-focus" data-action="focus" title="Jump to the existing wezterm pane for this session (or run Resume if there isn\'t one).">Go To</button>' : ''}
+        <div class="label" data-field="label" title="Click to rename this session">${escapeHtml(s.custom_label || s.label || s.session_id)}</div>
+        <div class="cwd-hint" data-field="cwd-hint" style="font-size:0.7rem;color:var(--text-dim);margin-top:0.15rem;word-break:break-all">${s.decoded_cwd ? escapeHtml(s.decoded_cwd) : ''}</div>
+        ${s.branch ? `<div class="branch-hint" data-field="branch-hint" style="font-size:0.7rem;color:var(--text-dim);margin-top:0.1rem">branch: ${escapeHtml(s.branch)}</div>` : ''}
+        <div class="meta" data-field="meta">
+          <span data-field="live-dot">${live ? '<span class="live-dot" title="live"></span>' : ''}</span>
+          <span class="badge status-${safeStatus}" data-field="status">${escapeHtml(s.status + inferredHint)}</span>
+          <span class="badge" data-field="source">${escapeHtml(sourceLabel)}</span>
+          ${s.host ? `<span class="badge" data-field="host" title="Machine this session is running on">${escapeHtml(s.host)}</span>` : ''}
+          <span class="badge" data-field="routing">${escapeHtml(routingLabel(s.routing))}</span>
+          <span class="badge" data-field="cost">$${(s.total_dollars || 0).toFixed(4)}</span>
+          <span class="badge" data-field="tokens">${s.total_input_tokens || 0}↓ / ${s.total_output_tokens || 0}↑</span>
+          <span data-field="depth">${s.spawn_depth ? `<span class="badge">depth ${s.spawn_depth}</span>` : ''}</span>
+        </div>
+        ${s.prompt_preview ? `<div class="prompt-preview-hint" data-field="prompt-preview-hint" style="font-size:0.7rem;color:var(--text-dim);margin-top:0.15rem;word-break:break-word">“${escapeHtml(s.prompt_preview)}”</div>` : ''}
+      </div>
+      <div class="session-summary loading" data-field="session-summary">
+        <div class="ss-label">Summary</div>
+        <div class="ss-short" data-field="ss-short">${escapeHtml(s.short_label || '')}</div>
+        <div class="ss-body" data-field="ss-body">Summarizing…</div>
+      </div>
+      <div class="events" data-field="events"></div>
+    `;
+    root.querySelector('[data-action="close"]').onclick = () => this.close();
+    const labelEl = root.querySelector('[data-field="label"]');
+    if (labelEl) labelEl.onclick = () => this._startLabelEdit(s);
+    if (showKill) root.querySelector('[data-action="kill"]').onclick = () => this.openKillModal(s);
+    if (showResume) root.querySelector('[data-action="resume"]').onclick = () => this._resumeSession(s);
+    if (showGoTo) root.querySelector('[data-action="focus"]').onclick = () => this._focusSession(s);
+  }
+
+  async _focusSession(s) {
+    const btn = this.container.querySelector('[data-action="focus"]');
+    if (btn) { btn.disabled = true; btn.textContent = 'Locating…'; }
+    try {
+      const r = await fetch(`/api/agents/sessions/${encodeURIComponent(s.session_id)}/focus`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+      });
+      if (!r.ok) {
+        const text = await r.text();
+        let msg = text;
+        try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) {}
+        if (r.status === 404) {
+          showToast(`Couldn't locate pane — session not running, wezterm unreachable, or SessionStart hook not installed.`, true);
+        } else if (r.status === 410) {
+          showToast(`Pane no longer exists. Click Resume to open a new one.`, true);
+        } else {
+          showToast(`Go To failed: ${msg}`, true);
+        }
+        return;
+      }
+      showToast(`Pane selected in wezterm. Click the wezterm dock icon to bring it forward.`, false);
+    } catch (err) {
+      showToast(`Go To failed: ${err.message}`, true);
+    } finally {
+      setTimeout(() => { if (btn) { btn.disabled = false; btn.textContent = 'Go To'; } }, 1500);
+    }
+  }
+
+  async _resumeSession(s) {
+    const btn = this.container.querySelector('[data-action="resume"]');
+    if (btn) { btn.disabled = true; btn.textContent = 'Resuming…'; }
+    try {
+      const r = await fetch(`/api/agents/sessions/${encodeURIComponent(s.session_id)}/resume`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}),
+      });
+      if (!r.ok) {
+        const text = await r.text();
+        let msg = text;
+        try { const j = JSON.parse(text); msg = j.detail || msg; } catch (_) {}
+        throw new Error(`HTTP ${r.status}: ${msg}`);
+      }
+      const result = await r.json();
+      let copied = !!result.clipboard_copied;
+      if (!copied && result.inner_command && navigator.clipboard && navigator.clipboard.writeText) {
+        try { await navigator.clipboard.writeText(result.inner_command); copied = true; } catch (_) {}
+      }
+      if (result.pane_id != null) {
+        showToast(`Wezterm tab opened (pane ${result.pane_id}). Focus button will return here.`, false);
+      } else if (copied) {
+        showToast(`Tab opened. Resume command copied to clipboard — paste it.`, false);
+      } else if (result.inner_command) {
+        showToast(`Tab opened. Run: ${result.inner_command}`, false);
+      } else {
+        showToast(`Spawned (pid ${result.pid}) in ${result.cwd}`, false);
+      }
+    } catch (err) {
+      showToast(`Resume failed: ${err.message}`, true);
+    } finally {
+      setTimeout(() => { if (btn) { btn.disabled = false; btn.textContent = 'Resume'; } }, 4000);
+    }
+  }
+
+  openKillModal(session) {
+    const descendants = (this.getDescendants(session) || []).filter(d => !TERMINAL.has(d.status));
+    const backdrop = document.createElement('div');
+    backdrop.className = 'modal-backdrop';
+    backdrop.innerHTML = `
+      <div class="modal" role="dialog" aria-labelledby="kill-title">
+        <h2 id="kill-title">Kill agent session?</h2>
+        <div class="target">${escapeHtml(session.label || session.session_id)}</div>
+        ${descendants.length > 0 ? `
+          <div class="descendants">
+            Will also kill ${descendants.length} descendant${descendants.length === 1 ? '' : 's'}:
+            ${descendants.slice(0, 5).map(d => `<div>• ${escapeHtml(d.label || d.session_id)}</div>`).join('')}
+            ${descendants.length > 5 ? `<div>…and ${descendants.length - 5} more</div>` : ''}
+          </div>
+        ` : ''}
+        <label style="font-size:0.75rem;color:var(--text-secondary)">Reason (optional)</label>
+        <textarea id="kill-reason" placeholder="Why are you killing this?"></textarea>
+        <div class="actions">
+          <button id="kill-cancel">Cancel</button>
+          <button class="danger" id="kill-confirm">Kill</button>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(backdrop);
+    const cleanup = () => { if (backdrop.parentNode) backdrop.parentNode.removeChild(backdrop); };
+    backdrop.addEventListener('click', e => { if (e.target === backdrop) cleanup(); });
+    backdrop.querySelector('#kill-cancel').onclick = cleanup;
+    backdrop.querySelector('#kill-confirm').onclick = async () => {
+      const reason = backdrop.querySelector('#kill-reason').value || '';
+      const confirmBtn = backdrop.querySelector('#kill-confirm');
+      confirmBtn.disabled = true;
+      confirmBtn.textContent = 'Killing…';
+      try {
+        const r = await fetch(`/api/agents/sessions/${encodeURIComponent(session.session_id)}/kill`, {
+          method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ reason }),
+        });
+        if (!r.ok) {
+          const text = await r.text();
+          throw new Error(`HTTP ${r.status}: ${text}`);
+        }
+        const result = await r.json();
+        const failures = result.failures || [];
+        const killed = result.killed || [];
+        if (killed.length === 0 && result.reason) {
+          showToast(`Already ${result.reason}`, false);
+        } else if (failures.length === 0) {
+          showToast(`Killed ${killed.length} session${killed.length === 1 ? '' : 's'}`, false);
+        } else {
+          showToast(`Killed ${killed.length}; ${failures.length} remote failure(s)`, true);
+        }
+        cleanup();
+      } catch (err) {
+        showToast(`Kill failed: ${err.message}`, true);
+        confirmBtn.disabled = false;
+        confirmBtn.textContent = 'Kill';
+      }
+    };
+  }
+
+  _startLabelEdit(s) {
+    const root = this.container;
+    const labelEl = root.querySelector('[data-field="label"]');
+    if (!labelEl || labelEl.querySelector('#label-edit-input')) return;
+    const current = s.custom_label || s.label || '';
+    const input = document.createElement('input');
+    input.id = 'label-edit-input';
+    input.type = 'text';
+    input.maxLength = 120;
+    input.value = current;
+    input.style.cssText =
+      'width:100%;box-sizing:border-box;font:inherit;font-weight:600;' +
+      'color:var(--text-primary,#fff);background:var(--bg-elev);' +
+      'border:1px solid var(--accent);border-radius:4px;padding:2px 6px';
+    labelEl.textContent = '';
+    labelEl.appendChild(input);
+    input.focus();
+    input.select();
+
+    let done = false;
+    const finish = (save) => {
+      if (done) return;
+      done = true;
+      if (save) this._saveLabelEdit(s, input.value);
+      else labelEl.textContent = s.custom_label || s.label || s.session_id;
+    };
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); finish(true); }
+      else if (e.key === 'Escape') { e.preventDefault(); finish(false); }
+    });
+    input.addEventListener('blur', () => finish(true));
+  }
+
+  async _saveLabelEdit(s, rawValue) {
+    const root = this.container;
+    const labelEl = root.querySelector('[data-field="label"]');
+    const fallback = () => { if (labelEl) labelEl.textContent = s.custom_label || s.label || s.session_id; };
+    try {
+      const r = await fetch(`/api/agents/sessions/${encodeURIComponent(s.session_id)}/label`, {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: (rawValue || '').trim() }),
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const data = await r.json();
+      const custom = data.custom_label || null;
+      s.custom_label = custom;
+      if (labelEl) labelEl.textContent = custom || s.label || s.session_id;
+      this.onLabelSaved(s.session_id, custom);
+    } catch (err) {
+      console.warn('label save failed', err);
+      fallback();
+    }
+  }
+
+  async _fetchSummary(sessionId) {
+    if (this.summaryAbort) this.summaryAbort.abort();
+    const ac = new AbortController();
+    this.summaryAbort = ac;
+    const timeoutId = setTimeout(() => ac.abort(), 5 * 60 * 1000);
+    try {
+      const r = await fetch(`/api/agents/sessions/${encodeURIComponent(sessionId)}/summary`, { signal: ac.signal });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const data = await r.json();
+      if (sessionId !== this.sessionId) return;
+      const wrap = this.container.querySelector('[data-field="session-summary"]');
+      if (!wrap) return;
+      wrap.classList.remove('loading');
+      const shortEl = wrap.querySelector('[data-field="ss-short"]');
+      const bodyEl = wrap.querySelector('[data-field="ss-body"]');
+      if (shortEl) shortEl.textContent = data.short_label || '';
+      if (bodyEl) bodyEl.innerHTML = renderSummaryBody(data.summary || '');
+      if (data.short_label) {
+        if (this.session) this.session.short_label = data.short_label;
+        this.onSummaryFetched(sessionId, data.short_label);
+      }
+    } catch (err) {
+      if (sessionId !== this.sessionId) return;
+      const bodyEl = this.container.querySelector('[data-field="session-summary"] [data-field="ss-body"]');
+      if (!bodyEl) return;
+      const friendly = err.name === 'AbortError'
+        ? 'Timed out — Gemma may be busy.'
+        : `Summary unavailable: ${err.message}.`;
+      bodyEl.innerHTML = `${escapeHtml(friendly)} <a href="#" data-action="retry-summary" style="color:var(--accent)">Retry</a>`;
+      const retry = bodyEl.querySelector('[data-action="retry-summary"]');
+      if (retry) {
+        retry.addEventListener('click', e => {
+          e.preventDefault();
+          bodyEl.textContent = 'Summarizing…';
+          this.container.querySelector('[data-field="session-summary"]')?.classList.add('loading');
+          this._fetchSummary(sessionId);
+        });
+      }
+    } finally {
+      clearTimeout(timeoutId);
+      if (this.summaryAbort === ac) this.summaryAbort = null;
+    }
+  }
+
+  _loadEvents(sessionId, attempt) {
+    fetch(`/api/agents/sessions/${encodeURIComponent(sessionId)}/events?limit=200`)
+      .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
+      .then(payload => {
+        if (sessionId !== this.sessionId) return;
+        const events = payload.events || [];
+        if (events.some(ev => (ev.kind || '') === 'user_message')) {
+          this.eventKindFilter = 'user_message';
+        }
+        const container = this.container.querySelector('[data-field="events"]');
+        if (container) container.innerHTML = '';
+        events.forEach(ev => this._appendEvent(ev, false));
+        this._applyEventFilter();
+        const es = new EventSource(`/api/agents/sessions/${encodeURIComponent(sessionId)}/stream?backfill=0`);
+        this.transcriptES = es;
+        es.addEventListener('transcript_event', e => {
+          try { this._appendEvent(JSON.parse(e.data), true); } catch (_) {}
+        });
+        es.addEventListener('closed', () => { es.close(); });
+        es.onerror = () => {};  // browser auto-retries
+      })
+      .catch(err => {
+        if (sessionId !== this.sessionId) return;
+        const container = this.container.querySelector('[data-field="events"]');
+        if (!container) return;
+        if (attempt < _EVENTS_RETRY_DELAYS.length) {
+          container.innerHTML = '<div class="event">Loading events… (reconnecting)</div>';
+          setTimeout(() => {
+            if (sessionId === this.sessionId) this._loadEvents(sessionId, attempt + 1);
+          }, _EVENTS_RETRY_DELAYS[attempt]);
+        } else {
+          container.innerHTML = `<div class="event">Failed to load events: ${escapeHtml(String(err))} <a href="#" data-action="retry-events" style="color:var(--accent)">Retry</a></div>`;
+          const retry = container.querySelector('[data-action="retry-events"]');
+          if (retry) retry.addEventListener('click', ev => {
+            ev.preventDefault();
+            container.innerHTML = '<div class="event">Loading events…</div>';
+            this._loadEvents(sessionId, 0);
+          });
+        }
+      });
+  }
+
+  _appendEvent(ev, _live) {
+    const container = this.container.querySelector('[data-field="events"]');
+    if (!container) return;
+    const kind = String(ev.kind || '');
+    const ts = formatTs(ev.ts);
+    const payload = ev.payload || null;
+    const prettyHtml = payload ? prettyPayload(payload) : '';
+    const rawJson = payload ? JSON.stringify(payload, null, 2) : '';
+    const div = document.createElement('div');
+    div.classList.add('event');
+    if (kind) {
+      const safeKind = kind.replace(/[^a-zA-Z0-9_-]/g, '_');
+      div.classList.add(`kind-${safeKind}`);
+      div.dataset.kind = kind;
+    }
+    div.innerHTML = `
+      <div><span class="kind" role="button" tabindex="0" title="Click to filter to this event type">${escapeHtml(kind)}</span><span class="ts">${escapeHtml(ts)}</span></div>
+      ${prettyHtml ? `<div class="payload" title="Click to expand">${prettyHtml}</div>` : ''}
+      ${rawJson ? `<pre class="payload-raw">${escapeHtml(rawJson)}</pre>` : ''}
+    `;
+    if (this.eventKindFilter && kind !== this.eventKindFilter) {
+      div.style.display = 'none';
+    }
+    const kindEl = div.querySelector('.kind');
+    if (kindEl && kind) {
+      kindEl.addEventListener('click', e => { e.stopPropagation(); this._toggleKindFilter(kind); });
+      kindEl.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this._toggleKindFilter(kind); }
+      });
+    }
+    div.addEventListener('click', e => {
+      if (e.target.closest('.kind')) return;
+      div.classList.toggle('expanded');
+    });
+    container.prepend(div);
+  }
+
+  _toggleKindFilter(kind) {
+    this.eventKindFilter = (this.eventKindFilter === kind) ? null : kind;
+    this._applyEventFilter();
+  }
+
+  _applyEventFilter() {
+    const container = this.container.querySelector('[data-field="events"]');
+    if (!container) return;
+    container.querySelectorAll('.event').forEach(el => {
+      const k = el.dataset.kind;
+      el.style.display = (!this.eventKindFilter || k === this.eventKindFilter) ? '' : 'none';
+    });
+    container.querySelectorAll('.kind').forEach(el => {
+      const k = el.parentElement?.parentElement?.dataset?.kind;
+      el.classList.toggle('kind-active-filter', !!(this.eventKindFilter && k === this.eventKindFilter));
+    });
+  }
+}

--- a/web/chat/conversations.js
+++ b/web/chat/conversations.js
@@ -193,7 +193,11 @@ export async function loadConversation(id) {
   stopPendingQuestionPolling();
 
   try {
-    const response = await fetch(`${endpoints.conversations}/${id}`);
+    // (round 1, finding #5) encodeURIComponent — `id` can arrive from the
+    // `?conversation=` deep link (main.js's maybeOpenDeepLinkedConversation),
+    // an unencoded URL query param, same as every other conversation-id
+    // fetch site (ask-stream.js, pending-question.js).
+    const response = await fetch(`${endpoints.conversations}/${encodeURIComponent(id)}`);
     if (response.ok) {
       const data = await response.json();
       elements.chatTitle.textContent = data.title || 'Conversation';

--- a/web/chat/main.js
+++ b/web/chat/main.js
@@ -72,10 +72,35 @@ export function initChat({ elements: els, endpoints: eps, hooks: hks } = {}) {
   // can look identical before and after (e.g. the lifeos default matches
   // index.html's initial markup).
   window.lifeChat.backendReady = initBackend(personasReady);
+  // (#851) A deep link naming a conversation — e.g. the board's "open" on
+  // a Hermes card, `/chat?conversation=<id>` — opens that thread once the
+  // backend restore above has settled, so it wins over whatever
+  // per-backend conversation initBackend() itself restored from
+  // sessionStorage. loadConversation() only needs `endpoints.conversations`
+  // (already set by the Object.assign calls above), not the resolved
+  // backend, but waiting on backendReady keeps this deterministic instead
+  // of racing initBackend()'s own restore. Purely additive: no `conversation`
+  // param leaves every existing boot path (including the plain `?mode=`/
+  // `?record=` deep links voice.js reads) byte-identical, and this never
+  // touches the SSE contract those params gate.
+  window.lifeChat.backendReady.then(() => { maybeOpenDeepLinkedConversation(); });
   initModel();  // restore the per-turn model picker (Auto/Sonnet/Opus/Gemma)
   initVoice();  // restore Voice|Text mode + wire the hold-to-talk dock (#361)
   setStatus('', 'Ready');
   inputField.focus();
+}
+
+// (#851) `?conversation=<id>` deep link — see initChat()'s call site above
+// for why this runs after backendReady rather than synchronously.
+function maybeOpenDeepLinkedConversation() {
+  let id = null;
+  try {
+    id = new URLSearchParams(window.location.search).get('conversation');
+  } catch (e) {
+    return;  // no URLSearchParams / blocked — same guard voice.js uses
+  }
+  if (!id) return;
+  loadConversation(id);
 }
 
 // --- Bridge for the classic shell script + inline handlers ---

--- a/web/crm.html
+++ b/web/crm.html
@@ -42,6 +42,31 @@
             touch-action: manipulation;
         }
 
+        * {
+            scrollbar-width: thin;
+            scrollbar-color: var(--border) transparent;
+        }
+
+        *::-webkit-scrollbar {
+            width: 10px;
+            height: 10px;
+        }
+
+        *::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        *::-webkit-scrollbar-thumb {
+            background-color: var(--border);
+            border-radius: 6px;
+            border: 2px solid transparent;
+            background-clip: padding-box;
+        }
+
+        *::-webkit-scrollbar-thumb:hover {
+            background-color: var(--text-muted);
+        }
+
         html, body {
             height: 100%;
             overflow: hidden;
@@ -4634,8 +4659,6 @@
             gap: 1rem;
             overflow-x: auto;
             padding: 0.5rem 0 1rem;
-            scrollbar-width: thin;
-            scrollbar-color: var(--border) transparent;
             margin-bottom: 1.5rem;
         }
 

--- a/web/home.html
+++ b/web/home.html
@@ -28,6 +28,31 @@
             --border: #2a2a3a;
         }
 
+        * {
+            scrollbar-width: thin;
+            scrollbar-color: var(--border) transparent;
+        }
+
+        *::-webkit-scrollbar {
+            width: 10px;
+            height: 10px;
+        }
+
+        *::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        *::-webkit-scrollbar-thumb {
+            background-color: var(--border);
+            border-radius: 6px;
+            border: 2px solid transparent;
+            background-clip: padding-box;
+        }
+
+        *::-webkit-scrollbar-thumb:hover {
+            background-color: var(--text-secondary);
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             background: var(--bg-primary);

--- a/web/index.html
+++ b/web/index.html
@@ -45,6 +45,31 @@
             touch-action: manipulation;  /* Disable iOS double-tap delay globally */
         }
 
+        * {
+            scrollbar-width: thin;
+            scrollbar-color: var(--border) transparent;
+        }
+
+        *::-webkit-scrollbar {
+            width: 10px;
+            height: 10px;
+        }
+
+        *::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        *::-webkit-scrollbar-thumb {
+            background-color: var(--border);
+            border-radius: 6px;
+            border: 2px solid transparent;
+            background-clip: padding-box;
+        }
+
+        *::-webkit-scrollbar-thumb:hover {
+            background-color: var(--text-muted);
+        }
+
         html, body {
             height: 100vh;   /* fallback for browsers without dvh */
             height: 100dvh;  /* track the mobile browser's dynamic chrome (address bar / keyboard) so the composer stays reachable */

--- a/web/journal-trends.html
+++ b/web/journal-trends.html
@@ -24,6 +24,31 @@
             --warn: #a855f7;
         }
 
+        * {
+            scrollbar-width: thin;
+            scrollbar-color: var(--border) transparent;
+        }
+
+        *::-webkit-scrollbar {
+            width: 10px;
+            height: 10px;
+        }
+
+        *::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        *::-webkit-scrollbar-thumb {
+            background-color: var(--border);
+            border-radius: 6px;
+            border: 2px solid transparent;
+            background-clip: padding-box;
+        }
+
+        *::-webkit-scrollbar-thumb:hover {
+            background-color: var(--text-secondary);
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             background: var(--bg-primary);

--- a/web/journal.html
+++ b/web/journal.html
@@ -23,6 +23,31 @@
             --border: #2a2a3a;
         }
 
+        * {
+            scrollbar-width: thin;
+            scrollbar-color: var(--border) transparent;
+        }
+
+        *::-webkit-scrollbar {
+            width: 10px;
+            height: 10px;
+        }
+
+        *::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        *::-webkit-scrollbar-thumb {
+            background-color: var(--border);
+            border-radius: 6px;
+            border: 2px solid transparent;
+            background-clip: padding-box;
+        }
+
+        *::-webkit-scrollbar-thumb:hover {
+            background-color: var(--text-secondary);
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             background: var(--bg-primary);


### PR DESCRIPTION
## TL;DR

Brings `main`'s Kanban board overhaul for `/agents` (task-store rewrite, cross-machine CLI session registration, card assignment, human-queue tool) and the CRM scrollbar-standardization styling into the CRM performance milestone branch. No behavior of either side was changed — this is purely reconciling two branches that diverged after the milestone forked, via a merge commit (not a rebase).


## Design

Merged `origin/main` (tip 87bc8dc, "style(web): standardize scrollbar design across all pages", #888) into `feat/crm-performance` (tip 4be34b9, the CRM performance milestone) with `git merge`, producing a merge commit with both branches as parents. No commits were rewritten and no force-push was used.

## Implementation Notes

Seven files had textual merge conflicts, all resolved by keeping both sides' additions:

- **`AGENTS.md`, `docs/guides/configuration.md`, `docs/guides/operations.md`, `docs/specs/product/mcp-tools.md`, `docs/specs/technical/architecture.md`** — pure "Last Updated" date races (both sides bumped the same line on the same day). Resolved to today's date; the rest of each diff was non-overlapping and auto-merged cleanly.
- **`docs/specs/product/api-reference.md`** — same date race, plus a second conflict in the Related Documents list where both sides added a different link (main's `agent-viz.md` link and the milestone's `observability.md#route-timing` link to the same section). Kept both lines.
- **`api/main.py`** — the only functional conflict, confined to the router-import line. Main added `agent_assignment` to the `api.routes` import (and its `app.include_router(agent_assignment.router)` call, which sat in an untouched region and auto-merged). The milestone added `route_timing`/`install_query_string_redaction_filter` imports. Resolved by combining all three into one import block; middleware order (CORS → scoped gzip → `RouteTimingMiddleware` outermost) was untouched by main and verified unchanged after the merge.

Everything else (`.env.example`, `config/settings.py`, `docs/specs/technical/client-surfaces.md`, `mcp_server.py`, `web/crm.html`, and ~100 other files from main's Kanban work) auto-merged with no conflict markers. Verified by comparing line counts of base/each-side/merged for every auto-merged file the task called out — each merged file's line count equals base + main's delta + milestone's delta exactly, confirming no hunk was silently dropped. For `web/crm.html` specifically: main's change was the global `*`-selector scrollbar CSS rule plus removal of one now-redundant localized `scrollbar-width`/`scrollbar-color` declaration; both landed, and only one `scrollbar-width: thin` declaration exists in the merged file (the global rule).

**Semantic-conflict check (no textual conflict, but same subsystem):** grepped for anything in main's diff touching CRM/people/photos route handlers, the interaction store, or the perf router. Main's diff never touches `api/routes/crm.py`, `api/routes/people.py`, `api/routes/photos.py`, `api/services/perf_trace.py`, or `api/routes/perf.py` — its work (task manager, agent board, human queue, agent-worker assignment/remote-spawn/model-catalog) is entirely disjoint from the milestone's CRM/perf work. `api/services/agent_tools.py`, `api/services/task_manager.py`, `api/routes/tasks.py` were all main-only changes (milestone never touched them), so no risk of silently overwriting either side's logic in those files either.

## Test evidence

### Automated tests

Static guards (milestone's #868 regression guard, scoped to crm/people/photos routers — none of which main touched):
```
$ HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" ~/.venvs/lifeos/bin/pytest tests/test_route_handlers_sync.py tests/test_route_handlers_no_shared_connections.py tests/test_route_handlers_mutation_lock.py tests/test_route_handlers_concurrency.py -q
17 passed in 5.52s
```

CRM test files:
```
$ ...pytest tests/test_crm_api.py tests/test_crm_data_integrity.py tests/test_crm_network_graph_selection.py tests/test_crm_people_list_batching.py tests/test_crm_request_hygiene_api.py tests/test_crm_ui_requirements.py -q -n 4 --dist loadscope
112 passed, 8 skipped in 21.71s
```

Every agents/tasks/human-queue test file main added or changed:
```
$ ...pytest tests/test_agent_board.py tests/test_agent_cli_session_events.py tests/test_agent_cli_session_task_link.py tests/test_agent_cli_sessions_snapshot.py tests/test_agent_kill_remote.py tests/test_agent_resume_remote.py tests/test_agent_system_prompt.py tests/test_agent_tools_human_queue.py tests/test_agent_tools_tasks.py -q -n 4 --dist loadscope
209 passed in 15.23s

$ ...pytest tests/test_agent_worker_assignment.py tests/test_agent_worker_claude_code_assignment.py tests/test_agent_worker_codex_assignment.py tests/test_agent_worker_dispatch_assignment.py tests/test_agent_worker_hermes_executor.py tests/test_agent_worker_human_queue.py tests/test_agent_worker_local_executor_thinking.py tests/test_agent_worker_loop.py tests/test_agent_worker_model_catalog.py tests/test_agent_worker_preflight_assignment.py tests/test_agent_worker_remote_spawn.py -q -n 4 --dist loadscope
167 passed in 14.99s

$ ...pytest tests/test_atomic_write.py tests/test_human_queue.py tests/test_human_queue_api.py tests/test_human_queue_sync.py tests/test_install_agent_hooks.py tests/test_lifeos_agent_hook.py tests/test_mcp_human_queue.py tests/test_settings.py tests/test_task_manager.py tests/test_task_watcher.py tests/test_tasks_api.py tests/test_workout_mcp_route.py tests/test_audit_e2e.py tests/test_agents_board_api.py tests/test_agents_board_open.py tests/test_agents_board_watch.py -q -n 4 --dist loadscope
517 passed in 37.87s
```

Full unit suite, under the shared push lock (matches the pre-push gate exactly):
```
$ flock -w 7200 /tmp/lifeos-push.lock ./scripts/test.sh
6389 passed, 8 skipped in 289.67s (0:04:49)
```

Server-free browser scope:
```
$ ...pytest tests/ -m "browser and not requires_server" -q -n 4 --dist loadscope
354 passed in 110.16s (0:01:50)
```

The pre-push hook re-ran both of the above during the actual push and got matching counts (6389 passed / 8 skipped; 354 passed).

### Manual verification

Started a private staging instance (`uvicorn` via the isolated-worktree launcher, port 8114) against the disposable staging data copy, and drove it with Playwright, checking console errors after every navigation:

- `/me`, `/family`, `/birthdays`, `/relationship` — fresh full-page loads: 0 console errors each.
- A person overview page (`/crm/{id}`), then its Timeline and Graph tabs (via `switchTab()`) — 0 console errors, including after a 1.5-2s wait for async data.
- Client-side nav: clicked the sidebar `<a data-page="...">` links between Me → Family → Birthdays → Relationship → Me (the actual `navigateTo()` click path, not just `history.pushState`) — 0 console errors on every hop.
- Back/forward: two `goBack()` calls then a `history.forward()` — 0 console errors.
- `/agents` (main's Kanban board) — 0 console errors, 0 warnings, board container present in the DOM after load.
- Confirmed the scrollbar styling from #888 is live: `getComputedStyle(document.documentElement).scrollbarWidth === "thin"` on `/me`.

(One caveat: `browser_console_messages` with `all: true` surfaced 140 pre-existing SVG `NaN`-attribute errors that persisted identically across every page I visited in this session — these did not reproduce under any single fresh navigation check (which reports only new errors since the last full page load) even when directly targeting the Graph tab and the Relationship page's own visualizations twice each with a wait for async render. This looks like carried-over console history from a different tab/session sharing the same Playwright browser process (this host has many agents active concurrently), not something this merge introduced — flagging for the reviewer to double-check if they see the same thing.)

## Review focus

- The `api/main.py` import-line resolution (combining `route_timing`/`install_query_string_redaction_filter` with `agent_assignment`) — the only hand-resolved functional conflict in this merge.
- The "140 stale NaN console errors" caveat above — I'm confident it's not a regression (every direct repro came back clean) but a second pair of eyes on the Graph/heatmap components under `/relationship` and a person's Graph tab wouldn't hurt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
