### PR TITLE
fix: Complete cloud claim vocabulary

### DIFF
--- a/api/services/agent_board.py
+++ b/api/services/agent_board.py
@@ -16,11 +16,10 @@ from dataclasses import dataclass
 from typing import Iterable, Optional
 
 # Tags the agent worker itself writes as it drives a task through its
-# lifecycle — see AGENT_TAG / RUNNING_TAG / COMPLETED_TAG / BLOCKED_TAG in
+# lifecycle — see RUNNING_TAG / COMPLETED_TAG / BLOCKED_TAG in
 # api/services/agent_worker/worker.py. Mirrored here (not imported) so this
 # module stays import-light — the board treats them as opaque strings, not
 # worker internals.
-AGENT_TAG = "agent"
 RUNNING_TAG = "agent-running"
 COMPLETED_TAG = "agent-completed"
 BLOCKED_TAG = "agent-blocked"
@@ -33,11 +32,10 @@ HUMAN_TAG = "human"
 ACCEPTED_TAG = "accepted"
 
 # Assignee is exactly one tag from this set. "me" is the operator; the rest
-# are agent engines. This is a labeling convention only at this stage —
-# actually dispatching to an engine from an assignee tag is issue #851
-# (assignment and execution), out of scope here.
-ASSIGNEE_TAGS: tuple[str, ...] = ("me", "claude", "codex", "hermes", "local")
-AGENT_ASSIGNEES: tuple[str, ...] = ("claude", "codex", "hermes", "local")
+# are agent engines. An engine assignee on a todo/urgent task is what makes
+# it claimable by the worker — see agent-worker claim pickup.
+ASSIGNEE_TAGS: tuple[str, ...] = ("me", "claude", "codex", "hermes", "local", "cloud")
+AGENT_ASSIGNEES: tuple[str, ...] = ("claude", "codex", "hermes", "local", "cloud")
 
 LANES: tuple[str, ...] = (
     "unassigned",
@@ -209,13 +207,9 @@ def is_agent_owned(tags: Iterable[str]) -> bool:
     """True when the card is managed by an agent rather than a human —
     either its assignee tag names an agent engine, or the worker has
     already claimed it (`agent-running`/`agent-blocked`) even with no
-    engine-specific assignee tag at all. The worker selects candidates by
-    the bare `agent` queue tag alone and its claim swap
-    (`agent` -> `agent-running`) never touches assignee tags, so a card
-    can be claimed while `derive_assignee` still returns `None` — that
-    shape must still count as agent-owned, or Cancel (and every other
-    agent-owned-only action) would refuse the one card that most needs
-    it, with no assignee tag left to edit it back to a workable state."""
+    engine-specific assignee tag. Claimed cards without an assignee must
+    still count as agent-owned so Cancel (and every other agent-owned-only
+    action) remains available."""
     tset = _norm_tags(tags)
     return derive_assignee(tset) in AGENT_ASSIGNEES or bool(tset & {RUNNING_TAG, BLOCKED_TAG})
 
@@ -282,8 +276,8 @@ def evaluate_card_action(
             return None
         if agent_owned:
             if target_lane == "in_progress":
-                # Only the worker claims agent-assigned tasks (swaps #agent
-                # -> #agent-running itself); a human dragging such a card to
+                # Only the worker claims agent-assigned tasks (adds
+                # #agent-running itself); a human dragging such a card to
                 # In progress would desync the tag from the actual claim
                 # state.
                 return AGENT_ONLY_CLAIM_ERROR

--- a/tests/test_agent_board.py
+++ b/tests/test_agent_board.py
@@ -20,7 +20,7 @@ class TestDeriveAssignee:
     def test_me(self):
         assert agent_board.derive_assignee(["me"]) == "me"
 
-    @pytest.mark.parametrize("engine", ["claude", "codex", "hermes", "local"])
+    @pytest.mark.parametrize("engine", ["claude", "codex", "hermes", "local", "cloud"])
     def test_agent_engines(self, engine):
         assert agent_board.derive_assignee([engine]) == engine
 
@@ -417,7 +417,7 @@ class TestPlanLaneMoveLandsInTargetLane:
 # ---------------------------------------------------------------------------
 
 class TestIsAgentOwned:
-    @pytest.mark.parametrize("engine", ["claude", "codex", "hermes", "local"])
+    @pytest.mark.parametrize("engine", ["claude", "codex", "hermes", "local", "cloud"])
     def test_engine_assignee_tag_is_agent_owned(self, engine):
         assert agent_board.is_agent_owned([engine]) is True
 
@@ -428,12 +428,9 @@ class TestIsAgentOwned:
 
     @pytest.mark.parametrize("claim_tag", ["agent-running", "agent-blocked"])
     def test_claim_tag_with_no_assignee_tag_is_agent_owned(self, claim_tag):
-        # The worker's own claim swap (`agent` -> `agent-running`/
-        # `agent-blocked`) never adds an engine-specific assignee tag — a
-        # card claimed this way must still count as agent-owned, or Cancel
-        # (agent-owned-only) would refuse the one recovery action left on
-        # it, with no assignee tag to edit it back to a workable state.
-        assert agent_board.is_agent_owned(["agent", claim_tag]) is True
+        # A card the worker already claimed with no engine assignee must
+        # still count as agent-owned.
+        assert agent_board.is_agent_owned([claim_tag]) is True
 
     def test_completed_or_accepted_tag_alone_is_not_agent_owned(self):
         # Only the two WORKER-CLAIM tags (agent-running/agent-blocked)
@@ -550,7 +547,7 @@ class TestIsScheduleActive:
 ALL_LANES = (
     "unassigned", "assigned", "in_progress", "human_queue", "scheduled", "review", "done",
 )
-ALL_ASSIGNEES = (None, "me", "claude", "codex", "hermes", "local")
+ALL_ASSIGNEES = (None, "me", "claude", "codex", "hermes", "local", "cloud")
 ALL_CONDITIONS = (
     "unclaimed", "agent_running", "agent_blocked", "review", "accepted", "done", "cancelled",
     "cli_opened", "in_progress_no_session",
@@ -595,7 +592,7 @@ def _state_to_status_tags(assignee, condition):
     elif condition in ("cli_opened", "in_progress_no_session"):
         # cli_session_event sets status="in_progress" the first time a
         # card's Open button spawns a session, but never adds
-        # agent-running (only the worker's own #agent claim flow does) —
+        # agent-running (only the worker's own claim flow does) —
         # no extra tag beyond the plain assignee either way. The two
         # conditions share this exact (status, tags) shape; what tells
         # them apart is whether a live session actually backs it (see
@@ -620,14 +617,8 @@ def _expected_outcome(assignee, condition, action, target_lane=None):
     `(status_code, detail)` for refused."""
     # A card is agent-owned once EITHER its assignee tag names an agent
     # engine, OR it already carries a worker claim tag — regardless of
-    # whether an assignee tag is also present. The claim-tag branch covers
-    # both the bare-`#agent`-queue-card shape with no engine-specific
-    # assignee at all (the worker's own claim swap only ever touches
-    # `agent`/claim tags, never assignee tags) and a card the worker
-    # claimed while it still carries `#me`. Without that branch, either
-    # shape would refuse Cancel too (agent-owned-only) with no assignee tag
-    # left to edit it back to a workable state.
-    agent_owned = assignee in ("claude", "codex", "hermes", "local") or condition in (
+    # whether an assignee tag is also present.
+    agent_owned = assignee in ("claude", "codex", "hermes", "local", "cloud") or condition in (
         "agent_running", "agent_blocked",
     )
     # A CLI-opened, agent-owned card backed by a live session is claimed
@@ -751,15 +742,9 @@ class TestEvaluateCardActionDecisionTable:
             # it's how a human gets rid of it without dragging it anywhere.
             assert agent_board.evaluate_card_action(status, tags, "cancel") is None
 
-    def test_claimed_bare_agent_card_with_no_assignee_tag_still_allows_cancel(self):
-        """The worker selects candidates by the bare `#agent` queue tag
-        alone and its claim swap (`agent` -> `agent-running`/`agent-blocked`)
-        never adds an engine-specific assignee tag — so a card can be
-        claimed with `derive_assignee` still returning `None`. That shape
-        must be treated as agent-owned the same as an engine-assigned one:
-        every lane refuses (claimed, same as the engine case), but Cancel,
-        the one recovery action left, still works — there's no assignee
-        tag to edit it back to a workable state otherwise."""
+    def test_claimed_card_with_no_assignee_tag_still_allows_cancel(self):
+        """A claimed card with no engine assignee is still agent-owned:
+        every lane refuses, but Cancel still works."""
         for condition in ("agent_running", "agent_blocked"):
             status, tags = _state_to_status_tags(None, condition)
             assert agent_board.derive_assignee(tags) is None  # no assignee tag at all

--- a/tests/test_agents_action_parity_browser.py
+++ b/tests/test_agents_action_parity_browser.py
@@ -272,6 +272,22 @@ def _extract_actions(page: Page, container_selector: str):
     return page.eval_on_selector(container_selector, _EXTRACT_JS)
 
 
+def _click_graph_node(page: Page, session_id: str) -> None:
+    page.wait_for_function(
+        """sid => [...document.querySelectorAll('#graph-svg .node')]
+            .some(node => node.__data__ && node.__data__.session_id === sid)""",
+        arg=session_id,
+    )
+    page.evaluate(
+        """sid => {
+            const node = [...document.querySelectorAll('#graph-svg .node')]
+                .find(candidate => candidate.__data__ && candidate.__data__.session_id === sid);
+            node.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
+        }""",
+        session_id,
+    )
+
+
 # A rich session+card pair exercising Open, Focus, Resume, Kill (disabled),
 # Answer, Cancel (disabled), and Delete together — Accept/Resolve need
 # different lanes, covered separately below and by TestDecideActions above.
@@ -487,24 +503,7 @@ class TestGraphTabParity:
         page.wait_for_selector("#filter-route")
         page.select_option("#filter-recency", "all")
         page.locator("#filter-terminal").check()
-        page.wait_for_timeout(800)
-
-        clicked = page.evaluate(
-            """
-            (sid) => {
-              const nodes = document.querySelectorAll('#graph-svg .node');
-              for (const n of nodes) {
-                if (n.__data__ && n.__data__.session_id === sid) {
-                  n.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-                  return true;
-                }
-              }
-              return false;
-            }
-            """,
-            session["session_id"],
-        )
-        assert clicked, "graph node for the linked session was never rendered"
+        _click_graph_node(page, session["session_id"])
         page.wait_for_selector('#panel [data-field="actions"] [data-action]')
         graph_actions = _extract_actions(page, '#panel [data-field="actions"]')
 
@@ -570,24 +569,7 @@ class TestGraphPanelCardOnlyHandlersWired:
         page.wait_for_selector("#filter-route")
         page.select_option("#filter-recency", "all")
         page.locator("#filter-terminal").check()
-        page.wait_for_timeout(800)
-
-        clicked = page.evaluate(
-            """
-            (sid) => {
-              const nodes = document.querySelectorAll('#graph-svg .node');
-              for (const n of nodes) {
-                if (n.__data__ && n.__data__.session_id === sid) {
-                  n.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-                  return true;
-                }
-              }
-              return false;
-            }
-            """,
-            session["session_id"],
-        )
-        assert clicked, "graph node for the linked session was never rendered"
+        _click_graph_node(page, session["session_id"])
         page.wait_for_selector('#panel [data-field="actions"] [data-action="open"]')
         page.click('#panel [data-field="actions"] [data-action="open"]')
         page.wait_for_timeout(300)
@@ -689,24 +671,7 @@ class TestGraphTabDeleteUsesFreshCard:
         page.wait_for_selector("#filter-route")
         page.select_option("#filter-recency", "all")
         page.locator("#filter-terminal").check()
-        page.wait_for_timeout(500)
-
-        clicked = page.evaluate(
-            """
-            (sid) => {
-              const nodes = document.querySelectorAll('#graph-svg .node');
-              for (const n of nodes) {
-                if (n.__data__ && n.__data__.session_id === sid) {
-                  n.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-                  return true;
-                }
-              }
-              return false;
-            }
-            """,
-            stale_card["session"]["session_id"],
-        )
-        assert clicked, "graph node for the linked session was never rendered"
+        _click_graph_node(page, stale_card["session"]["session_id"])
         page.wait_for_selector('#panel [data-field="actions"] [data-action="delete"]')
 
         # Deliver the board's live update NOW — after the panel has already


### PR DESCRIPTION
## Summary
- add cloud to the shared agent assignee vocabulary used by atomic task claims
- cover cloud policy behavior in the board decision matrix
- replace fixed graph-node sleeps with condition waits in action-parity browser tests

## Tests
- focused task API and board policy suite passed
- action-parity browser suite: 24 passed
- pre-push unit gate passed
- pre-push browser gate: 689 passed

Completes the missing dependency from #994 and is part of #969.