### PR TITLE
fix: raise the gate's per-run capacity to the runner's width

### DIFF
--- a/.github/workflows/candidate-verification.yml
+++ b/.github/workflows/candidate-verification.yml
@@ -168,6 +168,7 @@ jobs:
             --shard-index "$SHARD_INDEX"
             --shard-count "$SHARD_COUNT"
             --workers "$WORKERS"
+            --capacity-max-run-workers "$WORKERS"
           )
           if [ "$LANE" = browser-free ]; then
             # browser-free never touches a live server, so independent


### PR DESCRIPTION
The sharded gate refuses every leg before any test runs:

```
WORKERS: 4
scripts.test_capacity.CapacityError: requested workers exceed per-run capacity
```

Each leg asks for the runner's full width (`nproc`, which is 4 on this repository's runners), but `scripts/test_capacity.py` defaults a run to `PROVISIONAL_MAX_RUN_WORKERS = 2` while detecting `PROVISIONAL_TOTAL_WORKERS = 4`. A request of 4 against a per-run cap of 2 is refused, so all five legs fail in about two seconds and the required check concludes failure for every candidate.

The fix declares the same width as the leg's per-run maximum. `4` is within the host's detected total of `4`, which is the condition the capacity manager actually enforces, so the leg runs at the width the runner provides.

## Verification

Not verifiable through the gate: both `workflow_dispatch` and `pull_request_target` resolve this workflow from `main`, so a candidate cannot exercise a fix to the workflow that verifies it. This PR's own run uses the broken definition on `main` and will fail for the same reason every other candidate currently does. The first run to exercise the fix is the one after it lands.

Reviewed against the capacity manager's own logic: `max_run_workers = requested_max_run if requested_max_run is not None else normal_max`, then `if max_run_workers > total_workers: raise`. With `requested_max_run = 4` and `total_workers = 4`, the guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hQE16oZpdY9hNLna4psXX