### PR TITLE
fix: recalibrate the development lifecycle so small changes cost what they should

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 > **Audience:** All AI coding agents (Claude Code, Cursor, Copilot, etc.)
 > **Status:** Complete
-> **Last Updated:** 2026-09-04
+> **Last Updated:** 2026-09-10
 
 LifeOS is a self-hosted personal AI assistant with two halves:
 
@@ -411,11 +411,12 @@ Full standards in [docs/AGENTS.md](docs/AGENTS.md). Key rules:
 
 - **Product specs** describe WHAT (consumer view). Implementation details go in `specs/technical/`.
 - **ADRs are immutable.** To change a decision, create a new ADR that supersedes.
-- **Every doc** must have a Related Documents section with bidirectional links.
+- **Every doc** must have a Related Documents section (linking back and adding a tagline to each link is guidance, not enforced).
 - **No task lists in specs.** Specs describe target state. Tasks go in `docs/plans/` or GitHub issues.
 - **Synthetic data only** in all examples and test fixtures.
 - **Completed plans** must be moved to `docs/plans/archive/`.
 - **Current behavior only, everywhere.** Docs, code comments, docstrings, and test docstrings describe the system as it is — no "before/now", review rounds, findings, or issue/PR numbers cited as history. Git history holds that narrative.
+- **PR descriptions are short summaries.** No verification matrix, evidence section, or risk table required for work outside the named risk triggers — see [Development Lifecycle](docs/specs/standards/development-lifecycle.md#risk-and-review).
 
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,15 +1,15 @@
 # Documentation Strategy
 
 **Status:** Complete
-**Last Updated:** 2026-09-04
+**Last Updated:** 2026-09-10
 
 > **Backlog lives in GitHub issues.** Future work, deferred features, bugs, and enhancements are tracked as GitHub issues — never as `backlog.md` files in this directory. Plan files are reserved for time-bounded execution notes (migration plans, gap analyses, point-in-time issue-drafting context).
 
-**This document defines mandatory documentation standards. All contributors — human and AI — must follow these rules when creating or modifying documentation. Consistency is not optional; it ensures documentation remains navigable, maintainable, and valuable as a shared context layer.**
+**This document defines documentation standards for LifeOS. Its structural requirements are mandatory for all contributors — human and AI — because they keep documentation navigable, maintainable, and valuable as a shared context layer; the style guidance within it is advisory (see Purpose, below, for the split).**
 
 ## Purpose
 
-This strategy defines how we organize and maintain documentation in LifeOS. These are **rules, not guidelines** — following this strategy faithfully is critical to maintaining documentation quality across a collaborative human + AI agent project.
+This strategy defines how we organize and maintain documentation in LifeOS. Its structural requirements — frontmatter, document placement, a present Related Documents section, ADR immutability, synthetic data only, and current-behavior-only — are **rules, not guidelines**: a violation is a reportable finding under the [Development Lifecycle](specs/standards/development-lifecycle.md#risk-and-review) contract. The style guidance elsewhere in this document — phrasing, sentence structure, prose tone, link taglines — adds polish but is not independently reportable; apply it, but a reviewer does not raise a finding over a stylistic reading that leaves the structural requirements and the meaning intact.
 
 Documentation in LifeOS serves two readers equally:
 - **Human contributors** who need to onboard, debug, and design changes.
@@ -225,12 +225,19 @@ When splitting, keep a thin **index document** at the original path with pointer
 ## Cross-Linking Standards
 
 Every document must include a "Related Documents" section at the bottom.
+This is a structural requirement: its absence is a reportable finding.
 
 **Requirements:**
-1. **Bidirectional** — if A links to B, B must link to A. When you add a link in one direction, add the reciprocal link in the same PR.
-2. **Contextual** — every link has a "— short tagline" explaining the relationship.
-3. **Specific** — link to code with line numbers (`path/to/file.py:120-145`) when relevant.
-4. **Use the 4-bucket structure** below for consistency.
+1. **Present** — a Related Documents section listing at least the documents that motivated or are motivated by this one.
+2. **Specific** — link to code with line numbers (`path/to/file.py:120-145`) when relevant.
+3. **Use the 4-bucket structure** below for consistency.
+
+Linking back (B links to A because A links to B) and a short "— tagline"
+explaining each link are guidance, not enforced requirements: add them when
+touching a document anyway, but a missing reciprocal link or tagline is not
+a reportable finding. It blocks no reader following the forward link and
+has never been observed catching a defect — enforcing it as a rule mainly
+produced find-and-fix chores on every document touch.
 
 **Standard Related Documents template:**
 
@@ -274,6 +281,17 @@ Use only the buckets that apply — omit empty buckets rather than including the
 
 **Guides decay:**
 - Test commands you document before shipping. Stale guides are worse than missing guides.
+
+## Pull Request Descriptions
+
+A pull-request description is a short summary: what changed and why, in a
+few sentences. For work outside the [named risk
+triggers](specs/standards/development-lifecycle.md#risk-and-review), it does
+not require a verification matrix, a separate evidence section, or a risk
+table — the verification lane's preserved result is the evidence, and
+restating it in prose is not required. A change touching a named risk
+trigger states what verification evidence exists and where to find it, but
+the description still stays a summary, not an audited artifact.
 
 ## Writing for AI Readability
 
@@ -388,6 +406,7 @@ Aim for ≤30 lines. Subdirectory AGENTS.md files are wayfinding, not extended c
 ### Specifications
 - [vision/philosophy.md](vision/philosophy.md) — The privacy-first, local-first principles that frame doc decisions
 - [specs/standards/](specs/standards/) — Coding and testing conventions referenced by docs
+- [Development Lifecycle](specs/standards/development-lifecycle.md) — Defines the risk triggers this document's Purpose and Pull Request Descriptions sections reference
 
 ### Operational
 - [guides/](guides/) — Operator-facing setup and troubleshooting

--- a/docs/specs/standards/development-lifecycle.md
+++ b/docs/specs/standards/development-lifecycle.md
@@ -1,7 +1,7 @@
 # Development Lifecycle
 
 **Status:** Partial
-**Last Updated:** 2026-09-09
+**Last Updated:** 2026-09-10
 **Owner:** Development workflow
 
 This contract defines the shared implementation, review, verification, and
@@ -20,35 +20,67 @@ Every change receives the smallest lifecycle that fits its risk:
    candidate under test.
 5. Merge only after required evidence, approvals, and repository checks pass.
 
-Routine work may complete these phases inline or with one proportionate review.
-The lifecycle does not require a delegate for every task, impose a hard PR
-line-count cap, or create a separate documentation specialist for ordinary
-changes.
+Work outside the six risk triggers in [Risk and review](#risk-and-review)
+completes these phases inline, with one proportionate review standing in for
+phase 3 in full. The lifecycle does not require a delegate for every task,
+impose a hard PR line-count cap, or create a separate documentation
+specialist or verification findings loop for that work.
 
 ## Risk and review
 
-Classify risk by the behavior and failure impact, not by file count:
+Classify risk by the behavior and failure impact, not by file count. Six
+triggers require an independent adversarial review — someone other than the
+implementer, reading the diff adversarially against what it claims to do:
+
+- Behavior only observable in the running application
+- Concurrency or resource ownership
+- Schema or public API compatibility
+- Authentication or privacy boundaries
+- Money movement
+- Irreversible data loss
 
 | Work | Minimum review | Verification expectation |
 | --- | --- | --- |
 | Typo or mechanical correction | Brief inline review | Focused check when observable; otherwise document-only result |
 | Small isolated Python bug | One proportionate review | Focused regression test and selected lane evidence |
 | Frontend behavior change | One proportionate review | Browser or executable UI scenario plus selected lane evidence |
-| Concurrency or resource ownership | Independent adversarial reviewer from the other model family | Deterministic contention/cancellation/ownership evidence |
-| Schema or public API change | Independent adversarial reviewer from the other model family | Compatibility, migration, and boundary evidence |
+| Behavior only observable in the running application | Independent adversarial review | Executable scenario driving the running application, not module-level tests alone |
+| Concurrency or resource ownership | Independent adversarial review | Deterministic contention/cancellation/ownership evidence |
+| Schema or public API compatibility | Independent adversarial review | Compatibility, migration, and boundary evidence |
+| Authentication or privacy boundaries | Independent adversarial review | Boundary and authorization evidence |
+| Money movement | Independent adversarial review | Correctness and idempotency evidence for the affected transaction path |
+| Irreversible data loss | Independent adversarial review | Evidence that the destructive path is gated, confirmed, or recoverable |
 | Substantive review correction | Re-review the changed behavior | Re-run affected focused checks; preserve prior evidence where valid |
 | Infrastructure retry | Same review requirement as original work | Record the reason, command, result, and whether the retry is comparable |
 
-Complex work requires an identifiable reviewer from the other model family
-(Claude reviews OpenAI work, and OpenAI reviews Claude work). The reviewer
-must inspect executable evidence and record findings and disposition. If the
-other family is unavailable, readiness remains pending unless the operator
-grants an explicit exception; a same-family review is not relabeled as
-independent. Re-review substantive fixes, not formatting-only changes.
+For work outside those six triggers, one proportionate review is the
+complete review requirement. No separate documentation specialist and no
+separate verification findings loop apply to that work — documentation
+relevance and verification evidence are considerations inside the one
+review, not additional gates with their own rounds.
+
+A review reports exactly two kinds of finding: a defect reachable on a path
+a caller or user actually takes, and a missing test for behavior the diff
+claims to deliver. An observation below that bar — a stylistic preference, an
+unproven hypothetical, a rephrasing with no behavior change — is not
+recorded as a finding.
+
+Review converges when a round produces no accepted finding; that is the
+default outcome after the first round. A further round happens only because
+the preceding round produced an accepted finding — a round never exists to
+reconfirm that nothing is wrong. An accepted finding is fixed in the branch
+under review when it is in scope, not deferred to a follow-up pull request
+that pays a fresh gate run and review cycle.
+
+An independent reviewer from the other model family (Claude reviewing OpenAI
+work, or OpenAI reviewing Claude work) is advisory: when available, it
+informs the review; its absence never places readiness in a pending state
+and never requires an operator exception. A same-family independent review
+still satisfies the six triggers above. Re-review substantive fixes, not
+formatting-only changes.
 
 Use specialists only for a concrete risk such as security, architecture,
-concurrency, privacy, schema, or test strategy. Ordinary documentation
-relevance is part of the proportionate review. Unresolved defects block
+concurrency, privacy, schema, or test strategy. Unresolved defects block
 readiness; optional, unrelated work is not a readiness blocker.
 
 ## Verification and evidence
@@ -69,7 +101,10 @@ documentation checks, PR standards checks, and merge preparation may run
 focused commands but do not consume or rerun that authoritative plan. Broad
 gates remain required until an approved enforcement change records a safe
 reuse policy. Missing or mismatched evidence is a readiness failure, not a
-reason to guess or silently rerun a broad suite.
+reason to guess or silently rerun a broad suite. Verification preserves this
+evidence for the exact candidate; it does not run a separate multi-round
+findings loop of its own — anything it surfaces is a finding under [Risk and
+review](#risk-and-review) and is resolved within that one review.
 
 Verification separates queue/waiting, execution, and transfer time. It
 preserves positive and signal-derived exit status, cancellation, interruption,
@@ -108,12 +143,16 @@ The bounded evaluation matrix is:
 | Typo | Routine; inline review; no mandatory delegate |
 | Small Python bug | Routine; focused regression evidence |
 | Frontend behavior | Routine; executable browser/UI evidence |
-| Complex concurrency | Other-family adversarial review and deterministic evidence required |
-| Schema/API change | Other-family adversarial review and compatibility evidence required |
+| Behavior only observable in the running application | Independent adversarial review; executable evidence from the running application |
+| Concurrency or resource ownership | Independent adversarial review and deterministic evidence required |
+| Schema or public API compatibility | Independent adversarial review and compatibility evidence required |
+| Authentication or privacy boundaries | Independent adversarial review and boundary evidence required |
+| Money movement | Independent adversarial review and transaction-path evidence required |
+| Irreversible data loss | Independent adversarial review and recoverability evidence required |
 | Mechanical review correction | Recheck affected behavior; no new specialist unless risk changes |
 | Substantive review correction | Re-review the changed behavior and rerun affected checks |
 | Infrastructure failure | Preserve failure; retry only with an explicit reason |
-| Other-family unavailable | Readiness pending unless an explicit operator exception exists |
+| Other-family reviewer unavailable | A same-family independent review satisfies the trigger; readiness proceeds |
 
 ## Privacy and boundaries
 
@@ -128,6 +167,7 @@ GPU guards, and deployment controls remain owned by their current components.
 ### Specifications
 
 - [Testing Standards](testing-standards.md) — Lane selection and evidence rules
+- [Documentation Strategy](../../AGENTS.md) — Pull-request description expectations that reference this contract's risk triggers
 
 ### Code References
 

--- a/docs/specs/standards/testing-standards.md
+++ b/docs/specs/standards/testing-standards.md
@@ -1,7 +1,7 @@
 # Testing Standards
 
 **Status:** Complete
-**Last Updated:** 2026-09-09
+**Last Updated:** 2026-09-10
 **Audience:** All developers and AI agents
 
 Testing patterns and conventions for the LifeOS codebase.
@@ -110,6 +110,29 @@ host materializes a fresh, self-contained repository from the bundle (a
 throwaway `LifeOS Remote Test` identity, no source credentials) before the
 working-tree content — including uncommitted/untracked state — is rsynced
 on top, so `git status`/`auto`'s diff match the source exactly.
+
+## Tests as Evidence
+
+A test is evidence for a change only when it fails without that change.
+Before relying on a test to justify a change, revert the production diff and
+confirm the test fails; a test that still passes with the production change
+reverted is not evidence for it. Review treats a change carrying only such
+tests as missing a test, in the sense the [Development
+Lifecycle](development-lifecycle.md#risk-and-review) finding kinds define.
+
+Tests assert behavior. They never assert the wording of a comment, a
+docstring, a pull-request description, or a documentation sentence — a
+rewritten sentence that preserves meaning must not break a test.
+
+A change's tests pin the behavior it claims to deliver. Enumerating inputs no
+caller can produce is not required coverage, and review does not request it.
+This is a review consideration judged against what the diff claims to do,
+not a line-count ratio between test and production code.
+
+This section changes what a new or reworked test must do to count as
+evidence. It is not authorization to delete an existing test — [When Tests
+Fail After Your Changes](#when-tests-fail-after-your-changes), below, still
+governs that.
 
 ## Remote Testing Workflow
 

--- a/docs/specs/standards/testing-standards.md
+++ b/docs/specs/standards/testing-standards.md
@@ -113,26 +113,39 @@ on top, so `git status`/`auto`'s diff match the source exactly.
 
 ## Tests as Evidence
 
-A test is evidence for a change only when it fails without that change.
-Before relying on a test to justify a change, revert the production diff and
-confirm the test fails; a test that still passes with the production change
-reverted is not evidence for it. Review treats a change carrying only such
-tests as missing a test, in the sense the [Development
-Lifecycle](development-lifecycle.md#risk-and-review) finding kinds define.
+A test that passes against the pre-change code is not evidence for the
+change it accompanies. A hardening test added in response to review must be
+shown to fail against the pre-change code before it merges: revert the
+production diff, confirm the new test fails, then restore the diff. Review
+treats a change carrying only such tests as missing a test, in the sense the
+[Development Lifecycle](development-lifecycle.md#risk-and-review) finding
+kinds define.
 
-Tests assert behavior. They never assert the wording of a comment, a
-docstring, a pull-request description, or a documentation sentence — a
-rewritten sentence that preserves meaning must not break a test.
+Tests never assert the content of a comment, a docstring, a pull-request
+description, or a documentation sentence — a rewritten sentence that
+preserves meaning must not break a test. This is a preventive rule, not a
+response to an observed problem: an audit of the highest-ratio changes in
+this repository found no test asserting prose.
 
-A change's tests pin the behavior it claims to deliver. Enumerating inputs no
-caller can produce is not required coverage, and review does not request it.
-This is a review consideration judged against what the diff claims to do,
-not a line-count ratio between test and production code.
+Reduce duplication instead of adding more of it:
+- When several tests share one setup-and-assert skeleton and differ only in
+  an injected value, parametrize them rather than copy the skeleton per
+  case.
+- When a large fixture literal repeats across tests, build it with a shared
+  helper rather than copy the literal into each test.
 
-This section changes what a new or reworked test must do to count as
-evidence. It is not authorization to delete an existing test — [When Tests
-Fail After Your Changes](#when-tests-fail-after-your-changes), below, still
-governs that.
+Scope tests to reachable behavior:
+- A failure mode that requires a stubbed system binary to fail
+  conditionally on its own arguments is out of scope for the suite.
+- A branch a test's own description calls otherwise unreachable is covered
+  by extending an existing test, not by adding a new one.
+
+These are review considerations, not a line-count ratio between test and
+production code, and they do not authorize deleting existing coverage of
+real races, security gates, or crash-recovery paths. This section changes
+what a new or reworked test must do; it is not authorization to delete or
+weaken an existing test — [When Tests Fail After Your
+Changes](#when-tests-fail-after-your-changes), below, still governs that.
 
 ## Remote Testing Workflow
 


### PR DESCRIPTION
## Summary

Recalibrates the written lifecycle contract (PR 1 of #1023) so review effort tracks actual risk instead of landing uniformly on every change. This is a documentation/policy change only — no Python, no tests. The matching harness mechanics land separately as a PR in `nbramia/bootstraps` (issues are disabled there), referencing this issue.

The testing-standards criteria in this PR follow the issue's [correction and refinement](https://github.com/nbramia/LifeOS/issues/1023#issuecomment-5619194997): the original ratios were inflated by counting `scripts/` as infrastructure rather than production code, and a function-by-function audit of the highest-ratio changes found the suite itself is not the problem (62.9% of audited test lines cover plausible failure modes, 0% assert prose). The seven criteria below are grounded in that audit rather than in a ratio.

## What changed and why

**`docs/specs/standards/development-lifecycle.md`**
- Risk table now names exactly six triggers for independent adversarial review: behavior only observable in the running application, concurrency/resource ownership, schema/public API compatibility, authentication/privacy boundaries, money movement, irreversible data loss.
- For work outside those six, one proportionate review is the complete review requirement — no separate documentation specialist, no separate verification findings loop.
- Reportable findings narrowed to exactly two kinds: a defect reachable on a normal path, and a missing test for claimed behavior. Everything below that bar isn't recorded.
- Review converges on a quiet round by default; a further round requires an accepted finding in the preceding one. An accepted finding is fixed in the branch under review, not deferred to a follow-up PR.
- Other-model-family review is now advisory: its absence no longer holds readiness pending or requires an operator exception.
- Scenario outcome table updated to match every rule above, including the row for an unavailable other-family reviewer.

**`docs/specs/standards/testing-standards.md`** — new "Tests as Evidence" section with seven criteria:
1. A test that passes against the pre-change code is not evidence for that change; a hardening test added in response to review must be shown to fail against the pre-change code before it merges.
2. Tests sharing one setup-and-assert skeleton that differ only by an injected value are parametrized, not copied.
3. A repeated large fixture literal is built by a shared helper, not copied per test.
4. A failure mode requiring a stubbed system binary to fail conditionally on its own arguments is out of scope for the suite.
5. A branch a test's own description calls otherwise unreachable is covered by extending an existing test, not adding a new one.
6. No test asserts the content of a comment, docstring, PR description, or documentation sentence — stated as preventive; the audit found no such test.
7. These are review considerations, never a line-count ratio, and do not authorize deleting existing coverage of real races, security gates, or crash-recovery paths. Made explicit in the document, not just here: this changes what new/reworked tests must do, not authorization to delete or weaken an existing test.

**`docs/AGENTS.md`, `AGENTS.md`**
- New "Pull Request Descriptions" section/bullet: a description is a short summary; no verification matrix, evidence section, or risk table required for work outside the named risk triggers.

## Rules reduced, and why

Named per the issue's requirement — each is a rule whose only observed effect was generating findings without preventing a defect:

1. **Cross-Linking Standards' bidirectional-link and per-link-tagline requirements** (`docs/AGENTS.md` § Cross-Linking Standards, mirrored in `AGENTS.md`'s Documentation Rules Quick Reference). Reduced from enforced rule to guidance. A missing reciprocal link or tagline blocks no reader following the forward link and has never been observed catching a defect — enforcing it produced a find-and-fix chore on every document touch. The "Related Documents section must be present" requirement is unchanged and still enforced.
2. **`docs/AGENTS.md`'s blanket "everything here is a mandatory, rejectable rule" framing.** Narrowed to apply only to structural requirements (frontmatter, document placement, Related Documents presence, ADR immutability, synthetic-data-only, current-behavior-only). The stylistic guidance in the same document (phrasing, sentence structure, prose tone, taglines) is now explicitly advisory and not independently reportable — that blanket framing is what let a reviewer treat a prose preference as a rule violation.

## What I deliberately left alone

- No enforced gate is touched: required checks, branch protection, required approvals, the no-`--no-verify` rule, and published-history immutability are all unchanged.
- No harness mechanics (phase structure, reviewer/referee output schemas, round mechanics) — that's PR 2's scope in `nbramia/bootstraps`.
- Did not authorize deleting any existing test; testing-standards.md states this explicitly (criterion 7) and cross-references "When Tests Fail After Your Changes", which is untouched and still governs that.
- Did not touch `python-conventions.md` or any file outside this PR's four named files — the instruction-surface reduction is scoped to `docs/AGENTS.md`/`AGENTS.md` only, per the issue's file table.

## Verification

- This is a docs-only change; the pre-push hook confirmed docs-only and skipped the test suites on both pushes (correct per the repo's `decide_plan` logic).
- Ran `~/.venvs/lifeos/bin/python -m pytest tests/test_no_change_narration.py -q` — passes on both pushes (no new change-narration introduced).
- No docs-standards or link-check test exists in this repo beyond the narration ratchet (checked `tests/` for one).
- Re-read the full diff against every criterion in the issue's *Contract: risk and review*, *Contract: tests as evidence* (the replaced seven criteria), and *Contract: description and instruction surface* sections; each is satisfied.
- **This PR must itself pass the current 30-to-65-minute hosted gate** (`candidate-verification`) before merge.

Refs nbramia/LifeOS#1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hQE16oZpdY9hNLna4psXX