### PR TITLE
test(merge-people): isolate the relationship store singleton in merge tests

### DIFF
--- a/api/services/relationship.py
+++ b/api/services/relationship.py
@@ -1054,3 +1054,10 @@ def get_relationship_store(db_path: Optional[str] = None) -> RelationshipStore:
             if _relationship_store is None:
                 _relationship_store = RelationshipStore(db_path)
     return _relationship_store
+
+
+def reset_relationship_store() -> None:
+    """Reset singleton (for testing)."""
+    global _relationship_store
+    with _relationship_store_lock:
+        _relationship_store = None

--- a/tests/test_merge_people.py
+++ b/tests/test_merge_people.py
@@ -19,6 +19,23 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(autouse=True)
+def reset_relationship_store_singleton():
+    """Clear the process-wide RelationshipStore singleton around each test.
+
+    scripts.merge_people reaches the store through
+    api.services.relationship.get_relationship_store(), a singleton keyed to
+    whichever db_path first constructs it. Without this reset, a test that
+    exercises the real singleton (rather than patching it) leaves it pointed
+    at its own temporary crm.db for the rest of the worker's tests.
+    """
+    from api.services.relationship import reset_relationship_store
+
+    reset_relationship_store()
+    yield
+    reset_relationship_store()
+
+
 class TestMergedIdsTracking:
     """Tests for merged ID persistence and chain following."""
 
@@ -382,7 +399,7 @@ class TestMergePeopleToneAnalysisResults:
         interactions_db_path = str(tmp_path / "interactions.db")
 
         person_store = PersonEntityStore(crm_db_path)
-        RelationshipStore(crm_db_path)  # table only -- no rows needed
+        rel_store = RelationshipStore(crm_db_path)  # table only -- no rows needed
         SourceEntityStore(crm_db_path)  # table only -- no rows needed
         fact_store = PersonFactStore(crm_db_path)
         tone_store = ToneAnalysisStore(crm_db_path)
@@ -420,6 +437,7 @@ class TestMergePeopleToneAnalysisResults:
         monkeypatch.setattr("scripts.merge_people.get_interaction_db_path", lambda: interactions_db_path)
         monkeypatch.setattr("scripts.merge_people.MERGED_IDS_FILE", tmp_path / "merged_ids.json")
         monkeypatch.setattr("scripts.merge_people.MERGE_LOG_FILE", tmp_path / "merge_log.json")
+        monkeypatch.setattr("api.services.relationship.get_relationship_store", lambda *a, **k: rel_store)
         # Post-merge side effects unrelated to tone_analysis_results cleanup --
         # stubbed rather than wired up for real to keep this fixture from
         # growing into a second copy of person_entity/interaction fixtures.
@@ -480,7 +498,7 @@ class TestMergePeopleToneAnalysisResults:
         interactions_db_path = str(tmp_path / "interactions.db")
 
         person_store = PersonEntityStore(crm_db_path)
-        RelationshipStore(crm_db_path)
+        rel_store = RelationshipStore(crm_db_path)
         SourceEntityStore(crm_db_path)
         PersonFactStore(crm_db_path)
         InteractionStore(interactions_db_path, strict=False)
@@ -494,6 +512,7 @@ class TestMergePeopleToneAnalysisResults:
         monkeypatch.setattr("scripts.merge_people.get_interaction_db_path", lambda: interactions_db_path)
         monkeypatch.setattr("scripts.merge_people.MERGED_IDS_FILE", tmp_path / "merged_ids.json")
         monkeypatch.setattr("scripts.merge_people.MERGE_LOG_FILE", tmp_path / "merge_log.json")
+        monkeypatch.setattr("api.services.relationship.get_relationship_store", lambda *a, **k: rel_store)
         monkeypatch.setattr("api.services.person_stats.refresh_person_stats", lambda *a, **k: {})
         monkeypatch.setattr("api.services.relationship_metrics.update_strength_for_person", lambda *a, **k: None)
 


### PR DESCRIPTION
## TL;DR

Merge-person tests that build their own temporary database now also point the merge script's relationship lookups at that same database, and the underlying singleton is cleared around every test in the file, so a temp directory cleaned up after an earlier test can no longer leave a later test looking at a path that no longer holds the `relationships` table.

Closes #938

## Design

`scripts/merge_people.py`'s dry-run relationship count goes through `api.services.relationship.get_relationship_store()`, a process-wide singleton guarded by a lock. `tests/test_merge_people.py::TestMergePeopleToneAnalysisResults`'s `merge_env`/`merge_env_without_tone_table` fixtures already build a `RelationshipStore` on their own temporary `crm.db` to create the table, but never told the merge script to use that instance — so the script fell through to the real singleton, which caches whichever `db_path` first constructed it for the rest of the worker process. When that test's `tmp_path` directory is later removed, SQLite silently recreates an empty file at the stale path on the next connection, and any query against it fails with `no such table: relationships`.

## Implementation Notes

- `api/services/relationship.py`: added `reset_relationship_store()`, mirroring `reset_perf_trace_store()` in `api/services/perf_trace.py` — clears the module-level `_relationship_store` singleton under `_relationship_store_lock`.
- `tests/test_merge_people.py`:
  - `merge_env` and `merge_env_without_tone_table` now capture the `RelationshipStore` they already construct on the fixture's temporary `crm.db` and `monkeypatch.setattr("api.services.relationship.get_relationship_store", lambda *a, **k: rel_store)`, so `scripts.merge_people.merge_people()`'s local `from api.services.relationship import get_relationship_store` resolves to that instance instead of the real singleton.
  - A new module-level `reset_relationship_store_singleton` autouse fixture calls `reset_relationship_store()` before and after every test in the file, so no test can leave the singleton pointed at a path another test in the module will use.

## Test evidence

### Automated tests

`tests/test_merge_people.py -n 4 --dist loadscope -p no:randomly`, 20 consecutive runs, all green:

```
run 1 (no:randomly): exit=0  ============================== 25 passed in 3.57s ==============================
run 2 (no:randomly): exit=0  ============================== 25 passed in 3.59s ==============================
...
run 20 (no:randomly): exit=0  ============================== 25 passed in 3.49s ==============================
```

Same command without `-p no:randomly` (this environment does not have `pytest-randomly` installed, so ordering is otherwise identical — recorded for completeness), 20 consecutive runs, all green:

```
run 1 (random): exit=0  ============================== 25 passed in 3.48s ==============================
...
run 20 (random): exit=0  ============================== 25 passed in 3.50s ==============================
```

Static guards, the narration guard, and the touched test file together:

```
$ pytest tests/test_anthropic_api_guard.py tests/test_server_host_guard.py tests/test_vault_root_check.py tests/test_env_isolation.py tests/test_no_change_narration.py tests/test_merge_people.py -n 4 --dist loadscope -q
============================== 57 passed in 7.08s ==============================
```

Tests exercising the touched service module directly:

```
$ pytest tests/test_relationship.py tests/test_relationship_discovery.py tests/test_relationship_metrics.py tests/test_relationship_summary.py -n 4 --dist loadscope -m "not browser and not requires_server" -q
============================== 101 passed in 8.71s ==============================
```

Full unit suite + server-free browser tests via the pre-push gate (ran automatically on push, under the shared lock):

```
Running unit tests... passed (========== 6424 passed, 9 skipped, 804 warnings in 189.93s (0:03:09) ===========)
Running server-free browser tests... passed (=============== 358 passed, 6820 deselected in 284.44s (0:04:44) ===============)
```

### Manual verification

Reproduced the pre-fix failure directly, matching the reported symptom exactly, before applying any code change (the fix's diff was set aside and the working tree reverted to origin/main for this step):

1. In-process, called `api.services.relationship.get_relationship_store(db_path)` with a temporary path — simulating some other test on the same xdist worker constructing the singleton first — then deleted the database file at that path while leaving its parent directory in place (simulating the directory surviving past the test's own `tmp_path` cleanup, as the issue describes).
2. Ran `TestMergePeopleToneAnalysisResults::test_dry_run_reports_the_count_without_deleting_anything` in that same process (same singleton).

Result before the fix:

```
E       sqlite3.OperationalError: no such table: relationships
api/services/relationship.py:590: OperationalError
=========================== short test summary info ============================
FAILED tests/test_merge_people.py::TestMergePeopleToneAnalysisResults::test_dry_run_reports_the_count_without_deleting_anything
============================== 1 failed in 0.83s ==============================
```

The fix's diff was then reapplied and the identical scenario (same poisoned singleton, same deleted file) was re-run in a fresh process:

```
tests/test_merge_people.py .                                             [100%]
============================== 1 passed in 0.77s ===============================
```

This proves the fixture's `get_relationship_store` patch (not just the autouse reset) is what makes the test immune to a poisoned singleton — the test never touches the real singleton in the first place.

## Review focus

- Whether patching `api.services.relationship.get_relationship_store` (rather than `scripts.merge_people.get_relationship_store`) is the right patch target: `scripts/merge_people.py` does `from api.services.relationship import get_relationship_store` *inside* the function body on every call, so the name is re-resolved from `api.services.relationship`'s own namespace each time rather than cached at module-import time — confirmed by the reproduction above passing.
- Whether the new autouse fixture's scope (this test module only, not the suite-wide `reset_lightweight_singletons()` in `tests/reset_singletons.py`) is the right blast radius, versus also wiring it in there for other modules that might construct the same singleton without patching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
