### PR TITLE
fix(api): keep validation errors serializable

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -47,6 +47,7 @@ if os.environ.get("LIFEOS_TEST_INSTANCE") != "1":
 
 import asyncio
 import hashlib
+import json
 import logging
 import socket
 from contextlib import asynccontextmanager
@@ -483,13 +484,20 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     """Convert validation errors to 400 with clear messages."""
     errors = exc.errors()
 
-    # Sanitize errors for JSON serialization (convert bytes to string)
-    sanitized_errors = []
-    for error in errors:
-        sanitized = dict(error)
-        if "input" in sanitized and isinstance(sanitized["input"], bytes):
-            sanitized["input"] = sanitized["input"].decode("utf-8", errors="replace")
-        sanitized_errors.append(sanitized)
+    def json_safe(value):
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="replace")
+        if isinstance(value, dict):
+            return {str(key): json_safe(item) for key, item in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [json_safe(item) for item in value]
+        try:
+            json.dumps(value)
+        except (TypeError, ValueError):
+            return str(value)
+        return value
+
+    sanitized_errors = [json_safe(error) for error in errors]
 
     # Check if this is an empty query error
     for error in errors:

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -41,6 +41,7 @@ class TestAskStreamEndpoint:
         """Should return 400 for whitespace-only question."""
         response = client.post("/api/ask/stream", json={"question": "   "})
         assert response.status_code == 400
+        assert "Question cannot be empty" in str(response.json()["detail"])
 
     def test_stream_returns_event_stream(self, client):
         """Response should be text/event-stream."""

--- a/tests/test_search_api.py
+++ b/tests/test_search_api.py
@@ -182,6 +182,13 @@ class TestSearchRequestValidation:
         )
         assert response.status_code in [400, 415, 422]
 
+    def test_whitespace_query_returns_validation_message(self, client):
+        response = client.post("/api/search", json={"query": "   "})
+
+        assert response.status_code == 400
+        assert response.json()["error"] == "Query cannot be empty"
+        assert "Query cannot be empty" in str(response.json()["detail"])
+
     def test_handles_extra_fields(self, client):
         """Should ignore extra fields gracefully."""
         response = client.post("/api/search", json={


### PR DESCRIPTION
## Summary

A custom Pydantic validator puts its own exception object in the error's `ctx`, so `exc.errors()` carries a `ValueError` that `JSONResponse` cannot encode. The validation handler only decoded `bytes` in `input`, so every request rejected by such a validator raised inside the handler and returned 500 instead of the intended 400.

Reproducible against a running server today:

```
$ curl -s -o /dev/null -w '%{http_code}\n' -X POST localhost:8000/api/ask \
    -H 'Content-Type: application/json' -d '{"question":"   "}'
500
```

`/api/search` and `/api/ask/stream` share the handler and the same shape of validator.

The handler now walks each error and converts anything JSON cannot encode to its string form, keeping the existing bytes decoding. Coverage asserts the operator-facing message survives to the client on both routes; both new assertions fail against the previous handler with `TypeError: Object of type ValueError is not JSON serializable`.

Recreated on current `main` from the commit in #845, whose source branch was deleted and whose head GitHub no longer tracks. Original authorship preserved.

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154toV9apWwz3tCoc7cfx12
