### PR TITLE
test(hooks): keep the prepush-gate log tests out of the browser auto-marker

### DIFF
--- a/tests/test_prepush_gate.py
+++ b/tests/test_prepush_gate.py
@@ -286,7 +286,7 @@ def test_log_paths_differ_by_branch(tmp_path):
 
 
 @pytest.mark.unit
-def test_unit_and_browser_log_paths_differ(tmp_path):
+def test_unit_and_ui_suite_log_paths_differ(tmp_path):
     """A browser-test failure must not clobber the unit-run's output."""
     log, browser_log = _log_paths(_run_hook(tmp_path, "refs/heads/feat/gamma"))
     assert log != browser_log
@@ -456,7 +456,7 @@ def test_real_unit_failure_names_existing_log_with_failure_text(stub_python, tmp
 
 
 @pytest.mark.unit
-def test_real_browser_failure_does_not_clobber_unit_log(stub_python, tmp_path):
+def test_ui_suite_failure_does_not_clobber_unit_log(stub_python, tmp_path):
     """A browser-stage failure must name the BROWSER log, and the unit log
     (from the same run, which passed) must survive untouched."""
     result = _run_real_hook(


### PR DESCRIPTION
## TL;DR
Two prepush-gate log-path tests were silently skipped by both the pre-push
hook and `test.sh`'s unit scope, because their names happened to contain the
word "browser" and got auto-tagged into the browser suite even though they
are ordinary unit tests. This renames the two tests so they run where they
were always meant to run, with no behavior change to the tests themselves.

Closes #945

## Design
`tests/conftest.py` auto-adds the `browser` marker to any test whose name
contains the substring "browser" (or whose file path contains "playwright"),
on top of whatever marker the test already declares. Both affected tests
carry an explicit `unit` marker and exercise unit-only behavior (log path
resolution for the prepush hook), but the name-based auto-marker also
attached `browser` to them, which every unit-scoped `-m` filter excludes.
The fix is a pure rename — moving the tests out of the auto-marker's
name-matching net — not a change to the auto-marker itself, since the
auto-marker exists to catch genuinely unmarked or misnamed tests elsewhere
in the suite.

## Implementation Notes
- `tests/test_prepush_gate.py:289` — `test_unit_and_browser_log_paths_differ`
  renamed to `test_unit_and_ui_suite_log_paths_differ`.
- `tests/test_prepush_gate.py:459` — `test_real_browser_failure_does_not_clobber_unit_log`
  renamed to `test_ui_suite_failure_does_not_clobber_unit_log`.
- Function bodies, docstrings, and all other tests in the file are untouched.
- No other file references the old names (verified with a repo-wide grep).

## Test evidence

### Automated tests

Collect-only, unit-gate filter (`-m "not browser and not requires_server and not integration and not slow"`), on `tests/test_prepush_gate.py`:

- Before this change (at `c31efbc`):
  ```
  ================ 37/39 tests collected (2 deselected) in 0.09s =================
  ```
- After this change:
  ```
  ========================= 39 tests collected in 0.16s ==========================
  ```

Collect-only, pre-push gate filter (`-m "unit and not slow"`), after this change:
```
========================= 39 tests collected in 0.05s ==========================
```

Collect-only, `-m browser`, after this change (must be 0 selected):
```
================= no tests collected (39 deselected) in 0.05s ==================
```

Full run, `-m "unit and not slow"`, after this change — all 39 pass, including
both renamed tests:
```
tests/test_prepush_gate.py::test_unit_and_ui_suite_log_paths_differ PASSED [ 38%]
...
tests/test_prepush_gate.py::test_ui_suite_failure_does_not_clobber_unit_log PASSED [ 64%]
...
============================== 39 passed in 5.96s ==============================
```

`tests/test_no_change_narration.py`:
```
tests/test_no_change_narration.py .                                      [100%]
============================== 1 passed in 3.53s ===============================
```

### Manual verification
N/A — no runnable artifacts changed; this is a test-only rename.

## Review focus
- `tests/test_prepush_gate.py:289` and `:459` — confirm the new names read
  clearly as unit tests about log-path behavior (not the browser suite) and
  don't reintroduce any of the auto-marker's matched substrings
  (`browser`, `playwright`, `integration`, `real_`).
