### PR TITLE
docs: describe the two-file Pebble archive layout

### DIFF
--- a/docs/guides/pebble-capture.md
+++ b/docs/guides/pebble-capture.md
@@ -1,14 +1,16 @@
 # Pebble Capture Filing
 
 **Status:** Complete
-**Last Updated:** 2026-09-09
+**Last Updated:** 2026-09-10
 **Audience:** Operators
 
-Pebble owns `LifeOS/Log/Pebble/YYYY-MM-DD.md`. LifeOS reads its framed result
-records and never rewrites the archive, transcripts, or Pebble's private
-SQLite/audio spool. Only a complete v1 `result` frame with `status: ready` is
-eligible for filing; partial, invalid, uncertain, pending, and failed records
-remain evidence only.
+Pebble owns `LifeOS/Log/Pebble`, where each recording day is two files:
+`YYYY-MM-DD-raw.md` holds the framed records and `YYYY-MM-DD.md` holds Pebble's
+readable digest of them. LifeOS reads framed result records from that directory
+and never rewrites the archive, transcripts, or Pebble's private SQLite/audio
+spool. The digest carries no frames, so scanning it produces no effects. Only a
+complete v1 `result` frame with `status: ready` is eligible for filing; partial,
+invalid, uncertain, pending, and failed records remain evidence only.
 
 ## Enable and Validate
 


### PR DESCRIPTION
The Pebble producer now writes each recording day as two files: `LifeOS/Log/Pebble/YYYY-MM-DD-raw.md` holds the framed capture/result records, and `YYYY-MM-DD.md` holds a readable digest of them (one bullet per capture). The consumer guide still described a single daily file.

Documentation only — no consumer code change is needed. `PebbleCaptureConsumer` scans the producer-owned directory and acts only on valid v1 frames, so the digest (which contains none) produces no effects.

Producer side: nbramia/pebble#5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hQE16oZpdY9hNLna4psXX