### PR TITLE
test: skip config-dependent tests without personal config, use a proportional link ceiling

### DIFF
--- a/tests/test_entity_resolver.py
+++ b/tests/test_entity_resolver.py
@@ -200,6 +200,12 @@ class TestResolveByName:
         a clean checkout, it falls through to the generic "Work/" branch —
         so this needs a real configured settings.current_work_path.
         """
+        from config.settings import settings
+        if settings.current_work_path in ("", "Work/"):
+            pytest.skip(
+                "settings.current_work_path not configured beyond the generic default "
+                "(LIFEOS_CURRENT_WORK_PATH missing from .env)"
+            )
         # Use Work/ML path which is a known context pattern
         result = populated_resolver.resolve_by_name(
             "New Colleague",

--- a/tests/test_me_page.py
+++ b/tests/test_me_page.py
@@ -275,6 +275,8 @@ class TestMyPersonIdConstant:
     def test_my_person_id_is_valid_uuid(self):
         """MY_PERSON_ID should be a valid UUID string. Needs a real configured
         settings.my_person_id — empty (not a UUID) in a clean checkout."""
+        if not MY_PERSON_ID:
+            pytest.skip("settings.my_person_id not configured (LIFEOS_MY_PERSON_ID missing from .env)")
         import uuid
         # Should not raise
         uuid.UUID(MY_PERSON_ID)

--- a/tests/test_p91_data_integrity.py
+++ b/tests/test_p91_data_integrity.py
@@ -9,6 +9,7 @@ Tests must pass before P9.1 can be considered complete.
 NOTE: These tests require direct database access and will be skipped if
 the server is running (database locked). Stop the server to run these tests.
 """
+import math
 import os
 import re
 import sqlite3
@@ -87,19 +88,32 @@ class TestR1CleanDatabase:
 class TestR2EntityResolution:
     """R2: Correct Entity Resolution - People must actually be mentioned in linked notes."""
 
-    # Known unverifiable links, as of the last audit. These are not necessarily
-    # wrong: Granola rewrites note bodies after indexing, so an interaction
-    # created when a name was present can outlive the text that justified it.
-    # The point of the ceiling is to catch *new* bad links without pretending
-    # the existing backlog is clean. Lower it when links are cleaned up.
-    #
-    # The remainder was audited individually: it is dominated by one close
-    # family member appearing across journal and therapy notes that discuss
-    # her without naming her. The links resolution actually got wrong — vault
-    # mentions attached to people whose name is an initial plus a surname,
-    # which matched any extracted name sharing that letter (#551) — were
-    # removed, along with two non-person entities parsed out of note text.
-    MAX_UNVERIFIABLE_LINKS = 28
+    # A vault interaction is unverifiable when its linked person's name isn't
+    # found in the note's text or declared frontmatter. Some unverifiable
+    # links are not necessarily wrong: Granola rewrites note bodies after
+    # indexing, so an interaction created when a name was present can outlive
+    # the text that justified it. The ceiling is expressed as a share of rows
+    # checked, not an absolute count, so it scales with the size of the vault
+    # rather than drifting out of date as the vault grows.
+    UNVERIFIABLE_CEILING_FRACTION = 0.015
+
+    @staticmethod
+    def _unverifiable_ceiling(checked: int) -> int:
+        """Maximum unverifiable links allowed for a given number of checked
+        rows: a fraction of checked rows, rounded up, with a floor of 1."""
+        return max(1, math.ceil(checked * TestR2EntityResolution.UNVERIFIABLE_CEILING_FRACTION))
+
+    @staticmethod
+    def _format_unverifiable_failure(checked: int, unverifiable_ids: list[str], ceiling: int) -> str:
+        """Failure message for the unverifiable-link ceiling: counts plus up
+        to ten offending interaction ids. Never includes names or note
+        content."""
+        return (
+            f"Vault links that cannot be traced to their note rose to "
+            f"{len(unverifiable_ids)} (ceiling {ceiling}) out of {checked} checked. "
+            f"New entity-resolution false positives are the likely cause.\n"
+            + "\n".join(f"  {iid}" for iid in unverifiable_ids[:10])
+        )
 
     @staticmethod
     def _declared_people(content: str) -> list[str]:
@@ -140,7 +154,7 @@ class TestR2EntityResolution:
         store = get_person_entity_store()
         conn = sqlite3.connect(get_interaction_db_path())
         rows = conn.execute("""
-            SELECT person_id, source_id, title FROM interactions
+            SELECT id, person_id, source_id FROM interactions
             WHERE source_type IN ('vault', 'granola')
             AND source_id LIKE '/%'
         """).fetchall()
@@ -150,10 +164,10 @@ class TestR2EntityResolution:
         valid_two_letter_names = {'ed', 'al', 'jo', 'bo', 'ty', 'lu', 'li', 'an'}
 
         content_cache: dict[str, str] = {}
-        unverifiable = []
+        unverifiable_ids: list[str] = []
         checked = 0
 
-        for person_id, source_id, title in rows:
+        for interaction_id, person_id, source_id in rows:
             if not os.path.exists(source_id):
                 continue
             person = store.get_by_id(person_id)
@@ -198,22 +212,13 @@ class TestR2EntityResolution:
             ):
                 continue
 
-            unverifiable.append({
-                'person': person.canonical_name,
-                'file': source_id,
-                'title': title,
-            })
+            unverifiable_ids.append(interaction_id)
 
         assert checked > 0, "No vault interactions found to verify"
 
-        assert len(unverifiable) <= self.MAX_UNVERIFIABLE_LINKS, (
-            f"Vault links that cannot be traced to their note rose to "
-            f"{len(unverifiable)} (ceiling {self.MAX_UNVERIFIABLE_LINKS}) "
-            f"out of {checked} checked. New entity-resolution false positives "
-            f"are the likely cause.\n"
-            + "\n".join(
-                f"  {fp['person']} <- {fp['file']}" for fp in unverifiable[:5]
-            )
+        ceiling = self._unverifiable_ceiling(checked)
+        assert len(unverifiable_ids) <= ceiling, (
+            self._format_unverifiable_failure(checked, unverifiable_ids, ceiling)
         )
 
 class TestR3VaultLinks:

--- a/tests/test_vault_link_ceiling.py
+++ b/tests/test_vault_link_ceiling.py
@@ -1,0 +1,42 @@
+"""
+Unit tests for the vault-interaction unverifiable-link ceiling arithmetic
+and failure-message formatting used by test_p91_data_integrity.py.
+"""
+import pytest
+
+from tests.test_p91_data_integrity import TestR2EntityResolution as _R2
+
+pytestmark = pytest.mark.unit
+
+
+class TestUnverifiableCeilingArithmetic:
+    """Tests for the proportional ceiling computation."""
+
+    def test_ceiling_rounds_up(self):
+        """Ceiling is a fraction of checked rows, rounded up to the next integer."""
+        assert _R2._unverifiable_ceiling(100) == 2  # 1.5 -> 2
+        assert _R2._unverifiable_ceiling(101) == 2  # 1.515 -> 2
+        assert _R2._unverifiable_ceiling(67) == 2  # 1.005 -> 2
+
+    def test_ceiling_has_a_floor_of_one(self):
+        """Ceiling never drops below 1, even for a small number of checked rows."""
+        assert _R2._unverifiable_ceiling(1) == 1
+        assert _R2._unverifiable_ceiling(10) == 1
+
+
+class TestUnverifiableFailureMessage:
+    """Tests for the failure message shown when the ceiling is exceeded."""
+
+    def test_message_includes_counts_and_ceiling(self):
+        """Message names the checked count, unverifiable count, and ceiling."""
+        message = _R2._format_unverifiable_failure(100, ["a", "b", "c"], 2)
+        assert "3 (ceiling 2) out of 100 checked" in message
+
+    def test_message_lists_up_to_ten_ids_and_nothing_else(self):
+        """Message lists at most ten offending ids and includes no other detail."""
+        ids = [f"interaction-{i}" for i in range(15)]
+        message = _R2._format_unverifiable_failure(100, ids, 2)
+        for iid in ids[:10]:
+            assert iid in message
+        for iid in ids[10:]:
+            assert iid not in message


### PR DESCRIPTION
## TL;DR

Two tests that depend on the operator's personal configuration now skip with a clear reason instead of failing on a checkout that lacks it, and the vault-interaction link-quality test now scales its failure threshold with how much data it checked instead of using a fixed count.

Closes #921
Closes #922

## Design

- `tests/test_me_page.py::TestMyPersonIdConstant::test_my_person_id_is_valid_uuid` skips when `MY_PERSON_ID` (sourced from `settings.my_person_id`, i.e. the operator's `.env`) is empty.
- `tests/test_entity_resolver.py::TestResolveByName::test_create_with_context_inference` skips when `settings.current_work_path` is still the generic default, which is the actual condition under which the assertion (a vault-context inferred from a `Work/ML/`-style path) cannot hold. Both mirror the existing `Path(...).exists()` skip-guard style used by the fixture-scan tests in `tests/test_config_structure.py`.
- `tests/test_p91_data_integrity.py::TestR2EntityResolution::test_vault_interactions_mention_linked_person` now asserts a ceiling of 1.5% of checked rows (rounded up, minimum 1) instead of a fixed count of 28, so the ceiling scales with vault size instead of drifting stale. The ceiling arithmetic and failure-message formatting are extracted into two static helpers, unit-tested separately in `tests/test_vault_link_ceiling.py`.

## Implementation Notes

- `tests/test_me_page.py`: added an `if not MY_PERSON_ID: pytest.skip(...)` guard before the UUID assertion.
- `tests/test_entity_resolver.py`: added a guard checking `settings.current_work_path in ("", "Work/")` before exercising `_infer_vault_contexts`.
- `tests/test_p91_data_integrity.py` (`TestR2EntityResolution`): replaced the `MAX_UNVERIFIABLE_LINKS = 28` constant with `UNVERIFIABLE_CEILING_FRACTION = 0.015` and two new static methods, `_unverifiable_ceiling(checked)` and `_format_unverifiable_failure(checked, unverifiable_ids, ceiling)`. The interactions query now selects `id` so the failure message can report interaction ids instead of person names, file paths, or note titles.
- `tests/test_vault_link_ceiling.py` (new file): unit tests for the two static helpers above, using a synthetic checked/unverifiable count — no database or personal data involved. Named to avoid the `tests/test_p91_*.py` `.gitignore` pattern that would otherwise hide it from `git status`.

## Test evidence

### Automated tests

Config-absent state (no `.env`, no `config/crm_mappings.yaml` in this worktree):
```
$ HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" pytest tests/test_me_page.py::TestMyPersonIdConstant::test_my_person_id_is_valid_uuid tests/test_entity_resolver.py::TestResolveByName::test_create_with_context_inference -rs -q
tests/test_me_page.py s
tests/test_entity_resolver.py s
SKIPPED [1] tests/test_me_page.py:282: settings.my_person_id not configured (LIFEOS_MY_PERSON_ID missing from .env)
SKIPPED [1] tests/test_entity_resolver.py:205: settings.current_work_path not configured beyond the generic default (LIFEOS_CURRENT_WORK_PATH missing from .env)
2 skipped in 0.90s
```

Config-present state (simulated via monkeypatched `MY_PERSON_ID` / `settings.current_work_path`, since copying the real `.env` breaks ~25 unrelated agent-worker tests per the environment brief):
```
2 passed, 1 warning in 0.58s
```

Real production/staging data (`data/` symlinked in, 3,086 vault/granola interactions checked, 30 unverifiable, ceiling 47):
```
$ HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" pytest tests/test_p91_data_integrity.py::TestR2EntityResolution::test_vault_interactions_mention_linked_person -q
1 passed in 6.68s
```

Unit tests for the ceiling arithmetic and message formatting:
```
$ HIP_VISIBLE_DEVICES="" ROCR_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" pytest tests/test_vault_link_ceiling.py -q
4 passed in 2.39s
```

All four touched/added test files together:
```
73 passed, 7 skipped in 16.66s
```

Full unit suite + server-free browser tests under the push lock (pre-push hook):
```
Running unit tests... passed (6394 passed, 8 skipped, 805 warnings in 256.11s)
Running server-free browser tests... passed (358 passed, 6789 deselected in 292.46s)
```

`tests/test_no_change_narration.py` does not exist on `origin/main` at this branch point, so it was not run per the task instructions.

### Manual verification

Not applicable — this PR only changes test files; there is no server-facing behavior to verify manually.

## Review focus

- `test_create_with_context_inference`'s skip guard checks `settings.current_work_path`, not `config/crm_mappings.yaml`. I traced `_infer_vault_contexts` in `api/services/entity_resolver.py`: the branch this test exercises (`if settings.current_work_path and settings.current_work_path in path_str`) never reads `crm_mappings.yaml` — that file only feeds `DOMAIN_CONTEXT_MAP`/`COMPANY_NORMALIZATION`, used by a different branch. Gating the skip on the file's existence would be an inaccurate proxy (it could skip needlessly, or fail to skip when it should), so I gated on the actual settings value instead. Worth a second look given the originating issue named `crm_mappings.yaml` specifically.
- `tests/test_vault_link_ceiling.py` imports `TestR2EntityResolution` from `test_p91_data_integrity.py` under an alias (`_R2`) specifically so pytest's default `Test*` class collection doesn't pick it up a second time in the new module — confirmed via `--collect-only` that no duplicate collection occurs.
- 1.5% is the value given in the task; at the current 3,086 checked rows this yields a ceiling of 47, well above today's 30 unverifiable rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
