### PR TITLE
fix: give the gate the capacity headroom its nested runs need

### DIFF
--- a/.github/workflows/candidate-verification.yml
+++ b/.github/workflows/candidate-verification.yml
@@ -53,12 +53,12 @@ jobs:
   execute-candidate:
     name: candidate-execution
     runs-on: ubuntu-latest
-    # Both retained lanes run in this one job, and a healthy run has
-    # measured anywhere from roughly half an hour to just under an hour
-    # depending on runner speed. The ceiling exists to fail a genuinely
-    # stuck job, so it sits above the slowest healthy run observed rather
-    # than near the middle of the range.
-    timeout-minutes: 65
+    # Both retained lanes run in this one job, at the runner's full width
+    # with the capacity headroom the step below establishes. The ceiling
+    # exists to fail a genuinely stuck job, so it sits above the slowest
+    # healthy run observed with enough margin for dependency and Chromium
+    # setup, rather than near the middle of the range.
+    timeout-minutes: 45
     permissions:
       contents: read
     env:
@@ -137,12 +137,16 @@ jobs:
           echo "LANES=$LANES" >> "$GITHUB_ENV"
       - name: Verify the retained lanes this candidate's changes can affect
         run: |
-          # Two workers is the width with a completed-run record on this
-          # runner class: every run at two workers finished, and every run at
-          # the runner's full core count exceeded the ceiling. Record the
-          # runner's shape alongside it so a future change to this number
-          # rests on measurements rather than on the core count alone.
-          WORKERS=2
+          # The run width must stay strictly below the host capacity total.
+          # Two fast-unit tests dispatch their own nested verifier runs, and
+          # those acquire capacity slots of their own; when the outer run is
+          # allowed to hold every slot, they wait for one that never frees
+          # and the lane hangs until the ceiling rather than failing. Give
+          # the run the runner's full width and the total twice that, so the
+          # nested runs always have slots to take.
+          WORKERS="$(nproc)"
+          python trusted-runner/scripts/test_capacity.py configure \
+            --total-workers "$((WORKERS * 2))" --max-run-workers "$WORKERS"
           echo "runner reports $(nproc) logical processors; using $WORKERS test workers"
           free -h || true
           python trusted-runner/scripts/verify_candidate.py pushed-ref \
@@ -152,6 +156,7 @@ jobs:
             --evidence-root "$RUNNER_TEMP/lifeos-verification-evidence" \
             --lanes "$LANES" \
             --workers "$WORKERS" \
+            --capacity-max-run-workers "$WORKERS" \
             --parallel-browser-free
 
   publish-aggregate:

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -3455,6 +3455,11 @@ async def focus_claude_code_session(
     }
 
 
+# A CLI session has no DB status, so its stream closes once this many seconds
+# pass with no new transcript event. Heartbeats do not postpone the close.
+_CLI_STREAM_IDLE_CLOSE_SECONDS = 300.0
+
+
 async def _stream_claude_code_session(session_id: str, backfill: int):
     """Per-session SSE generator for Claude Code (cc:-prefixed) sessions."""
     yield ": ok\n\n"
@@ -3488,10 +3493,7 @@ async def _stream_claude_code_session(session_id: str, backfill: int):
         elif time.time() - last_heartbeat_at >= 15.0:
             yield ": heartbeat\n\n"
             last_heartbeat_at = time.time()
-        # Claude Code has no DB status — close after 5 minutes of no new
-        # transcript events so we don't hold connections forever. Heartbeats
-        # do NOT postpone this — only real new events do.
-        if time.time() - last_new_event_at > 300.0:
+        if time.time() - last_new_event_at > _CLI_STREAM_IDLE_CLOSE_SECONDS:
             yield (
                 "event: closed\n"
                 f"data: {json.dumps({'session_id': session_id, 'status': 'idle'})}\n\n"
@@ -3536,7 +3538,7 @@ async def _stream_codex_session(session_id: str, backfill: int):
         elif time.time() - last_heartbeat_at >= 15.0:
             yield ": heartbeat\n\n"
             last_heartbeat_at = time.time()
-        if time.time() - last_new_event_at > 300.0:
+        if time.time() - last_new_event_at > _CLI_STREAM_IDLE_CLOSE_SECONDS:
             yield (
                 "event: closed\n"
                 f"data: {json.dumps({'session_id': session_id, 'status': 'idle'})}\n\n"

--- a/tests/test_agent_transcript_mirror_events.py
+++ b/tests/test_agent_transcript_mirror_events.py
@@ -182,8 +182,13 @@ def test_events_endpoint_returns_mirrored_transcript_for_remote_session(client, 
 # ---------------------------------------------------------------------------
 
 
-def test_stream_endpoint_returns_mirrored_transcript_for_remote_session(client, stores, mirror_root):
+def test_stream_endpoint_returns_mirrored_transcript_for_remote_session(client, stores, mirror_root, monkeypatch):
     _write_cc_transcript(mirror_root / "laptop" / "claude_code" / "-home-user-proj" / "sess-e5.jsonl")
+
+    # Breaking out of the loop below does not end the response: closing the
+    # stream waits for the generator, which runs until its idle close. Pin
+    # that to a short interval so this test costs a second, not five minutes.
+    monkeypatch.setattr(agents_route, "_CLI_STREAM_IDLE_CLOSE_SECONDS", 1.0)
 
     lines: list[str] = []
     with client.stream("GET", "/api/agents/sessions/cc:sess-e5/stream?backfill=5") as r:


### PR DESCRIPTION
The candidate gate could not pass: at two workers a full run measured ~63
minutes against a 65-minute ceiling, and raising the run width to the
runner's core count made jobs hang rather than finish.

The cause is capacity, not lane size. Two fast-unit tests dispatch their
own nested verifier runs, which acquire capacity slots of their own. When
the outer run is permitted to hold every slot, those nested runs wait for a
slot that never frees and the lane hangs until the ceiling.

Measured on the same two test files, four workers, sole variable being the
host capacity budget:

| capacity | result |
|---|---|
| `total=4, max_run=4` | hangs; killed at 360s, stalled at 40/70 |
| `total=8, max_run=4` | 70 passed in 64s |

The gate now configures the host total to twice the run width before
verifying, takes the runner's full core count, and keeps a ceiling above
the resulting wall clock with setup headroom.

Separately, the Claude Code and Codex stream generators now share a named
idle-close interval so a test that stops reading early can pin it. One test
was paying the full five-minute close on every run; that file now completes
in under three seconds.

Local evidence, full selection: fast-unit 8126 passed / 1 skipped (16m11s),
browser-free 711 passed (3m11s), verifier result success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEjBgu9QvzoZMfEn9zBCqJ