### PR TITLE
feat: Claim tasks by engine assignment

### DIFF
--- a/api/services/agent_worker/worker.py
+++ b/api/services/agent_worker/worker.py
@@ -3,9 +3,10 @@
 Per-tick flow:
   - wake any sessions whose sleep timer has expired
   - check the daily spend cap
-  - list todo+#agent tasks from the API
-  - for each unclaimed candidate: atomic tag swap, preflight, route
-    (local → run on Gemma; claude → defer to Issue D; ask/ambiguous → block)
+  - list todo/urgent tasks carrying an engine assignee (or Managed Agents
+    consent tag) from the API
+  - for each unclaimed candidate: claim with `#agent-running`, preflight, route
+    (local → run on Gemma; claude → Managed Agents; ask/ambiguous → block)
   - on terminal outcomes, swap to the matching #agent-* status tag and
     notify via Telegram
 
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
 
 from api.services.agent_worker.completion_signal import has_positive_completion_signal
 from api.services.agent_worker.assignment import extract_assignment
+from api.services.agent_board import AGENT_ASSIGNEES as _BOARD_AGENT_ASSIGNEES
 from api.services.agent_worker.preflight import (
     ROUTE_ASK,
     ROUTE_CLAUDE,
@@ -387,12 +389,31 @@ BLOCKED_TAG = "agent-blocked"
 FAILED_TAG = "agent-failed"
 BUDGET_EXCEEDED_TAG = "agent-budget-exceeded"
 
+# Lifecycle claim / terminal tags — a task carrying any of these is already
+# mid-flight or finished and must not be re-claimed from the pickup list.
+_CLAIM_EXCLUSION_TAGS = frozenset({
+    RUNNING_TAG, BLOCKED_TAG, COMPLETED_TAG, FAILED_TAG, BUDGET_EXCEEDED_TAG,
+})
+
 # Task statuses that the worker will pick up for execution. `todo` is the
 # everyday-task default; `urgent` (Obsidian Tasks `[!]`) is for high-priority
 # items the operator wants run ahead of the queue — both should trigger the
-# agent if tagged `#agent`. The list API only accepts a single status per
-# request, so we fan out and dedupe.
+# agent if tagged `#agent` or an engine assignee. The list API only accepts a single
+# status (and a single tag) per request, so we fan out and dedupe.
 AGENT_PICKUP_STATUSES = ("todo", "urgent")
+
+# Tags that make a todo/urgent task eligible for claim: the legacy `#agent`
+# queue marker, every board engine assignee, plus Managed Agents consent tags
+# (not board assignees, but valid executors on scheduled / tagged work).
+# Board assignees are imported so the board vocabulary and pickup set cannot
+# drift. Bare `#agent` remains pickupable alongside engine/consent tags.
+_MANAGED_AGENTS_CONSENT_TAGS = ("cloud-haiku", "cloud-sonnet")
+AGENT_PICKUP_TAGS: tuple[str, ...] = (
+    (AGENT_TAG,) + tuple(_BOARD_AGENT_ASSIGNEES) + _MANAGED_AGENTS_CONSENT_TAGS
+)
+_AGENT_ASSIGNEE_SET = frozenset(_BOARD_AGENT_ASSIGNEES)
+_CONSENT_TAG_SET = frozenset(_MANAGED_AGENTS_CONSENT_TAGS)
+_PICKUP_TAG_SET = frozenset(AGENT_PICKUP_TAGS)
 
 # #760: best-effort WIP-branch discovery for an interrupted CLI session — a
 # regex over past tool_use transcript events, never a live `git` call.
@@ -662,15 +683,23 @@ class Worker:
             if session.parent_session_id:
                 recovered += 1
                 continue
-            self._swap_tag(session.task_id, RUNNING_TAG, AGENT_TAG)
-            # Rolling back to #agent — return the vault checkbox to "todo"
+            task_snapshot = self._fetch_task(session.task_id) or {}
+            tags_now = self._norm_task_tags(task_snapshot)
+            # Restore `#agent` only when that was the handoff (or no engine/consent
+            # tag remains). Engine-only and consent-only cards just drop running.
+            handoff = tags_now & (_AGENT_ASSIGNEE_SET | _CONSENT_TAG_SET)
+            if AGENT_TAG in tags_now or not handoff:
+                self._swap_tag(session.task_id, RUNNING_TAG, AGENT_TAG)
+            else:
+                self._remove_tag_if_present(session.task_id, RUNNING_TAG)
+            # Rolling back claim — return the vault checkbox to "todo"
             # so the operator sees the task as un-started rather than stuck
             # in "in_progress".
             self._set_task_status(session.task_id, "todo")
             self._notify(
                 f"⚠️ {_worker_label(session.routing)}: task left in {session.status!r} from a prior "
-                f"run could not be safely resumed — tag rolled back to "
-                f"#{AGENT_TAG} for retry. Transcript: "
+                f"run could not be safely resumed — removed #{RUNNING_TAG} for "
+                f"retry. Transcript: "
                 f"`data/agent_transcripts/{sid}.jsonl`"
             )
             recovered += 1
@@ -1314,7 +1343,7 @@ class Worker:
     def _timeout_stale_clarifications(self) -> None:
         """Send a one-time nudge for clarifications older than the configured
         timeout. The task stays at #agent-blocked permanently after that — the
-        operator can manually re-tag with #agent to retry.
+        operator can manually re-tag with an engine assignee to retry.
         """
         timeout_seconds = settings.agent_clarification_timeout_hours * 3600
         cutoff = int(time.time()) - timeout_seconds
@@ -1323,8 +1352,9 @@ class Worker:
             # Close every stale row, but only nudge for actual clarifications
             # (agent BLOCKED awaiting input). Completion follow-ups
             # (kind='followup', #234) are just replyable notifications; a
-            # "re-tag with #agent to retry" nudge is wrong for them. Marking
-            # them timed out also keeps stale follow-up rows from accumulating.
+            # "re-tag with an engine assignee to retry" nudge is wrong for
+            # them. Marking them timed out also keeps stale follow-up rows
+            # from accumulating.
             self.session_store.mark_question_timed_out(q["id"])
             if (q.get("kind") or "clarification") != "clarification":
                 continue
@@ -1337,7 +1367,8 @@ class Worker:
                 f"⏰ {label}: task is still waiting on your reply.\n\n"
                 f"Question: {q['question'][:300]}\n\n"
                 f"(Task remains at #{BLOCKED_TAG}. Reply to the original "
-                f"question to unblock, or re-tag with #{AGENT_TAG} to retry.)"
+                f"question to unblock, or re-tag with an engine assignee "
+                f"to retry.)"
             )
 
     def _process_human_queue(self) -> None:
@@ -1481,30 +1512,49 @@ class Worker:
     # ------------------------------------------------------------------
 
     def _list_agent_tasks(self) -> list[dict[str, Any]]:
-        """Fetch open `#agent` tasks from the API.
+        """Fetch open claimable tasks from the API.
 
-        The list endpoint only filters on a single status string, so we fan
-        out across `AGENT_PICKUP_STATUSES` (`todo` + `urgent` by default) and
-        dedupe by task id. A task that appears under both statuses in quick
-        succession is still claimed once.
+        Fans out across `AGENT_PICKUP_STATUSES` × `AGENT_PICKUP_TAGS`
+        (`todo`/`urgent` × every engine assignee / Managed Agents consent
+        tag) and dedupes by task id. A candidate must still carry a pickup
+        tag, and must not already have a lifecycle claim/terminal tag
+        (`agent-running`, `agent-blocked`, `agent-completed`,
+        `agent-failed`, `agent-budget-exceeded`) — engine-only tasks keep
+        their assignee tag after claim, so the tag fan-out alone would
+        otherwise re-list in-flight work.
         """
         seen: set[str] = set()
         all_tasks: list[dict[str, Any]] = []
         for status in AGENT_PICKUP_STATUSES:
-            try:
-                resp = self._http.get(
-                    f"{self.api_base}/api/tasks",
-                    params={"status": status, "tag": AGENT_TAG},
-                )
-                resp.raise_for_status()
-                for task in resp.json().get("tasks", []):
-                    tid = task.get("id")
-                    if tid and tid not in seen:
-                        seen.add(tid)
-                        all_tasks.append(task)
-            except Exception as exc:
-                logger.warning("failed to list agent tasks (status=%s): %s", status, exc)
-        return all_tasks
+            for tag in AGENT_PICKUP_TAGS:
+                try:
+                    resp = self._http.get(
+                        f"{self.api_base}/api/tasks",
+                        params={"status": status, "tag": tag},
+                    )
+                    resp.raise_for_status()
+                    for task in resp.json().get("tasks", []):
+                        tid = task.get("id")
+                        if tid and tid not in seen:
+                            seen.add(tid)
+                            all_tasks.append(task)
+                except Exception as exc:
+                    logger.warning(
+                        "failed to list agent tasks (status=%s, tag=%s): %s",
+                        status, tag, exc,
+                    )
+        candidates: list[dict[str, Any]] = []
+        for task in all_tasks:
+            tags = {str(t).lstrip("#").lower() for t in (task.get("tags") or [])}
+            if tags & _CLAIM_EXCLUSION_TAGS:
+                continue
+            if (
+                AGENT_TAG in tags
+                or tags & _AGENT_ASSIGNEE_SET
+                or tags & _CONSENT_TAG_SET
+            ):
+                candidates.append(task)
+        return candidates
 
     def _swap_tag(self, task_id: str, from_tag: str, to_tag: str) -> bool:
         try:
@@ -1517,6 +1567,37 @@ class Worker:
         except Exception as exc:
             logger.warning("swap_tag failed for %s: %s", task_id, exc)
             return False
+
+    def _claim_task(self, task_id: str) -> bool | None:
+        """Return whether the claim consumed `#agent`, or None if it lost."""
+        try:
+            resp = self._http.post(
+                f"{self.api_base}/api/tasks/{task_id}/claim-agent",
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+            if not payload.get("claimed"):
+                return None
+            return bool(payload.get("consumed_queue_tag"))
+        except Exception as exc:
+            logger.warning("claim_agent failed for %s: %s", task_id, exc)
+            return None
+
+    def _remove_tag_if_present(self, task_id: str, tag: str) -> bool:
+        try:
+            resp = self._http.post(
+                f"{self.api_base}/api/tasks/{task_id}/remove-tag",
+                params={"tag": tag},
+            )
+            resp.raise_for_status()
+            return bool(resp.json().get("ok"))
+        except Exception as exc:
+            logger.warning("remove_tag_if_present failed for %s: %s", task_id, exc)
+            return False
+
+    @staticmethod
+    def _norm_task_tags(task: dict[str, Any] | None) -> set[str]:
+        return {str(t).lstrip("#").lower() for t in ((task or {}).get("tags") or [])}
 
     def _complete_task(self, task_id: str) -> bool:
         try:
@@ -1710,16 +1791,16 @@ class Worker:
     # ------------------------------------------------------------------
 
     def _claim(self, task_id: str) -> bool:
-        """Atomically swap `#agent` → `#agent-running` and record the session.
+        """Atomically claim a pickup candidate and record the session.
+
+        Legacy `#agent` tasks: swap `#agent` → `#agent-running`.
+        Engine-only tasks (no `#agent`): atomically ADD `#agent-running`.
 
         Returns True iff this worker won the race.
         """
-        if not self._swap_tag(task_id, AGENT_TAG, RUNNING_TAG):
+        consumed_queue_tag = self._claim_task(task_id)
+        if consumed_queue_tag is None:
             return False
-        # Sync vault status to in_progress so the operator can see at a
-        # glance which tasks are actively being worked on, not just by
-        # tag color.
-        self._set_task_status(task_id, "in_progress")
         try:
             session = self.session_store.create(
                 task_id=task_id,
@@ -1732,12 +1813,12 @@ class Worker:
             )
             return True
         except Exception as exc:
-            # Already-claimed by a sibling worker, or DB hiccup. Try to un-do
-            # the tag swap so the task remains pickable.
             logger.error("session create failed for %s: %s", task_id, exc)
-            if not self._swap_tag(task_id, RUNNING_TAG, AGENT_TAG):
-                # Rollback failed — task is stuck at #agent-running. Notify so
-                # the operator can intervene before this silently strands work.
+            if consumed_queue_tag:
+                rolled_back = self._swap_tag(task_id, RUNNING_TAG, AGENT_TAG)
+            else:
+                rolled_back = self._remove_tag_if_present(task_id, RUNNING_TAG)
+            if not rolled_back:
                 self._notify(
                     f"⚠️ Agent worker: failed to claim task {task_id} and could "
                     f"not roll back tag. Task stuck at #{RUNNING_TAG} — please "
@@ -2694,7 +2775,7 @@ class Worker:
                     f"⏸ {_worker_label(ROUTE_REMOTE)}: task '{title}' routed to #cloud but the "
                     f"remote provider not configured — set LIFEOS_REMOTE_LLM_* "
                     f"(LIFEOS_REMOTE_LLM_URL, LIFEOS_REMOTE_LLM_MODEL, "
-                    f"LIFEOS_REMOTE_LLM_API_KEY) in .env, then retag with #{AGENT_TAG}."
+                    f"LIFEOS_REMOTE_LLM_API_KEY) in .env, then re-tag with an engine assignee to retry."
                 )
                 return
             executor = self._get_remote_executor(caller_session_id=session.session_id)
@@ -2721,7 +2802,7 @@ class Worker:
                     f"Managed Agents isn't configured. Set ANTHROPIC_API_KEY, "
                     f"LIFEOS_AGENT_PRESET_ID, and LIFEOS_AGENT_ENVIRONMENT_ID "
                     f"in .env (see docs/guides/agent-worker-setup.md for the "
-                    f"console flow), then retag with #{AGENT_TAG}."
+                    f"console flow), then re-tag with an engine assignee to retry."
                 )
                 return
             try:

--- a/tests/test_agent_worker_clarifications.py
+++ b/tests/test_agent_worker_clarifications.py
@@ -6,7 +6,7 @@ End-to-end:
   2. User replies (reply-threaded). The listener's deposit hook updates
      pending_questions.answer.
   3. Worker tick scans answered+unprocessed, injects the answer as a user
-     turn, swaps tag back to #agent-running, resumes the local executor.
+     turn, adds `#agent-running` if needed, resumes the local executor.
 
 Also covers `lifeos_agent_user_ask` (agent-initiated clarification) and the
 3-day timeout path.
@@ -24,6 +24,7 @@ from api.services.agent_worker.local_executor import ExecutorOutcome
 from api.services.agent_worker.session_store import (
     STATUS_BLOCKED,
     STATUS_BUDGET_EXCEEDED,
+    STATUS_CLAIMED,
     STATUS_COMPLETED,
     STATUS_FAILED,
     STATUS_RUNNING,
@@ -63,12 +64,45 @@ class FakeApi:
             tags[tags.index(f)] = to
             t["tags"] = tags
             return httpx.Response(200, json={"swapped": True})
+        if request.method == "POST" and path.endswith("/claim-agent"):
+            tid = path.split("/")[-2]
+            t = self.tasks.get(tid)
+            if not t:
+                return httpx.Response(200, json={"claimed": False})
+            tags = list(t.get("tags", []))
+            consumed = "agent" in tags
+            if consumed:
+                tags[tags.index("agent")] = "agent-running"
+            else:
+                tags.append("agent-running")
+            t["tags"] = tags
+            t["status"] = "in_progress"
+            return httpx.Response(200, json={"claimed": True, "consumed_queue_tag": consumed})
+        if request.method == "POST" and path.endswith("/remove-tag"):
+            tid = path.split("/")[-2]
+            tag = request.url.params.get("tag")
+            t = self.tasks.get(tid)
+            if not t or tag not in t.get("tags", []):
+                return httpx.Response(200, json={"ok": False})
+            tags = list(t["tags"])
+            tags.remove(tag)
+            t["tags"] = tags
+            return httpx.Response(200, json={"ok": True})
         if request.method == "PUT" and path.endswith("/complete"):
             tid = path.split("/")[-2]
             t = self.tasks.get(tid)
             if not t:
                 return httpx.Response(404)
             t["status"] = "done"
+            return httpx.Response(200, json=t)
+        if request.method == "PUT" and path.startswith("/api/tasks/"):
+            tid = path.split("/")[-1]
+            t = self.tasks.get(tid)
+            if not t:
+                return httpx.Response(404)
+            body = json.loads(request.content or b"{}")
+            for k, v in body.items():
+                t[k] = v
             return httpx.Response(200, json=t)
         if request.method == "GET" and "/api/tasks/" in path:
             tid = path.split("/")[-1]
@@ -158,7 +192,7 @@ def _local_ok_preflight():
 
 @pytest.mark.unit
 def test_ambiguous_task_sends_clarification_with_tracked_id(tmp_path: Path):
-    api = FakeApi([{"id": "t1", "description": "reply to John", "status": "todo", "tags": ["agent"]}])
+    api = FakeApi([{"id": "t1", "description": "reply to John", "status": "todo", "tags": ["local"]}])
     executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
     w = _make_worker(tmp_path, api, preflight_caller=_ambiguity_preflight(), local_executor=executor)
     w.tick()
@@ -182,7 +216,7 @@ def test_ambiguous_task_sends_clarification_with_tracked_id(tmp_path: Path):
 @pytest.mark.unit
 def test_reply_threaded_answer_resumes_blocked_session(tmp_path: Path):
     """End-to-end: ambiguous → answered → resumed → completed."""
-    api = FakeApi([{"id": "t1", "description": "reply to John", "status": "todo", "tags": ["agent"]}])
+    api = FakeApi([{"id": "t1", "description": "reply to John", "status": "todo", "tags": ["local"]}])
     # First call: returns "ambiguous". After resume, preflight isn't called
     # again — the executor handles the rest.
     executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="emailed Doe"))
@@ -233,7 +267,12 @@ def test_stale_answered_question_doesnt_redeposit(tmp_path: Path):
 
 @pytest.mark.unit
 def test_routing_ask_local_reply_routes_to_local_executor(tmp_path: Path):
-    """Routing-ask resume: user reply 'local' must run the local executor."""
+    """Routing-ask resume: user reply 'local' must run the local executor.
+
+    Ask-routing is only reachable without an engine assignee tag (those
+    force a route in preflight). Drive `_dispatch` on an already-claimed
+    card that carries only `#agent-running`.
+    """
 
     def routing_ask_preflight():
         import json
@@ -246,10 +285,12 @@ def test_routing_ask_local_reply_routes_to_local_executor(tmp_path: Path):
             })
         return _caller
 
-    api = FakeApi([{"id": "t1", "description": "research dolphins", "status": "todo", "tags": ["agent"]}])
+    api = FakeApi([{"id": "t1", "description": "research dolphins",
+                    "status": "in_progress", "tags": [RUNNING_TAG]}])
     executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="ok"))
     w = _make_worker(tmp_path, api, preflight_caller=routing_ask_preflight(), local_executor=executor)
-    w.tick()
+    w.session_store.create(task_id="t1", status=STATUS_CLAIMED)
+    w._dispatch(api.tasks["t1"])
 
     # Task is blocked, routing=ask.
     blocked = w.session_store.list_sessions(status=STATUS_BLOCKED)[0]
@@ -280,10 +321,12 @@ def test_routing_ask_unparseable_reply_reasks(tmp_path: Path):
             })
         return _caller
 
-    api = FakeApi([{"id": "t1", "description": "x", "status": "todo", "tags": ["agent"]}])
+    api = FakeApi([{"id": "t1", "description": "x", "status": "in_progress",
+                    "tags": [RUNNING_TAG]}])
     executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
     w = _make_worker(tmp_path, api, preflight_caller=routing_ask_preflight(), local_executor=executor)
-    w.tick()
+    w.session_store.create(task_id="t1", status=STATUS_CLAIMED)
+    w._dispatch(api.tasks["t1"])
 
     msg_id, _ = w._sent_with_ids[0]
     w.session_store.deposit_answer(msg_id, "yeah whatever you like")
@@ -492,7 +535,7 @@ def test_lifeos_agent_user_ask_fails_when_telegram_unavailable(tmp_path: Path):
 def test_failed_task_registers_followup_and_reply_resumes(tmp_path: Path):
     """A FAILED task's notification is replyable: replying resumes the session,
     swapping the failed tag back to running, and a clean completion follows."""
-    api = FakeApi([{"id": "t1", "description": "do the thing", "status": "todo", "tags": ["agent"]}])
+    api = FakeApi([{"id": "t1", "description": "do the thing", "status": "todo", "tags": ["local"]}])
     executor = _SequenceExecutor([
         ExecutorOutcome(status=STATUS_FAILED, reason="boom"),
         ExecutorOutcome(status=STATUS_COMPLETED, final_text="fixed it"),
@@ -520,7 +563,7 @@ def test_failed_task_registers_followup_and_reply_resumes(tmp_path: Path):
 @pytest.mark.unit
 def test_budget_exceeded_task_registers_followup(tmp_path: Path):
     """BUDGET_EXCEEDED notifications are replyable too."""
-    api = FakeApi([{"id": "t1", "description": "big job", "status": "todo", "tags": ["agent"]}])
+    api = FakeApi([{"id": "t1", "description": "big job", "status": "todo", "tags": ["local"]}])
     executor = _StubExecutor(ExecutorOutcome(status=STATUS_BUDGET_EXCEEDED, reason="out of budget"))
     w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
     w.tick()
@@ -538,7 +581,7 @@ def test_reply_to_non_first_chunk_matches_and_resumes(tmp_path: Path):
 
     Uses a long FAILED reason (the failure body isn't vault-spilled, so it
     actually exceeds one 4096-char chunk)."""
-    api = FakeApi([{"id": "t1", "description": "task", "status": "todo", "tags": ["agent"]}])
+    api = FakeApi([{"id": "t1", "description": "task", "status": "todo", "tags": ["local"]}])
     long_reason = "y" * 9000  # forces the notification body across 3 chunks
     executor = _SequenceExecutor([
         ExecutorOutcome(status=STATUS_FAILED, reason=long_reason),
@@ -668,7 +711,7 @@ def test_operator_session_dispatches_and_registers_followup(tmp_path: Path):
     completion registers a replyable follow-up (Phase 1)."""
     from api.services.agent_worker.operator_spawn import create_operator_session
 
-    api = FakeApi([])  # no #agent vault tasks
+    api = FakeApi([])  # no engine-assigned vault tasks
     executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="done"))
     w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
 
@@ -715,11 +758,11 @@ def test_operator_ask_resolution_dispatches_after_reply(tmp_path: Path):
 
 @pytest.mark.unit
 def test_operator_session_coexists_with_agent_task(tmp_path: Path):
-    """An operator spawn and a normal #agent task both run in the same tick
-    without interfering."""
+    """An operator spawn and a normal engine-assigned task both run in the
+    same tick without interfering."""
     from api.services.agent_worker.operator_spawn import create_operator_session
 
-    api = FakeApi([{"id": "t1", "description": "agent task", "status": "todo", "tags": ["agent"]}])
+    api = FakeApi([{"id": "t1", "description": "agent task", "status": "todo", "tags": ["local"]}])
     executor = _StubExecutor(ExecutorOutcome(status=STATUS_COMPLETED, final_text="done"))
     w = _make_worker(tmp_path, api, preflight_caller=_local_ok_preflight(), local_executor=executor)
 

--- a/tests/test_agent_worker_loop.py
+++ b/tests/test_agent_worker_loop.py
@@ -83,6 +83,36 @@ class FakeApi:
             task["tags"] = tags
             return httpx.Response(200, json={"swapped": True})
 
+        if request.method == "POST" and request.url.path.endswith("/claim-agent"):
+            task_id = request.url.path.split("/")[-2]
+            task = self.tasks.get(task_id)
+            if not task:
+                return httpx.Response(200, json={"claimed": False, "reason": "task not found"})
+            tags = list(task.get("tags", []))
+            pickup = {"agent", "claude", "codex", "hermes", "local", "cloud", "cloud-haiku", "cloud-sonnet"}
+            excluded = {"agent-running", "agent-blocked", "agent-completed", "agent-failed", "agent-budget-exceeded"}
+            if task.get("status") not in {"todo", "urgent"} or not pickup.intersection(tags) or excluded.intersection(tags):
+                return httpx.Response(200, json={"claimed": False, "reason": "task is no longer eligible"})
+            consumed = "agent" in tags
+            if consumed:
+                tags[tags.index("agent")] = "agent-running"
+            else:
+                tags.append("agent-running")
+            task["tags"] = tags
+            task["status"] = "in_progress"
+            return httpx.Response(200, json={"claimed": True, "consumed_queue_tag": consumed})
+
+        if request.method == "POST" and request.url.path.endswith("/remove-tag"):
+            task_id = request.url.path.split("/")[-2]
+            tag = request.url.params.get("tag")
+            task = self.tasks.get(task_id)
+            if not task or tag not in task.get("tags", []):
+                return httpx.Response(200, json={"ok": False, "reason": "tag not present"})
+            tags = list(task["tags"])
+            tags.remove(tag)
+            task["tags"] = tags
+            return httpx.Response(200, json={"ok": True})
+
         if request.method == "PUT" and request.url.path.endswith("/complete"):
             task_id = request.url.path.split("/")[-2]
             task = self.tasks.get(task_id)
@@ -111,6 +141,15 @@ class FakeApi:
             return httpx.Response(200, json=task)
 
         return httpx.Response(404)
+
+
+@pytest.fixture(autouse=True)
+def _clear_agent_default_route(monkeypatch):
+    """Host `.env` can set LIFEOS_AGENT_DEFAULT_ROUTE; that demotes
+    ambiguity/non-fatal sanity and would make "must block" tests flaky.
+    Tests that need a default route monkeypatch it back on explicitly."""
+    from config.settings import settings as _settings
+    monkeypatch.setattr(_settings, "agent_default_route", "")
 
 
 def _make_worker(tmp_path: Path, api: FakeApi, *, preflight_caller, local_executor,
@@ -188,8 +227,8 @@ def test_worker_picks_up_urgent_status_tasks_too(tmp_path: Path):
     the urgent status signals high-priority work the operator wants run
     sooner, not 'skip the agent.'"""
     api = FakeApi(tasks=[
-        {"id": "t-todo",   "description": "ordinary task",  "status": "todo",   "tags": ["agent", "local"]},
-        {"id": "t-urgent", "description": "urgent task",    "status": "urgent", "tags": ["agent", "local"]},
+        {"id": "t-todo",   "description": "ordinary task",  "status": "todo",   "tags": ["local"]},
+        {"id": "t-urgent", "description": "urgent task",    "status": "urgent", "tags": ["local"]},
         {"id": "t-other",  "description": "irrelevant",     "status": "todo",   "tags": ["other"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="done"))
@@ -228,7 +267,7 @@ def test_worker_dedups_when_task_appears_under_both_statuses(tmp_path: Path):
             return super().handler(request)
 
     api = _DupeApi(tasks=[
-        {"id": "t1", "description": "dup", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "dup", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="ok"))
     w = _make_worker(tmp_path, api,
@@ -241,7 +280,7 @@ def test_worker_dedups_when_task_appears_under_both_statuses(tmp_path: Path):
 @pytest.mark.unit
 def test_dispatch_local_completes_and_marks_task_done(tmp_path: Path):
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "hello there", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "hello there", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="hi back"))
     w = _make_worker(tmp_path, api,
@@ -262,7 +301,7 @@ def test_dispatch_local_completes_and_marks_task_done(tmp_path: Path):
 @pytest.mark.unit
 def test_ambiguous_title_lands_in_blocked(tmp_path: Path):
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "reply to John", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "reply to John", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="should not run"))
     preflight = _golden_preflight(
@@ -286,13 +325,18 @@ def test_ambiguous_title_lands_in_blocked(tmp_path: Path):
 
 @pytest.mark.unit
 def test_routing_ask_lands_in_blocked_with_model_question(tmp_path: Path):
+    """Ask-routing is only reachable without an engine assignee tag (those
+    force a route in preflight). Drive `_dispatch` on an already-claimed
+    card that carries only `#agent-running`."""
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "research dolphins", "status": "todo", "tags": ["agent"]},
+        {"id": "t1", "description": "research dolphins", "status": "in_progress",
+         "tags": [RUNNING_TAG]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
     preflight = _golden_preflight(routing="ask")
     w = _make_worker(tmp_path, api, preflight_caller=preflight, local_executor=executor)
-    w.tick()
+    w.session_store.create(task_id="t1", status=STATUS_CLAIMED)
+    w._dispatch(api.tasks["t1"])
 
     assert executor.calls == []
     assert BLOCKED_TAG in api.tasks["t1"]["tags"]
@@ -332,7 +376,7 @@ def test_insane_task_lands_in_failed(tmp_path: Path):
     """A deterministically destructive title (matched by the code, not the
     model's prose) still fails closed — #747 must not weaken this guard."""
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "rm -rf /", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "rm -rf /", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
     preflight = _golden_preflight(routing="local", sane=False, sane_reason="destructive")
@@ -352,7 +396,7 @@ def test_mundane_sane_false_task_lands_in_blocked_not_cancelled(tmp_path: Path):
     api = FakeApi(tasks=[
         {"id": "t1",
          "description": "Display the transcribed message immediately after sending",
-         "status": "todo", "tags": ["agent", "local"]},
+         "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="should not run"))
     preflight = _golden_preflight(
@@ -378,7 +422,7 @@ def test_sane_false_and_ambiguous_blocked_messages_are_distinguishable(tmp_path:
     ambiguity must produce distinguishable operator-facing text, not one
     generic 'blocked' string."""
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "reply to John", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "reply to John", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="should not run"))
     preflight = _golden_preflight(
@@ -403,7 +447,7 @@ def test_routing_flavored_ambiguity_does_not_block(tmp_path: Path):
     not block the task — routing decides."""
     api = FakeApi(tasks=[
         {"id": "t1", "description": "Turn the record button white when idle",
-         "status": "todo", "tags": ["agent", "local"]},
+         "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="ran"))
     preflight = _golden_preflight(
@@ -433,7 +477,7 @@ def test_default_route_demotes_ambiguity_and_runs(tmp_path: Path, monkeypatch):
     from config.settings import settings as _settings
     monkeypatch.setattr(_settings, "agent_default_route", "local")
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "reply to John", "status": "todo", "tags": ["agent"]},
+        {"id": "t1", "description": "reply to John", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="replied"))
     preflight = _golden_preflight(
@@ -459,7 +503,7 @@ def test_default_route_does_not_rescue_fatal_sanity(tmp_path: Path, monkeypatch)
     from config.settings import settings as _settings
     monkeypatch.setattr(_settings, "agent_default_route", "local")
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "rm -rf /", "status": "todo", "tags": ["agent"]},
+        {"id": "t1", "description": "rm -rf /", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
     preflight = _golden_preflight(routing="local", sane=False, sane_reason="destructive")
@@ -488,7 +532,7 @@ def test_default_route_demotes_nonfatal_sanity_and_runs(tmp_path: Path, monkeypa
     monkeypatch.setattr(_settings, "agent_default_route", "local")
     api = FakeApi(tasks=[
         {"id": "t1", "description": "Display the transcribed message immediately after sending",
-         "status": "todo", "tags": ["agent"]},
+         "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="ran"))
     sane_reason = "This is a product specification or feature request, not a task an agent can execute."
@@ -527,7 +571,7 @@ def test_default_route_demotes_second_field_verdict_sanity_and_runs(tmp_path: Pa
         {"id": "t1",
          "description": "Bring the macOS setup script's service catalog up to parity "
                          "with Linux for the agent worker and MCP-HTTP bridge",
-         "status": "todo", "tags": ["agent"]},
+         "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="ran"))
     sane_reason = "This is a product specification or feature request, not a task an agent can execute."
@@ -552,7 +596,7 @@ def test_no_default_route_nonfatal_sanity_still_parks(tmp_path: Path, monkeypatc
     monkeypatch.setattr(_settings, "agent_default_route", "")
     api = FakeApi(tasks=[
         {"id": "t1", "description": "Display the transcribed message immediately after sending",
-         "status": "todo", "tags": ["agent", "local"]},
+         "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text="should not run"))
     sane_reason = "This is a product specification or feature request, not a task an agent can execute."
@@ -572,7 +616,7 @@ def test_no_default_route_nonfatal_sanity_still_parks(tmp_path: Path, monkeypatc
 @pytest.mark.unit
 def test_executor_budget_exceeded_sets_budget_exceeded_tag(tmp_path: Path):
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "long task", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "long task", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_BUDGET_EXCEEDED, reason="budget exceeded (max_tokens)",
@@ -600,7 +644,7 @@ def test_claude_routing_without_managed_credentials_blocks(tmp_path: Path, monke
         # `#cloud-sonnet` is the operator asking for the API route explicitly;
         # without it an inferred cloud route would park at `ask` instead (#584).
         {"id": "t1", "description": "summarize", "status": "todo",
-         "tags": ["agent", "cloud-sonnet"]},
+         "tags": ["cloud-sonnet"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
     preflight = _golden_preflight(routing="claude")
@@ -625,7 +669,7 @@ def test_cloud_tag_routes_to_remote_provider_when_configured(tmp_path: Path, mon
     monkeypatch.setattr(_settings, "remote_llm_api_key", "test-fireworks-key", raising=False)
     api = FakeApi(tasks=[
         {"id": "t1", "description": "summarize", "status": "todo",
-         "tags": ["agent", "cloud"]},
+         "tags": ["cloud"]},
     ])
     remote_executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_COMPLETED, final_text="done", served_by="accounts/fireworks/models/deepseek-v3",
@@ -655,7 +699,7 @@ def test_cloud_tag_parks_when_remote_provider_unconfigured(tmp_path: Path, monke
     monkeypatch.setattr(_settings, "remote_llm_api_key", "", raising=False)
     api = FakeApi(tasks=[
         {"id": "t1", "description": "summarize", "status": "todo",
-         "tags": ["agent", "cloud"]},
+         "tags": ["cloud"]},
     ])
     local_executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
     remote_executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
@@ -679,7 +723,7 @@ def test_claude_routing_with_managed_executor_starts_and_polls(tmp_path: Path):
     subsequent ticks until terminal."""
     api = FakeApi(tasks=[
         {"id": "t1", "description": "summarize my inbox", "status": "todo",
-         "tags": ["agent", "cloud-sonnet"]},
+         "tags": ["cloud-sonnet"]},
     ])
 
     class _StubManagedExecutor:
@@ -753,7 +797,7 @@ def test_completion_summary_uses_transcript_pointer_when_final_text_empty(tmp_pa
     transcript pointer instead of an empty body so the operator can inspect
     what actually happened."""
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "do the thing", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "do the thing", "status": "todo", "tags": ["local"]},
     ])
     # final_text="" simulates the empty-text path.
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
@@ -801,7 +845,7 @@ def test_completion_summary_renders_four_bucket_breakdown(tmp_path: Path):
     that #137 actually landed."""
     api = FakeApi(tasks=[
         {"id": "t1", "description": "draft email", "status": "todo",
-         "tags": ["agent", "cloud-sonnet"]},
+         "tags": ["cloud-sonnet"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_COMPLETED, final_text="Drafted.",
@@ -875,7 +919,7 @@ def test_completion_summary_includes_init_failed_mcps_footer(tmp_path: Path):
     the completion summary appends a "Note: N MCP server(s) unavailable"
     footer so the operator can fix or remove the broken connectors."""
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "summarize my calendar", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "summarize my calendar", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_COMPLETED,
@@ -902,7 +946,7 @@ def test_completion_summary_includes_init_failed_mcps_footer(tmp_path: Path):
 def test_completion_summary_omits_footer_when_no_init_failures(tmp_path: Path):
     """No footer noise when all MCPs initialized cleanly."""
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "answer the question", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "answer the question", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_COMPLETED, final_text="42.", init_failed_mcps=[],
@@ -1143,7 +1187,7 @@ def test_recovery_skips_json_tool_results_and_summarizes_tool_calls(tmp_path: Pa
 
     api = FakeApi(tasks=[
         {"id": "t1", "description": "compare gmail vs slack",
-         "status": "todo", "tags": ["agent", "local"]},
+         "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_COMPLETED, final_text="",
@@ -1184,7 +1228,7 @@ def test_recovery_inlines_short_text_tool_result(tmp_path: Path):
     from api.services.agent_worker.transcript_store import TranscriptStore as _TS
     api = FakeApi(tasks=[
         {"id": "t1", "description": "draft", "status": "todo",
-         "tags": ["agent", "local"]},
+         "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_COMPLETED, final_text="",
@@ -1406,7 +1450,7 @@ def test_followup_reply_reopens_completed_session_and_reruns_with_new_turn(tmp_p
     still refers to the prior assistant turn), and re-runs the executor."""
     api = FakeApi(tasks=[
         {"id": "t1", "description": "summarize X", "status": "todo",
-         "tags": ["agent", "local"]},
+         "tags": ["local"]},
     ])
     # Two executor invocations — first completes, second handles the followup.
     class _TwoStepExecutor:
@@ -1472,7 +1516,7 @@ def test_empty_final_text_surfaces_last_tool_result_from_transcript(tmp_path: Pa
 
     api = FakeApi(tasks=[
         {"id": "t1", "description": "draft email", "status": "todo",
-         "tags": ["agent", "local"]},
+         "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_COMPLETED, final_text="",
@@ -1525,7 +1569,7 @@ def test_empty_final_text_without_side_effect_marks_failed(tmp_path: Path):
     #agent-failed."""
     api = FakeApi(tasks=[
         {"id": "t1", "description": "research thing", "status": "todo",
-         "tags": ["agent", "local"]},
+         "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_COMPLETED, final_text="",
@@ -1552,7 +1596,7 @@ def test_empty_final_text_with_high_spend_skips_failure_guard(tmp_path: Path):
     this gap; this guard handles the residual lag."""
     api = FakeApi(tasks=[
         {"id": "t1", "description": "expensive research", "status": "todo",
-         "tags": ["agent", "running"]},
+         "tags": ["running"]},
     ])
     api.tasks["t1"]["tags"] = ["agent-running"]
 
@@ -1593,7 +1637,7 @@ def test_empty_final_text_with_side_effect_tool_still_marks_completed(tmp_path: 
     """
     api = FakeApi(tasks=[
         {"id": "t1", "description": "draft an email", "status": "todo",
-         "tags": ["agent", "running"]},  # already #agent-running for the swap
+         "tags": ["running"]},  # already #agent-running for the swap
     ])
     # Manually flip the running tag — handle_outcome's success path swaps
     # RUNNING_TAG → COMPLETED_TAG, so the running tag must be present.
@@ -1623,13 +1667,14 @@ def test_empty_final_text_with_side_effect_tool_still_marks_completed(tmp_path: 
 
 
 @pytest.mark.unit
+
 def test_claim_sets_vault_status_to_in_progress(tmp_path: Path):
-    """When the worker claims a task (swap #agent → #agent-running), the
+    """When the worker claims a task (adds #agent-running), the
     vault checkbox status must also flip to "in_progress" so the operator
     can see at a glance which tasks are actively being worked on."""
     api = FakeApi(tasks=[
         {"id": "t1", "description": "do thing", "status": "todo",
-         "tags": ["agent", "local"]},
+         "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_COMPLETED, final_text="done",
@@ -1646,12 +1691,98 @@ def test_claim_sets_vault_status_to_in_progress(tmp_path: Path):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("engine", ["hermes", "cloud", "local", "claude", "codex"])
+def test_list_and_claim_engine_only_without_agent_tag(tmp_path: Path, engine: str):
+    """Engine assignee alone is the handoff — list + claim without `#agent`."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "engine only", "status": "todo",
+         "tags": [engine]},
+        {"id": "t-me", "description": "human only", "status": "todo",
+         "tags": ["me"]},
+        {"id": "t-done", "description": "already claimed", "status": "todo",
+         "tags": [engine, RUNNING_TAG]},
+    ])
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=_StubExecutor(outcome=ExecutorOutcome(
+                         status=STATUS_COMPLETED, final_text="done",
+                     )))
+    listed = w._list_agent_tasks()
+    ids = {t["id"] for t in listed}
+    assert ids == {"t1"}
+    assert w._claim("t1") is True
+    assert RUNNING_TAG in api.tasks["t1"]["tags"]
+    assert engine in api.tasks["t1"]["tags"]
+    assert AGENT_TAG not in api.tasks["t1"]["tags"]
+    assert api.tasks["t1"]["status"] == "in_progress"
+    # Second claim loses the race (running already present)
+    assert w._claim("t1") is False
+
+
+
+@pytest.mark.unit
+def test_list_and_claim_bare_agent_still_works(tmp_path: Path):
+    """Legacy dual claim: bare `#agent` remains pickupable."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "legacy queue", "status": "todo",
+         "tags": ["agent"]},
+    ])
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=_StubExecutor(outcome=ExecutorOutcome(
+                         status=STATUS_COMPLETED, final_text="done",
+                     )))
+    listed = w._list_agent_tasks()
+    assert [t["id"] for t in listed] == ["t1"]
+    assert w._claim("t1") is True
+    assert RUNNING_TAG in api.tasks["t1"]["tags"]
+    assert AGENT_TAG not in api.tasks["t1"]["tags"]
+
+
+
+@pytest.mark.unit
+def test_me_alone_is_not_listed_for_claim(tmp_path: Path):
+    api = FakeApi(tasks=[
+        {"id": "t-me", "description": "human only", "status": "todo",
+         "tags": ["me"]},
+    ])
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="local"),
+                     local_executor=_StubExecutor(outcome=ExecutorOutcome(
+                         status=STATUS_COMPLETED, final_text="done",
+                     )))
+    assert w._list_agent_tasks() == []
+
+
+@pytest.mark.unit
+def test_resume_pending_engine_only_does_not_inject_agent(tmp_path: Path):
+    """Crash recovery on an engine-only claim drops `#agent-running` without
+    leaving the engine assignee."""
+    api = FakeApi(tasks=[
+        {"id": "t1", "description": "hermes only", "status": "in_progress",
+         "tags": ["hermes", RUNNING_TAG]},
+    ])
+    w = _make_worker(tmp_path, api,
+                     preflight_caller=_golden_preflight(routing="hermes"),
+                     local_executor=None)
+    w.session_store.create(task_id="t1", routing="hermes", status=STATUS_RUNNING)
+
+    n = w.resume_pending()
+
+    assert n == 1
+    assert AGENT_TAG not in api.tasks["t1"]["tags"]
+    assert RUNNING_TAG not in api.tasks["t1"]["tags"]
+    assert "hermes" in api.tasks["t1"]["tags"]
+    assert api.tasks["t1"]["status"] == "todo"
+
+
+@pytest.mark.unit
 def test_budget_exceeded_sets_vault_status_to_cancelled(tmp_path: Path):
     """Terminal non-success states (budget_exceeded, failed) flip the vault
     checkbox to "cancelled" rather than leaving it stranded at "in_progress"."""
     api = FakeApi(tasks=[
         {"id": "t1", "description": "expensive task", "status": "todo",
-         "tags": ["agent", "local"]},
+         "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_BUDGET_EXCEEDED, reason="max_tokens",
@@ -1714,7 +1845,7 @@ def test_completion_label_says_local_for_local_routing(tmp_path: Path):
     """Operator wants to know at a glance whether a result came from local
     Gemma or cloud Claude — the worker label is route-aware."""
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "task", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "task", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_COMPLETED, final_text="done",
@@ -1736,7 +1867,7 @@ def test_completion_label_reports_remote_fallback_model_when_served_by_set(tmp_p
     served the session, not just the static "local" route label — #658's
     report-observed-not-configured principle applied to this new path."""
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "task", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "task", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_COMPLETED, final_text="done",
@@ -1758,7 +1889,7 @@ def test_completion_inline_summary_kept_when_under_cap(tmp_path: Path):
     every completion now also lands a note in the vault — so the message carries
     the full body plus a 'Saved to vault' pointer + obsidian:// link."""
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "summarize", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "summarize", "status": "todo", "tags": ["local"]},
     ])
     # Just under the 2000-char inline cap
     short_text = "Here is the answer. " * 50  # 1000 chars
@@ -1786,7 +1917,7 @@ def test_failed_task_writes_no_agent_output(tmp_path: Path):
     from config.settings import settings as _settings
 
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "do the thing", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "do the thing", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_FAILED, reason="boom"))
     w = _make_worker(tmp_path, api,
@@ -1814,7 +1945,7 @@ def test_completion_spills_to_vault_when_over_cap(tmp_path: Path, monkeypatch):
     # the over-cap spillover via _StubExecutor on the local path.
     api = FakeApi(tasks=[
         {"id": "t1", "description": "Big report on Julia",
-         "status": "todo", "tags": ["agent", "local"]},
+         "status": "todo", "tags": ["local"]},
     ])
     long_text = (
         "Julia Barnes is the CEO of The Movement Cooperative.\n\n"
@@ -1860,7 +1991,7 @@ def test_completion_falls_back_to_truncation_when_vault_unset(tmp_path: Path, mo
 
     api = FakeApi(tasks=[
         {"id": "t1", "description": "report", "status": "todo",
-         "tags": ["agent", "local"]},
+         "tags": ["local"]},
     ])
     long_text = "X" * 3000
     executor = _StubExecutor(outcome=ExecutorOutcome(
@@ -1954,7 +2085,7 @@ def test_managed_executor_omits_vault_ids_when_vault_unset(tmp_path: Path, monke
 @pytest.mark.unit
 def test_sleep_yield_does_not_mark_terminal(tmp_path: Path):
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "wait for it", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "wait for it", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(
         status=STATUS_YIELDED, wake_at=99999999999,  # far future
@@ -1977,7 +2108,7 @@ def test_sleep_yield_does_not_mark_terminal(tmp_path: Path):
 @pytest.mark.unit
 def test_worker_skips_already_claimed_tasks(tmp_path: Path):
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "hi", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "hi", "status": "todo", "tags": ["local"]},
     ])
     executor = _StubExecutor(outcome=ExecutorOutcome(status=STATUS_COMPLETED, final_text=""))
     w = _make_worker(tmp_path, api,
@@ -1985,7 +2116,7 @@ def test_worker_skips_already_claimed_tasks(tmp_path: Path):
                      local_executor=executor)
     w.tick()
     # Re-tag back to #agent and verify the worker doesn't claim it again.
-    api.tasks["t1"]["tags"] = ["agent", "local"]
+    api.tasks["t1"]["tags"] = ["local"]
     api.tasks["t1"]["status"] = "todo"
     assert w.tick() == 0
     # Executor was called exactly once across both ticks.
@@ -1995,7 +2126,7 @@ def test_worker_skips_already_claimed_tasks(tmp_path: Path):
 @pytest.mark.unit
 def test_worker_pauses_at_daily_cap(tmp_path: Path):
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "x", "status": "todo", "tags": ["agent", "local"]},
+        {"id": "t1", "description": "x", "status": "todo", "tags": ["local"]},
     ])
     transport = httpx.MockTransport(api.handler)
     client = httpx.Client(transport=transport, base_url="http://api")
@@ -2067,7 +2198,7 @@ def test_top_level_cli_task_dispatched_off_tick_not_inline(tmp_path: Path):
             return ExecutorOutcome(status=STATUS_COMPLETED, final_text="all done", notifications_sent=1)
 
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "do the thing", "status": "todo", "tags": ["agent"]},
+        {"id": "t1", "description": "do the thing", "status": "todo", "tags": ["claude"]},
     ])
     pool = _CapturingPool()
     w = _make_worker(tmp_path, api,
@@ -2119,8 +2250,8 @@ def test_second_cli_task_claimed_and_runs_while_first_blocks(tmp_path: Path):
                 status=STATUS_COMPLETED, final_text="fast done", notifications_sent=1)
 
     api = FakeApi(tasks=[
-        {"id": "t-slow", "description": "slow task", "status": "todo", "tags": ["agent"]},
-        {"id": "t-fast", "description": "fast task", "status": "todo", "tags": ["agent"]},
+        {"id": "t-slow", "description": "slow task", "status": "todo", "tags": ["claude"]},
+        {"id": "t-fast", "description": "fast task", "status": "todo", "tags": ["claude"]},
     ])
     w = _make_worker(tmp_path, api,
                      preflight_caller=_golden_preflight(routing="claude_code"),
@@ -2166,7 +2297,7 @@ def test_clarification_processing_continues_while_cli_task_blocks(tmp_path: Path
             return ExecutorOutcome(status=STATUS_COMPLETED, final_text="slow done")
 
     api = FakeApi(tasks=[
-        {"id": "t-slow", "description": "slow task", "status": "todo", "tags": ["agent"]},
+        {"id": "t-slow", "description": "slow task", "status": "todo", "tags": ["claude"]},
         {"id": "t-other", "description": "other task", "status": "blocked",
          "tags": [BLOCKED_TAG, "local"]},
     ])
@@ -2218,7 +2349,7 @@ def test_cli_inflight_guard_covers_top_level_dispatch(tmp_path: Path):
             return ExecutorOutcome(status=STATUS_COMPLETED, final_text="done")
 
     api = FakeApi(tasks=[
-        {"id": "t1", "description": "do the thing", "status": "todo", "tags": ["agent"]},
+        {"id": "t1", "description": "do the thing", "status": "todo", "tags": ["claude"]},
     ])
     pool = _CapturingPool()  # never runs -> the session stays "in flight"
     w = _make_worker(tmp_path, api,
@@ -2238,10 +2369,7 @@ def test_cli_inflight_guard_covers_top_level_dispatch(tmp_path: Path):
 
 @pytest.mark.unit
 def test_resume_pending_rolls_back_top_level_cli_session_same_as_before(tmp_path: Path):
-    """(#753) resume_pending()'s startup-recovery semantics for a top-level
-    claude_code/codex #agent session are unchanged by routing dispatch
-    through the pool — a crash-time CLAIMED/RUNNING session still rolls back
-    to #agent for retry, exactly as before this fix."""
+    """Crash-time CLAIMED/RUNNING with no engine assignee restores `#agent`."""
     api = FakeApi(tasks=[
         {"id": "t1", "description": "do the thing", "status": "in_progress",
          "tags": [RUNNING_TAG]},

--- a/tests/test_agent_worker_preflight.py
+++ b/tests/test_agent_worker_preflight.py
@@ -785,8 +785,15 @@ def test_default_llm_caller_uses_anthropic_when_key_set_no_probe(monkeypatch):
     from config.settings import settings
     from api.services.llm_client import AnthropicLLMClient, LocalLLMClient
 
+    # Host .env may force LIFEOS_AGENT_PREFLIGHT_ENGINE=remote; pin auto so
+    # this exercises the Anthropic-first default-caller path.
+    monkeypatch.setattr(settings, "agent_preflight_engine", "auto", raising=False)
     monkeypatch.setattr(settings, "anthropic_api_key", "test-anthropic-key", raising=False)
     monkeypatch.setattr(settings, "agent_preflight_model", "claude-haiku-4-5", raising=False)
+    monkeypatch.setattr(settings, "agent_remote_executor", False, raising=False)
+    monkeypatch.setattr(settings, "remote_llm_base_url", "", raising=False)
+    monkeypatch.setattr(settings, "remote_llm_model", "", raising=False)
+    monkeypatch.setattr(settings, "remote_llm_api_key", "", raising=False)
 
     captured = {}
 
@@ -823,6 +830,7 @@ def test_default_llm_caller_falls_back_to_local_when_reachable(monkeypatch):
     from config.settings import settings
     from api.services.llm_client import LocalLLMClient
 
+    monkeypatch.setattr(settings, "agent_preflight_engine", "auto", raising=False)
     monkeypatch.setattr(settings, "anthropic_api_key", "", raising=False)
     monkeypatch.setattr(settings, "agent_remote_executor", False, raising=False)
     monkeypatch.setattr(settings, "remote_llm_base_url", "", raising=False)

--- a/tests/test_agent_worker_self_restart.py
+++ b/tests/test_agent_worker_self_restart.py
@@ -68,6 +68,30 @@ class _FakeApi:
             tags[tags.index(from_tag)] = to_tag
             task["tags"] = tags
             return httpx.Response(200, json={"swapped": True})
+        if request.method == "POST" and path.endswith("/claim-agent"):
+            task_id = path.split("/")[-2]
+            task = self.tasks.get(task_id)
+            if not task:
+                return httpx.Response(200, json={"claimed": False, "reason": "task not found"})
+            tags = list(task.get("tags", []))
+            consumed = "agent" in tags
+            if consumed:
+                tags[tags.index("agent")] = "agent-running"
+            else:
+                tags.append("agent-running")
+            task["tags"] = tags
+            task["status"] = "in_progress"
+            return httpx.Response(200, json={"claimed": True, "consumed_queue_tag": consumed})
+        if request.method == "POST" and path.endswith("/remove-tag"):
+            task_id = path.split("/")[-2]
+            tag = request.url.params.get("tag")
+            task = self.tasks.get(task_id)
+            if not task or tag not in task.get("tags", []):
+                return httpx.Response(200, json={"ok": False, "reason": "tag not present"})
+            tags = list(task["tags"])
+            tags.remove(tag)
+            task["tags"] = tags
+            return httpx.Response(200, json={"ok": True})
         if request.method == "PUT" and path.endswith("/complete"):
             task_id = path.split("/")[-2]
             task = self.tasks.get(task_id)
@@ -157,7 +181,7 @@ def test_resume_pending_self_restart_finalizes_quietly(tmp_path: Path):
     assert w._sent_telegram == [], f"expected no rollback notice; got {w._sent_telegram}"
     refreshed = w.session_store.get("doctor_task")
     assert refreshed.status == STATUS_COMPLETED
-    # Tag advanced to completed, NOT rolled back to #agent.
+    # Tag advanced to completed; engine consent tag remains.
     assert COMPLETED_TAG in api.tasks["doctor_task"]["tags"]
     assert AGENT_TAG not in api.tasks["doctor_task"]["tags"]
     # Vault checkbox advanced to done ([x]) too — not left stuck at in_progress
@@ -212,7 +236,11 @@ def test_resume_pending_without_marker_still_rolls_back(tmp_path: Path):
     assert n == 1
     assert len(w._sent_telegram) == 1
     assert "could not be safely resumed" in w._sent_telegram[0]
-    assert AGENT_TAG in api.tasks["crashed_task"]["tags"]
+    assert AGENT_TAG not in api.tasks["crashed_task"]["tags"]
+    assert RUNNING_TAG not in api.tasks["crashed_task"]["tags"]
+    assert "cloud-sonnet" in api.tasks["crashed_task"]["tags"]
+    assert RUNNING_TAG not in api.tasks["crashed_task"]["tags"]
+    assert "cloud-sonnet" in api.tasks["crashed_task"]["tags"]
     kinds = [e["kind"] for e in w.transcript_store.read(session.session_id)]
     assert "resume_failed" in kinds
 

--- a/tests/test_me_family_aggregates_oracle.py
+++ b/tests/test_me_family_aggregates_oracle.py
@@ -33,6 +33,7 @@ that.
 import uuid
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
 
@@ -563,12 +564,30 @@ def _as_set(dict_list):
 
 
 @pytest.fixture
-def stores(tmp_path):
+def stores(tmp_path, monkeypatch):
     interaction_db = str(tmp_path / "interactions.db")
     person_db = str(tmp_path / "crm.db")
     istore = InteractionStore(interaction_db, strict=False)
     pstore = PersonEntityStore(person_db)
     pstore._blocklist.clear()
+    # Oracle expects no tracked relationships (no committed family_members.json).
+    # A developer machine with a local gitignored copy would otherwise leak
+    # Parent/Coparent rows into every Me-interactions assertion.
+    family_cfg = (
+        Path(__file__).resolve().parents[1] / "config" / "family_members.json"
+    )
+    real_exists = Path.exists
+
+    def _exists(self):
+        try:
+            if self.resolve() == family_cfg.resolve():
+                return False
+        except Exception:
+            if str(self) == str(family_cfg):
+                return False
+        return real_exists(self)
+
+    monkeypatch.setattr(Path, "exists", _exists)
     return istore, pstore
 
 

--- a/tests/test_route_handlers_concurrency.py
+++ b/tests/test_route_handlers_concurrency.py
@@ -69,7 +69,12 @@ def _assert_fast_request_not_blocked(client, *, slow_request):
         elapsed = time.time() - start
 
         for future in slow_futures:
-            slow_response = future.result(timeout=SLEEP_SECONDS + 5)
+            # Under a saturated host (full xdist suite + other agents), the
+            # TestClient threadpool can take longer than the sleep itself to
+            # schedule all four slow handlers — wait generously for them to
+            # finish so this assertion stays about the *fast* request bound
+            # below, not about scheduler latency for the slow ones.
+            slow_response = future.result(timeout=SLEEP_SECONDS + 60)
             assert slow_response.status_code == 200
 
     assert fast_response.status_code == 200


### PR DESCRIPTION
## Summary
- discover todo and urgent tasks by engine assignee, Managed Agents consent tag, or legacy #agent
- atomically claim engine-only tasks through the eligibility-checked claim route
- preserve the legacy queue marker during rollback and restart recovery
- dispatch cloud assignments to the remote provider without fallback when unconfigured

## Tests
- focused worker routing and claim tests passed
- pre-push unit gate: 7,453 passed, 9 skipped
- pre-push browser gate: 689 passed

Part of #969.