### PR TITLE
test(agents): wait for the snapshot before asserting the graph host filter's options

### DIFF
--- a/tests/test_agents_graph_redesign_ui_browser.py
+++ b/tests/test_agents_graph_redesign_ui_browser.py
@@ -176,7 +176,7 @@ def _open_agents(page: Page, base_url, snapshot=None, focus_calls=None, search_m
     page.locator("#filter-terminal").check()
     # Nodes render synchronously once the filters above are applied — wait
     # for the first one rather than for a fixed delay.
-    page.wait_for_selector(".node", timeout=8000)
+    page.wait_for_selector(".node")
     return errors
 
 

--- a/tests/test_agents_graph_redesign_ui_browser.py
+++ b/tests/test_agents_graph_redesign_ui_browser.py
@@ -174,7 +174,9 @@ def _open_agents(page: Page, base_url, snapshot=None, focus_calls=None, search_m
     page.wait_for_selector("#filter-route")
     page.select_option("#filter-recency", "all")
     page.locator("#filter-terminal").check()
-    page.wait_for_timeout(500)
+    # Nodes render synchronously once the filters above are applied — wait
+    # for the first one rather than for a fixed delay.
+    page.wait_for_selector(".node", timeout=8000)
     return errors
 
 

--- a/tests/test_agents_host_filter_ui_browser.py
+++ b/tests/test_agents_host_filter_ui_browser.py
@@ -165,8 +165,7 @@ def _open_agents(page: Page, base_url):
     # applies it, so wait for those options rather than for the select
     # itself, which exists in the markup before any data arrives.
     page.wait_for_function(
-        "document.querySelector('#filter-host').options.length > 1",
-        timeout=8000,
+        "document.querySelector('#filter-host').options.length > 1"
     )
 
 
@@ -443,7 +442,7 @@ def _open_agents2(page: Page, base_url):
     page.locator("#filter-terminal").check()
     # Nodes render synchronously once the filters above are applied — wait
     # for the first one rather than for a fixed delay.
-    page.wait_for_selector(".node", timeout=8000)
+    page.wait_for_selector(".node")
 
 
 class TestRecentChipAndRouteFilterAndNodeLabels:
@@ -682,7 +681,7 @@ def _open_agents3(page: Page, base_url):
     page.locator("#filter-terminal").check()
     # Nodes render synchronously once the filters above are applied — wait
     # for the first one rather than for a fixed delay.
-    page.wait_for_selector(".node", timeout=8000)
+    page.wait_for_selector(".node")
 
 
 class TestSearchDropdownRawIdGuard:
@@ -826,7 +825,7 @@ def _open_agents4(page: Page, base_url, search_matches=None):
     page.locator("#filter-terminal").check()
     # Nodes render synchronously once the filters above are applied — wait
     # for the first one rather than for a fixed delay.
-    page.wait_for_selector(".node", timeout=8000)
+    page.wait_for_selector(".node")
 
 
 class TestSearchDropdownLabelSourcePrecedence:

--- a/tests/test_agents_host_filter_ui_browser.py
+++ b/tests/test_agents_host_filter_ui_browser.py
@@ -160,7 +160,14 @@ def _open_agents(page: Page, base_url):
     # #850: the board is the default tab; the graph (and its filters) live
     # behind the Graph tab and only initialize once it's opened.
     page.click('[data-tab="graph"]')
-    page.wait_for_selector("#filter-host")
+    # The host select ships with only its `all` option; the per-host options
+    # are appended once `GET /api/agents/snapshot` resolves and the graph
+    # applies it, so wait for those options rather than for the select
+    # itself, which exists in the markup before any data arrives.
+    page.wait_for_function(
+        "document.querySelector('#filter-host').options.length > 1",
+        timeout=8000,
+    )
 
 
 class TestHostFilter:
@@ -180,7 +187,6 @@ class TestHostFilter:
         # widen recency to "all time" first.
         page.select_option("#filter-recency", "all")
         page.select_option("#filter-host", "laptop-a")
-        page.wait_for_timeout(400)  # let the filtered re-render settle
         nodes = page.locator(".node")
         expect(nodes).to_have_count(1)
 
@@ -194,14 +200,12 @@ class TestEndedStatus:
     def test_ended_session_hidden_by_default(self, page: Page, agents_base_url):
         _open_agents(page, agents_base_url)
         page.select_option("#filter-recency", "all")
-        page.wait_for_timeout(400)
         expect(page.locator(".node")).to_have_count(2)
 
     def test_ended_session_shown_when_include_finished_is_checked(self, page: Page, agents_base_url):
         _open_agents(page, agents_base_url)
         page.select_option("#filter-recency", "all")
         page.locator("#filter-terminal").check()
-        page.wait_for_timeout(400)
         expect(page.locator(".node")).to_have_count(3)
 
 
@@ -437,7 +441,9 @@ def _open_agents2(page: Page, base_url):
     page.wait_for_selector("#filter-route")
     page.select_option("#filter-recency", "all")
     page.locator("#filter-terminal").check()
-    page.wait_for_timeout(400)
+    # Nodes render synchronously once the filters above are applied — wait
+    # for the first one rather than for a fixed delay.
+    page.wait_for_selector(".node", timeout=8000)
 
 
 class TestRecentChipAndRouteFilterAndNodeLabels:
@@ -455,13 +461,11 @@ class TestRecentChipAndRouteFilterAndNodeLabels:
     def test_route_filter_selecting_hermes_shows_only_hermes_node(self, page: Page, agents_base_url):
         _open_agents2(page, agents_base_url)
         page.select_option("#filter-route", "hermes")
-        page.wait_for_timeout(400)
         expect(page.locator(".node")).to_have_count(1)
 
     def test_route_filter_selecting_ask_shows_only_ask_node(self, page: Page, agents_base_url):
         _open_agents2(page, agents_base_url)
         page.select_option("#filter-route", "ask")
-        page.wait_for_timeout(400)
         expect(page.locator(".node")).to_have_count(1)
 
     def test_no_node_label_is_a_literal_question_mark(self, page: Page, agents_base_url):
@@ -477,8 +481,6 @@ class TestRecentChipAndRouteFilterAndNodeLabels:
 
         _open_agents2(page, agents_base_url)
         expect(page.locator(".node")).to_have_count(7)
-        # Let the force-layout / label-render tick settle before reading text.
-        page.wait_for_timeout(300)
         labels = page.eval_on_selector_all(
             "text.node-label", "els => els.map(e => e.textContent)"
         )
@@ -498,7 +500,7 @@ class TestRecentChipAndRouteFilterAndNodeLabels:
         It returns "" instead, so the node falls through to `label` exactly
         as it already does for a raw-id `short_label`."""
         _open_agents2(page, agents_base_url)
-        page.wait_for_timeout(300)
+        expect(page.locator(".node")).to_have_count(7)
         rows = page.evaluate(
             "() => Array.from(document.querySelectorAll('.node')).map(el => ({"
             "session_id: el.__data__.session_id,"
@@ -517,7 +519,7 @@ class TestRecentChipAndRouteFilterAndNodeLabels:
         which would let the raw id `label` the ingest falls back to shadow
         the far more useful `prompt_preview`."""
         _open_agents2(page, agents_base_url)
-        page.wait_for_timeout(300)
+        expect(page.locator(".node")).to_have_count(7)
         rows = page.evaluate(
             "() => Array.from(document.querySelectorAll('.node')).map(el => ({"
             "session_id: el.__data__.session_id,"
@@ -537,7 +539,7 @@ class TestRecentChipAndRouteFilterAndNodeLabels:
         that raw id and must fall through to the next real candidate
         (`model_label` here, since there's no `prompt_preview`)."""
         _open_agents2(page, agents_base_url)
-        page.wait_for_timeout(300)
+        expect(page.locator(".node")).to_have_count(7)
         rows = page.evaluate(
             "() => Array.from(document.querySelectorAll('.node')).map(el => ({"
             "session_id: el.__data__.session_id,"
@@ -678,7 +680,9 @@ def _open_agents3(page: Page, base_url):
     page.wait_for_selector("#filter-route")
     page.select_option("#filter-recency", "all")
     page.locator("#filter-terminal").check()
-    page.wait_for_timeout(400)
+    # Nodes render synchronously once the filters above are applied — wait
+    # for the first one rather than for a fixed delay.
+    page.wait_for_selector(".node", timeout=8000)
 
 
 class TestSearchDropdownRawIdGuard:
@@ -820,7 +824,9 @@ def _open_agents4(page: Page, base_url, search_matches=None):
     page.wait_for_selector("#filter-route")
     page.select_option("#filter-recency", "all")
     page.locator("#filter-terminal").check()
-    page.wait_for_timeout(400)
+    # Nodes render synchronously once the filters above are applied — wait
+    # for the first one rather than for a fixed delay.
+    page.wait_for_selector(".node", timeout=8000)
 
 
 class TestSearchDropdownLabelSourcePrecedence:
@@ -865,7 +871,6 @@ class TestSearchDropdownLabelSourcePrecedence:
         ]
         _open_agents4(page, agents_base_url, search_matches=matches)
         page.locator("#search-input").fill("zz")
-        page.wait_for_timeout(400)
         results = page.locator(".search-result")
         expect(results).to_have_count(2)
         titles = results.locator(".sr-name").all_inner_texts()
@@ -880,7 +885,6 @@ class TestSearchDropdownLabelSourcePrecedence:
         ]
         _open_agents4(page, agents_base_url, search_matches=matches)
         page.locator("#search-input").fill("llm-short")
-        page.wait_for_timeout(400)
         result = page.locator(".search-result", has_text="dropdowntest-llm-short")
         expect(result).to_be_visible()
         name_el = result.locator(".sr-name")


### PR DESCRIPTION
Closes #958 (issue stays open for the milestone orchestrator).

## What this does

`tests/test_agents_host_filter_ui_browser.py` asserts on state that only exists after `GET /api/agents/snapshot` resolves and `web/agents/graph.js` applies it, but its open helpers wait only for elements that ship in the static markup. `#filter-host` is present with just its `all` option before any data arrives, so waiting for the element proves nothing about the data. Under parallel load the assertion wins the race and two tests fail spuriously, costing a full gate cycle.

Every helper in the file now waits on observable output instead:

- `_open_agents` waits for `#filter-host` to carry more than its `all` option, which is exactly the snapshot-derived state its tests read.
- `_open_agents2`, `_open_agents3` and `_open_agents4` wait for the first `.node` to render.
- In-test fixed sleeps are gone. Where the following assertion is a Playwright `expect(...)`, the sleep was dead weight and is removed; where the following read is non-retrying (`page.evaluate`), it is replaced by an `expect(...).to_have_count(...)` on the nodes that read depends on. No `wait_for_timeout` remains in the file.

`tests/test_agents_graph_redesign_ui_browser.py`'s module-level `_open_agents` carries the same shape, with a fixed 500 ms sleep in front of non-retrying `page.evaluate` reads, so it gets the same node wait. Nothing else in that file changes.

No product code changes. The file stays server-free with no `requires_server` marker.

## Proof the waits are load-bearing

- Stubbing the snapshot to return no sessions makes both `TestHostFilter` tests fail on the wait rather than pass vacuously or hang: `2 failed in 31.62s`, each with `TimeoutError: Page.wait_for_function`. Restoring the file returns `2 passed in 2.34s`.
- Serving a genuinely slow `/api/agents/snapshot` from the fixture's own HTTP server reproduces the issue's exact failure signature against the pre-change file (`assert 'laptop-a' in ['all']` and `Page.select_option: Timeout 30000ms exceeded ... did not find some options`), and the changed file passes the same scenario.

## Verification

- `tests/test_agents_host_filter_ui_browser.py`: 26 passed, at `-n 4`, three runs before and three after.
- `tests/test_agents_graph_redesign_ui_browser.py`: 33 passed.
- Pre-push gate: 7330 unit passed, and the full `browser and not requires_server` selection 604 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWVWnyri65hMc3S2u6kRaY
