### PR TITLE
fix: set the gate ceiling above the slowest healthy run

### DIFF
--- a/.github/workflows/candidate-verification.yml
+++ b/.github/workflows/candidate-verification.yml
@@ -53,10 +53,12 @@ jobs:
   execute-candidate:
     name: candidate-execution
     runs-on: ubuntu-latest
-    # The retained lanes have measured at roughly 38m (fast-unit) + 11m
-    # (browser-free), before dependency and Chromium setup. Keep a bounded
-    # ceiling with enough setup headroom rather than timing out a healthy run.
-    timeout-minutes: 45
+    # Both retained lanes run in this one job, and a healthy run has
+    # measured anywhere from roughly half an hour to just under an hour
+    # depending on runner speed. The ceiling exists to fail a genuinely
+    # stuck job, so it sits above the slowest healthy run observed rather
+    # than near the middle of the range.
+    timeout-minutes: 65
     permissions:
       contents: read
     env:


### PR DESCRIPTION
A 45-minute job ceiling cancelled a verification run that was still making progress:

```
candidate-execution: cancelled 2026-09-10T16:18:55Z -> 2026-09-10T17:04:13Z
```

45m18s, no test failure — the ceiling ended it. A cancelled execution publishes a failing required check, so the ceiling itself became the thing blocking merges.

Healthy runs of this job have measured 32, 44, and 52 minutes on different runners. A ceiling of 45 sits inside that range, so it cancels roughly half of healthy runs. It returns to 65, above the slowest healthy run observed, which is what a ceiling meant to catch a stuck job should be.

The comment above it now records that reasoning, so the number is not re-tuned downward without new measurements.

## What this does not claim

Raising the ceiling is not a speedup. Widening the workers to the runner's count did not produce a measurable improvement — this run still exceeded 45 minutes with four workers, against 44 to 52 minutes previously with two. The one measured gain from that work is the browser-free lane's parallel mode, which ran 715 tests in 307s against 609s serially, and that is retained.

Reducing this gate's wall clock needs the partitioning work in #1030, not ceiling or worker tuning.

## Verification

`tests/test_candidate_ci_boundary.py` — 14 passed, run locally before merge because a change to this workflow cannot verify itself: both triggers resolve the definition from the base branch, so this PR's own run would use the 45-minute ceiling it removes.

`yaml.safe_load` confirms the file parses, both triggers resolve, and `timeout-minutes` is 65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hQE16oZpdY9hNLna4psXX