### PR TITLE
fix: restore the verification job's steps to job level

### DIFF
--- a/.github/workflows/candidate-verification.yml
+++ b/.github/workflows/candidate-verification.yml
@@ -68,7 +68,7 @@ jobs:
       HIP_VISIBLE_DEVICES: ""
       ROCR_VISIBLE_DEVICES: ""
       CUDA_VISIBLE_DEVICES: ""
-          steps:
+    steps:
       - name: Checkout the protected runner definition
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
`.github/workflows/candidate-verification.yml` does not parse:

```
YAML ERROR: while parsing a block mapping
  in candidate-verification.yml, line 63, column 7
expected <block end>, but found '<block mapping start>'
  in candidate-verification.yml, line 71, column 11
```

`steps:` carries ten spaces of indentation instead of four, so it reads as a key under `env:` rather than a job-level key. GitHub therefore cannot resolve the workflow's triggers, and dispatching it fails:

```
HTTP 422: Workflow does not have 'workflow_dispatch' trigger
```

That blocks every merge, because the publisher's authoritative verification is a `workflow_dispatch` against this file.

One line: `steps:` returns to job level.

## Verification

```
YAML parses OK; on: ['pull_request_target', 'workflow_dispatch'] | jobs: ['execute-candidate', 'publish-aggregate']
steps in execute-candidate: 7
```

Parsed with `yaml.safe_load`, confirming both triggers resolve and all seven steps belong to the job rather than to `env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hQE16oZpdY9hNLna4psXX