### PR TITLE
feat: Add atomic eligible agent claims

### DIFF
--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -10,12 +10,23 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from api.services import human_queue
+from api.services.agent_board import AGENT_ASSIGNEES
 from api.services.agent_worker.session_store import SessionStore
 from api.services.task_manager import get_task_manager, Task, TaskConflictError, VALID_STATUSES
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/tasks", tags=["tasks"])
+
+# Same claim vocabulary the worker fans out on (engine assignees + Managed
+# Agents consent tags). dry_run previews only when the create would be
+# worker-claimable.
+_AGENT_PICKUP_TAGS = frozenset(("agent", *AGENT_ASSIGNEES, "cloud-haiku", "cloud-sonnet"))
+_AGENT_CLAIM_EXCLUSION_TAGS = frozenset({
+    "agent-running", "agent-blocked", "agent-completed",
+    "agent-failed", "agent-budget-exceeded",
+})
+_AGENT_PICKUP_STATUSES = frozenset({"todo", "urgent"})
 
 # Lazy module-level singleton, mirroring api/routes/agents.py's own
 # `_get_session_store()` — needed here to answer "is there actually a live
@@ -67,12 +78,12 @@ class CreateTaskRequest(BaseModel):
     tags: Optional[list[str]] = Field(
         default=None,
         description="List of tags (e.g., ['work', 'urgent']). Add exactly the "
-                    "tags the operator named. A routing tag (agent/local/claude/"
-                    "codex/cloud/cloud-haiku/cloud-sonnet) only if the operator "
-                    "explicitly named that engine — these tags are operator-"
-                    "authority and outrank every routing safeguard, so inventing "
-                    "one injects your own engine preference at the highest-"
-                    "precedence slot.",
+                    "tags the operator named. A routing tag (local/claude/"
+                    "codex/hermes/cloud/cloud-haiku/cloud-sonnet) only if the "
+                    "operator explicitly named that engine — these tags are "
+                    "operator-authority and outrank every routing safeguard, "
+                    "so inventing one injects your own engine preference at "
+                    "the highest-precedence slot.",
     )
     reminder_id: Optional[str] = Field(default=None, description="Associated reminder ID")
     notes: Optional[str] = Field(
@@ -87,11 +98,12 @@ class CreateTaskRequest(BaseModel):
     )
     dry_run: Optional[bool] = Field(
         default=False,
-        description="When true and the task carries the #agent tag, run the "
-                    "Haiku preflight and return the routing + cost estimate "
-                    "without creating the task. Used by prompt-engineering "
-                    "iteration to inspect routing decisions without dispatching "
-                    "a managed session. Costs ~$0.001 for the preflight call.",
+        description="When true and the task carries an engine assignee or "
+                    "Managed Agents consent tag, run the Haiku preflight and "
+                    "return the routing + cost estimate without creating the "
+                    "task. Used by prompt-engineering iteration to inspect "
+                    "routing decisions without dispatching a managed session. "
+                    "Costs ~$0.001 for the preflight call.",
     )
 
 
@@ -125,8 +137,8 @@ class UpdateTaskRequest(BaseModel):
     tags: Optional[list[str]] = Field(
         default=None,
         description="Replaces the task's tag list. Add exactly the tags the "
-                    "operator named. A routing tag (agent/local/claude/codex/"
-                    "cloud/cloud-haiku/cloud-sonnet) only if the operator "
+                    "operator named. A routing tag (local/claude/codex/"
+                    "hermes/cloud/cloud-haiku/cloud-sonnet) only if the operator "
                     "explicitly named that engine — these tags are operator-"
                     "authority and outrank every routing safeguard.",
     )
@@ -204,15 +216,17 @@ class ConflictListResponse(BaseModel):
 async def create_task(request: CreateTaskRequest):
     """Create a new task, or preview its agent routing without creating it.
 
-    When `dry_run=true` and the request carries the #agent tag, the route runs
-    the Haiku preflight classifier and returns the routing decision + cost
-    estimate without persisting a task or dispatching a session. Used by
-    prompt-engineering iteration to inspect routing decisions cheaply
-    (only the preflight call costs anything, ~$0.001).
+    When `dry_run=true` and the request carries an engine assignee or Managed
+    Agents consent tag, the route runs the Haiku preflight classifier and
+    returns the routing decision + cost estimate without persisting a task or
+    dispatching a session. Used by prompt-engineering iteration to inspect
+    routing decisions cheaply (only the preflight call costs anything,
+    ~$0.001).
 
-    For non-#agent tasks (or `dry_run=false`), the task is created normally.
+    Otherwise (no engine/consent tag, or `dry_run=false`), the task is created
+    normally.
     """
-    if request.dry_run and _has_agent_tag(request.tags):
+    if request.dry_run and _has_agent_pickup_tag(request.tags):
         return _build_preflight_preview(request)
     _require_valid_status(request.status)
     manager = get_task_manager()
@@ -236,10 +250,10 @@ async def create_task(request: CreateTaskRequest):
     return TaskResponse.from_task(task)
 
 
-def _has_agent_tag(tags: Optional[list[str]]) -> bool:
+def _has_agent_pickup_tag(tags: Optional[list[str]]) -> bool:
     if not tags:
         return False
-    return any(t.lstrip("#").lower() == "agent" for t in tags)
+    return any(t.lstrip("#").lower() in _AGENT_PICKUP_TAGS for t in tags)
 
 
 def _build_preflight_preview(request: CreateTaskRequest) -> PreflightPreviewResponse:
@@ -504,10 +518,11 @@ async def swap_tag(
 ):
     """Atomically replace one tag with another on a task.
 
-    Used by the external agent worker to claim `#agent` tasks. Returns
-    `{swapped: false}` (with a `reason`) when the task does not exist or
-    `from` is not currently among the task's tags — both indicate the worker
-    should move on to the next candidate rather than retry.
+    Used by the external agent worker for lifecycle tag transitions (e.g.
+    `#agent-running` → `#agent-completed`). Returns `{swapped: false}` (with
+    a `reason`) when the task does not exist or `from` is not currently among
+    the task's tags — both indicate the worker should move on to the next
+    candidate rather than retry.
     """
     manager = get_task_manager()
     if manager.get(task_id) is None:
@@ -517,6 +532,58 @@ async def swap_tag(
     except TaskConflictError as e:
         raise HTTPException(status_code=409, detail=str(e))
     return SwapTagResponse(swapped=ok, reason=None if ok else f"tag '{from_tag}' not present")
+
+
+class MutateTagResponse(BaseModel):
+    ok: bool
+    reason: Optional[str] = None
+
+
+class ClaimAgentResponse(BaseModel):
+    claimed: bool
+    consumed_queue_tag: bool = False
+    reason: Optional[str] = None
+
+
+@router.post("/{task_id}/claim-agent", response_model=ClaimAgentResponse)
+async def claim_agent_task(task_id: str):
+    """Atomically claim a currently eligible task for the agent worker."""
+    manager = get_task_manager()
+    if manager.get(task_id) is None:
+        return ClaimAgentResponse(claimed=False, reason="task not found")
+    try:
+        claimed, consumed_queue_tag = manager.claim_for_agent(
+            task_id,
+            pickup_tags=set(_AGENT_PICKUP_TAGS),
+            exclusion_tags=set(_AGENT_CLAIM_EXCLUSION_TAGS),
+            eligible_statuses=set(_AGENT_PICKUP_STATUSES),
+        )
+    except TaskConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    return ClaimAgentResponse(
+        claimed=claimed,
+        consumed_queue_tag=consumed_queue_tag,
+        reason=None if claimed else "task is no longer eligible",
+    )
+
+
+@router.post("/{task_id}/remove-tag", response_model=MutateTagResponse)
+async def remove_tag(
+    task_id: str,
+    tag: str = Query(..., description="Tag to remove if present (with or without '#')"),
+):
+    """Atomically remove a tag when present.
+
+    Used by the agent worker to roll back a claim by dropping `#agent-running`.
+    """
+    manager = get_task_manager()
+    if manager.get(task_id) is None:
+        return MutateTagResponse(ok=False, reason="task not found")
+    try:
+        ok = manager.remove_tag_if_present(task_id, tag)
+    except TaskConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    return MutateTagResponse(ok=ok, reason=None if ok else f"tag '{tag}' not present")
 
 
 @router.get("/{task_id}", response_model=TaskResponse)

--- a/api/services/task_manager.py
+++ b/api/services/task_manager.py
@@ -125,6 +125,10 @@ class _TagAbsentError(Exception):
     CAS retry re-read the task (e.g. someone else already swapped it)."""
 
 
+class _TaskNotClaimableError(Exception):
+    """Internal signal that a claim precondition failed after a CAS re-read."""
+
+
 @dataclass
 class Task:
     """A task stored in the vault."""
@@ -493,6 +497,126 @@ class TaskManager:
             self._save_index()
             self._write_dashboard()
             logger.info(f"swap_tag {task_id}: {from_norm} → {to_norm}")
+            return True
+
+    def claim_for_agent(
+        self,
+        task_id: str,
+        *,
+        pickup_tags: set[str],
+        exclusion_tags: set[str],
+        eligible_statuses: set[str],
+        queue_tag: str = "agent",
+        running_tag: str = "agent-running",
+    ) -> tuple[bool, bool]:
+        """Atomically claim an eligible task and return `(claimed, consumed_queue_tag)`.
+
+        Eligibility is checked again on every compare-and-swap retry so a stale
+        worker listing cannot claim a task whose status or assignment changed.
+        """
+        pickup = {tag.lstrip("#").lower() for tag in pickup_tags}
+        excluded = {tag.lstrip("#").lower() for tag in exclusion_tags}
+        statuses = {status.lower() for status in eligible_statuses}
+        queue = queue_tag.lstrip("#").lower()
+        running = running_tag.lstrip("#")
+        consumed_queue_tag = False
+
+        def is_claimable(task: Task) -> bool:
+            tags = {tag.lstrip("#").lower() for tag in task.tags}
+            return task.status.lower() in statuses and bool(tags & pickup) and not bool(tags & excluded)
+
+        with self._lock:
+            current = self._tasks.get(task_id)
+            if not current or not is_claimable(current):
+                return False, False
+
+            path = Path(current.source_file)
+
+            def compute() -> Task:
+                nonlocal consumed_queue_tag
+                t = self._tasks[task_id]
+                if not is_claimable(t):
+                    raise _TaskNotClaimableError()
+                new_task = copy.copy(t)
+                new_tags = list(t.tags)
+                queue_index = next(
+                    (i for i, tag in enumerate(new_tags) if tag.lstrip("#").lower() == queue),
+                    None,
+                )
+                consumed_queue_tag = queue_index is not None
+                if queue_index is None:
+                    new_tags.append(running)
+                else:
+                    new_tags[queue_index] = running
+                new_task.tags = new_tags
+                new_task.status = "in_progress"
+                new_task.updated_at = _now_iso()
+                return new_task
+
+            try:
+                found, task = self._cas_rewrite(path, task_id, compute)
+            except _TaskNotClaimableError:
+                return False, False
+            if not found:
+                self._tasks.pop(task_id, None)
+                self._last_written_line.pop(task_id, None)
+                self._save_index()
+                self._write_dashboard()
+                return False, False
+
+            self._reposition_file(path)
+            self._save_index()
+            self._write_dashboard()
+            logger.info("claim_for_agent %s: consumed_queue_tag=%s", task_id, consumed_queue_tag)
+            return True, consumed_queue_tag
+
+    def remove_tag_if_present(self, task_id: str, tag: str) -> bool:
+        """Atomically remove `tag` when present.
+
+        Returns True when the tag is absent after the call, False if the task is gone or
+        the tag is already absent.
+        """
+        tag_cmp = tag.lstrip("#").lower()
+        with self._lock:
+            current = self._tasks.get(task_id)
+            if not current:
+                return False
+            if not any(t.lstrip("#").lower() == tag_cmp for t in current.tags):
+                return False
+
+            path = Path(current.source_file)
+
+            def compute() -> Task:
+                t = self._tasks[task_id]
+                try:
+                    idx = next(
+                        i for i, existing in enumerate(t.tags)
+                        if existing.lstrip("#").lower() == tag_cmp
+                    )
+                except StopIteration:
+                    raise _TagAbsentError()
+                new_task = copy.copy(t)
+                new_tags = list(t.tags)
+                del new_tags[idx]
+                new_task.tags = new_tags
+                new_task.updated_at = _now_iso()
+                return new_task
+
+            try:
+                found, task = self._cas_rewrite(path, task_id, compute)
+            except _TagAbsentError:
+                return False
+            if not found:
+                self._tasks.pop(task_id, None)
+                self._last_written_line.pop(task_id, None)
+                self._save_index()
+                self._write_dashboard()
+                return False
+
+            self._reposition_file(path)
+            self._save_index()
+            self._write_dashboard()
+            logger.info(f"remove_tag_if_present {task_id}: -{tag_cmp}")
             return True
 
     def delete(self, task_id: str) -> bool:

--- a/tests/test_task_manager_swap_tag.py
+++ b/tests/test_task_manager_swap_tag.py
@@ -1,6 +1,6 @@
 """Atomic tag-swap tests for TaskManager.
 
-Used by the external agent worker to claim `#agent` tasks exactly once even
+Used by the external agent worker to perform atomic tag transitions even
 when multiple workers race. Storage is markdown-based with a single in-process
 lock, so the racing scenario is *two threads sharing one TaskManager* — which
 matches production where the worker hits the API server's singleton.
@@ -78,3 +78,91 @@ def test_swap_tag_is_atomic_under_race(manager: TaskManager):
     final_tags = manager.get(task.id).tags
     assert final_tags.count("agent-running") == 1
     assert "agent" not in final_tags
+
+
+def _claim(manager: TaskManager, task_id: str) -> tuple[bool, bool]:
+    return manager.claim_for_agent(
+        task_id,
+        pickup_tags={"agent", "hermes", "cloud"},
+        exclusion_tags={"agent-running", "agent-blocked", "agent-completed"},
+        eligible_statuses={"todo", "urgent"},
+    )
+
+
+@pytest.mark.unit
+def test_claim_for_agent_adds_running_for_engine_only_task(manager: TaskManager):
+    task = manager.create("engine only", tags=["hermes"])
+    assert _claim(manager, task.id) == (True, False)
+    refreshed = manager.get(task.id)
+    assert "agent-running" in refreshed.tags
+    assert "hermes" in refreshed.tags
+    assert refreshed.status == "in_progress"
+
+
+@pytest.mark.unit
+def test_claim_for_agent_consumes_legacy_queue_tag(manager: TaskManager):
+    task = manager.create("legacy", tags=["agent"])
+    assert _claim(manager, task.id) == (True, True)
+    assert manager.get(task.id).tags == ["agent-running"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("status", "tags"),
+    [
+        ("done", ["hermes"]),
+        ("todo", ["research"]),
+        ("todo", ["hermes", "agent-running"]),
+        ("todo", ["cloud", "agent-blocked"]),
+    ],
+)
+def test_claim_for_agent_rejects_ineligible_current_state(manager: TaskManager, status, tags):
+    task = manager.create("ineligible", status=status, tags=tags)
+    assert _claim(manager, task.id) == (False, False)
+    refreshed = manager.get(task.id)
+    assert refreshed.status == status
+    assert refreshed.tags == tags
+
+
+@pytest.mark.unit
+def test_claim_for_agent_returns_false_when_already_claimed(manager: TaskManager):
+    task = manager.create("already", tags=["hermes", "agent-running"])
+    assert _claim(manager, task.id) == (False, False)
+    assert manager.get(task.id).tags == ["hermes", "agent-running"]
+
+
+@pytest.mark.unit
+def test_claim_for_agent_is_atomic_under_race(manager: TaskManager):
+    task = manager.create("racey engine", tags=["cloud"])
+    n = 8
+    results: list[tuple[bool, bool]] = []
+    barrier = threading.Barrier(n)
+
+    def attempt():
+        barrier.wait()
+        results.append(_claim(manager, task.id))
+
+    threads = [threading.Thread(target=attempt) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert results.count((True, False)) == 1, f"expected exactly one winner, got {results}"
+    assert manager.get(task.id).tags.count("agent-running") == 1
+
+
+@pytest.mark.unit
+def test_remove_tag_if_present_removes_when_present(manager: TaskManager):
+    task = manager.create("claimed", tags=["hermes", "agent-running"])
+    assert manager.remove_tag_if_present(task.id, "agent-running") is True
+    refreshed = manager.get(task.id)
+    assert "agent-running" not in refreshed.tags
+    assert "hermes" in refreshed.tags
+    assert "agent" not in refreshed.tags
+
+
+@pytest.mark.unit
+def test_remove_tag_if_present_returns_false_when_absent(manager: TaskManager):
+    task = manager.create("clean", tags=["hermes"])
+    assert manager.remove_tag_if_present(task.id, "agent-running") is False

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -172,9 +172,9 @@ class TestTasksAPI:
 
     # --- DRY RUN (#138) ---
 
-    def test_dry_run_with_agent_tag_returns_preflight_preview(self, client, mock_task_manager):
-        """dry_run=true on an #agent task runs preflight and returns the
-        routing decision + cost estimate WITHOUT creating the task."""
+    def test_dry_run_with_engine_tag_returns_preflight_preview(self, client, mock_task_manager):
+        """dry_run=true on an engine-assigned task runs preflight and returns
+        the routing decision + cost estimate WITHOUT creating the task."""
         from api.services.agent_worker.preflight import (
             PreflightBudget,
             PreflightResult,
@@ -192,7 +192,7 @@ class TestTasksAPI:
         with patch("api.services.agent_worker.preflight.run_preflight", return_value=fake_result):
             response = client.post("/api/tasks", json={
                 "description": "draft my Q4 review",
-                "tags": ["agent"],
+                "tags": ["local"],
                 "dry_run": True,
             })
         assert response.status_code == 200
@@ -228,7 +228,7 @@ class TestTasksAPI:
         with patch("api.services.agent_worker.preflight.run_preflight", return_value=fake_result):
             response = client.post("/api/tasks", json={
                 "description": "draft my Q4 review",
-                "tags": ["agent", "cloud"],
+                "tags": ["cloud"],
                 "dry_run": True,
             })
         assert response.status_code == 200
@@ -261,14 +261,14 @@ class TestTasksAPI:
         with patch("api.services.agent_worker.preflight.run_preflight", return_value=fake_result):
             response = client.post("/api/tasks", json={
                 "description": "draft my Q4 review",
-                "tags": ["agent", "cloud"],
+                "tags": ["cloud"],
                 "dry_run": True,
             })
         assert response.status_code == 200
         assert response.json()["estimated_dollars"] == 0.0
 
-    def test_dry_run_without_agent_tag_falls_through_to_create(self, client, mock_task_manager):
-        """dry_run is a no-op for non-#agent tasks — the task is still created."""
+    def test_dry_run_without_engine_tag_falls_through_to_create(self, client, mock_task_manager):
+        """dry_run is a no-op without an engine/consent tag — the task is still created."""
         response = client.post("/api/tasks", json={
             "description": "shopping list",
             "dry_run": True,
@@ -277,12 +277,35 @@ class TestTasksAPI:
         # Falls through to real task creation.
         mock_task_manager.create.assert_called_once()
 
+    def test_dry_run_bare_agent_tag_preserves_legacy_preview(self, client, mock_task_manager):
+        """Legacy queue-only tasks remain both claimable and previewable."""
+        from api.services.agent_worker.preflight import PreflightBudget, PreflightResult, ROUTE_LOCAL
+
+        fake_result = PreflightResult(
+            budget=PreflightBudget(wall_seconds=60, max_tokens=1_000, max_dollars=0.1),
+            routing=ROUTE_LOCAL,
+            routing_reason="default route",
+            expected_output="text",
+            ambiguity=None,
+            sane=True,
+            sane_reason="",
+        )
+        with patch("api.services.agent_worker.preflight.run_preflight", return_value=fake_result):
+            response = client.post("/api/tasks", json={
+                "description": "legacy handoff",
+                "tags": ["agent"],
+                "dry_run": True,
+            })
+        assert response.status_code == 200
+        assert response.json()["dry_run"] is True
+        mock_task_manager.create.assert_not_called()
+
     def test_dry_run_false_creates_task_normally(self, client, mock_task_manager):
-        """dry_run=false on an #agent task still creates it (the worker
-        picks it up later and does its own preflight)."""
+        """dry_run=false on an engine-assigned task still creates it (the
+        worker picks it up later and does its own preflight)."""
         response = client.post("/api/tasks", json={
             "description": "dispatch this",
-            "tags": ["agent"],
+            "tags": ["local"],
             "dry_run": False,
         })
         assert response.status_code == 200
@@ -791,6 +814,30 @@ class TestTasksAPI:
         mock_task_manager.swap_tag.side_effect = TaskConflictError("too many conflicting writes")
         response = client.post("/api/tasks/abc12345/swap-tag?from=agent&to=agent-running")
         assert response.status_code == 409
+
+    def test_claim_agent_uses_atomic_eligibility_checked_write(self, client, mock_task_manager):
+        mock_task_manager.claim_for_agent.return_value = (True, False)
+        response = client.post("/api/tasks/abc12345/claim-agent")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "claimed": True,
+            "consumed_queue_tag": False,
+            "reason": None,
+        }
+        kwargs = mock_task_manager.claim_for_agent.call_args.kwargs
+        assert "agent" in kwargs["pickup_tags"]
+        assert "cloud" in kwargs["pickup_tags"]
+        assert "agent-running" in kwargs["exclusion_tags"]
+        assert kwargs["eligible_statuses"] == {"todo", "urgent"}
+
+    def test_claim_agent_reports_stale_candidate_without_mutating(self, client, mock_task_manager):
+        mock_task_manager.claim_for_agent.return_value = (False, False)
+        response = client.post("/api/tasks/abc12345/claim-agent")
+
+        assert response.status_code == 200
+        assert response.json()["claimed"] is False
+        assert response.json()["reason"] == "task is no longer eligible"
 
 
 class TestListTasksParameterDocs:


### PR DESCRIPTION
## Summary
- add a single compare-and-swap claim operation that revalidates task status, pickup tags, and lifecycle exclusions
- claim and move tasks to in-progress in one markdown write
- expose the worker-only claim route while preserving lifecycle tag rollback helpers

## Tests
- pre-push: 7,455 passed, 9 skipped
- browser gate: 694 passed
- focused claim/task API suite: 195 passed

Part of #969.