### PR TITLE
fix(tests): give CRM and task stores owned paths under parallel runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -537,21 +537,24 @@ def _isolate_integration_persistent_stores(request, tmp_path, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _isolate_default_crm_db_path(request, tmp_path, monkeypatch):
-    """Give this test its own default CRM db path instead of the shared one.
+    """Redirect a default-constructed ``RelationshipStore``'s database path
+    to a path owned by this test.
 
-    ``get_crm_db_path()`` (used by ``RelationshipStore``, ``SourceEntityStore``,
-    and anything else that constructs one of those stores without an explicit
-    ``db_path``) resolves from ``settings.chroma_path``, whose default is the
-    *relative* ``./data/chromadb`` -- resolved against the pytest process's
-    cwd. Every xdist worker shares that cwd, so two workers that both
-    construct a default-path store race ``RelationshipStore._init_db()``'s
-    connect-then-``CREATE TABLE IF NOT EXISTS`` window on the same file: the
-    second worker's first query can see an empty database and raise
-    ``no such table: relationships`` (#952).
-    ``_isolate_slow_crm_schema``/``_isolate_integration_persistent_stores``
-    above already redirect this for their own markers; this covers the
-    remaining default case with an owned path instead of serializing workers
-    or restructuring ``_init_db``.
+    ``RelationshipStore.__init__`` falls back to ``get_crm_db_path()`` when
+    no ``db_path`` is given, and ``_init_db()`` connects to that path
+    (creating the file) before issuing ``CREATE TABLE IF NOT EXISTS`` -- a
+    concurrent process connecting to the same file inside that window sees
+    an empty database and raises
+    ``sqlite3.OperationalError: no such table: relationships``. Every test
+    that skips this fixture resolves the same shared path, since
+    ``get_crm_db_path()`` derives from ``settings.chroma_path``. Rebinding
+    ``db_paths``'s own ``settings`` name covers every caller of
+    ``get_crm_db_path()`` -- relationships, source entities, tone analysis,
+    person facts -- because they all read it through that one function,
+    while stores that reach ``settings.chroma_path`` through their own
+    module (usage tracking, conversations, the keyword index) keep the
+    real setting. Tests marked ``slow`` or ``integration`` carry their own
+    redirection above and are left alone here.
     """
     if request.node.get_closest_marker("slow") is not None:
         yield
@@ -560,26 +563,34 @@ def _isolate_default_crm_db_path(request, tmp_path, monkeypatch):
         yield
         return
 
+    from types import SimpleNamespace
+
     from api.utils import db_paths
 
-    monkeypatch.setattr(db_paths.settings, "chroma_path", tmp_path / "chromadb")
+    monkeypatch.setattr(
+        db_paths, "settings", SimpleNamespace(chroma_path=tmp_path / "chromadb")
+    )
     yield
 
 
 @pytest.fixture(autouse=True)
 def _isolate_default_task_manager_paths(request, tmp_path, monkeypatch):
-    """Give ``get_task_manager()``'s default singleton isolated paths.
+    """Redirect ``get_task_manager()``'s default singleton to a vault and
+    index path owned by this test.
 
-    ``TaskManager.__init__`` unconditionally loads/creates its index file and
-    (re)writes ``vault/LifeOS/Tasks/Dashboard.md`` the moment it constructs --
-    there is no lazy "only touch disk when asked" path. The only call site
-    that constructs one with every argument defaulted is ``get_task_manager()``
-    itself, reached without an explicit override by code such as
-    ``agent_system_prompt._get_existing_tags()`` while building a chat system
-    prompt. Without this, a plain local pytest run (not routed through
-    ``verify_candidate.py``'s candidate-data symlink) creates
-    ``data/task_index.json`` and ``vault/LifeOS/Tasks/Dashboard.md`` in the
-    real checkout (#1012).
+    ``TaskManager.__init__`` loads/creates its index file and rewrites
+    ``vault/LifeOS/Tasks/Dashboard.md`` unconditionally, and
+    ``get_task_manager()`` is the only call site that constructs one with
+    every argument defaulted -- reachable, for example, from
+    ``agent_system_prompt._get_existing_tags()`` while building a chat
+    system prompt. Rebinding ``task_manager``'s own ``settings`` name and
+    index constant gives that default construction an owned vault and index
+    path without touching ``settings.vault_path``, which directory
+    resolution and other subsystems read directly. ``get_task_manager``
+    itself is left intact, so a test that injects its own manager by
+    setting the ``_task_manager`` singleton still has that manager served
+    to the code under test. Tests marked ``slow`` or ``integration`` carry
+    their own redirection above and are left alone here.
     """
     if request.node.get_closest_marker("slow") is not None:
         yield
@@ -588,11 +599,16 @@ def _isolate_default_task_manager_paths(request, tmp_path, monkeypatch):
         yield
         return
 
-    import api.services.task_manager as task_manager_mod
-    from config.settings import settings
+    from types import SimpleNamespace
 
-    monkeypatch.setattr(settings, "vault_path", tmp_path / "vault")
-    monkeypatch.setattr(task_manager_mod, "DEFAULT_INDEX_PATH", tmp_path / "task_index.json")
+    import api.services.task_manager as task_manager_mod
+
+    monkeypatch.setattr(
+        task_manager_mod, "settings", SimpleNamespace(vault_path=tmp_path / "vault")
+    )
+    monkeypatch.setattr(
+        task_manager_mod, "DEFAULT_INDEX_PATH", tmp_path / "task_index.json"
+    )
     monkeypatch.setattr(task_manager_mod, "_task_manager", None)
     yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -535,6 +535,68 @@ def _isolate_integration_persistent_stores(request, tmp_path, monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def _isolate_default_crm_db_path(request, tmp_path, monkeypatch):
+    """Give this test its own default CRM db path instead of the shared one.
+
+    ``get_crm_db_path()`` (used by ``RelationshipStore``, ``SourceEntityStore``,
+    and anything else that constructs one of those stores without an explicit
+    ``db_path``) resolves from ``settings.chroma_path``, whose default is the
+    *relative* ``./data/chromadb`` -- resolved against the pytest process's
+    cwd. Every xdist worker shares that cwd, so two workers that both
+    construct a default-path store race ``RelationshipStore._init_db()``'s
+    connect-then-``CREATE TABLE IF NOT EXISTS`` window on the same file: the
+    second worker's first query can see an empty database and raise
+    ``no such table: relationships`` (#952).
+    ``_isolate_slow_crm_schema``/``_isolate_integration_persistent_stores``
+    above already redirect this for their own markers; this covers the
+    remaining default case with an owned path instead of serializing workers
+    or restructuring ``_init_db``.
+    """
+    if request.node.get_closest_marker("slow") is not None:
+        yield
+        return
+    if request.node.get_closest_marker("integration") is not None:
+        yield
+        return
+
+    from api.utils import db_paths
+
+    monkeypatch.setattr(db_paths.settings, "chroma_path", tmp_path / "chromadb")
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _isolate_default_task_manager_paths(request, tmp_path, monkeypatch):
+    """Give ``get_task_manager()``'s default singleton isolated paths.
+
+    ``TaskManager.__init__`` unconditionally loads/creates its index file and
+    (re)writes ``vault/LifeOS/Tasks/Dashboard.md`` the moment it constructs --
+    there is no lazy "only touch disk when asked" path. The only call site
+    that constructs one with every argument defaulted is ``get_task_manager()``
+    itself, reached without an explicit override by code such as
+    ``agent_system_prompt._get_existing_tags()`` while building a chat system
+    prompt. Without this, a plain local pytest run (not routed through
+    ``verify_candidate.py``'s candidate-data symlink) creates
+    ``data/task_index.json`` and ``vault/LifeOS/Tasks/Dashboard.md`` in the
+    real checkout (#1012).
+    """
+    if request.node.get_closest_marker("slow") is not None:
+        yield
+        return
+    if request.node.get_closest_marker("integration") is not None:
+        yield
+        return
+
+    import api.services.task_manager as task_manager_mod
+    from config.settings import settings
+
+    monkeypatch.setattr(settings, "vault_path", tmp_path / "vault")
+    monkeypatch.setattr(task_manager_mod, "DEFAULT_INDEX_PATH", tmp_path / "task_index.json")
+    monkeypatch.setattr(task_manager_mod, "_task_manager", None)
+    yield
+
+
 # Collection names `VectorStore` actually writes to on a real install:
 # `VectorStore`'s own class default (also what `get_vector_store()`'s
 # process-wide singleton resolves to) plus every non-vault indexer's own

--- a/tests/test_crm_db_path_isolation.py
+++ b/tests/test_crm_db_path_isolation.py
@@ -1,26 +1,20 @@
-"""Regression tests for #952: xdist workers sharing one lazily-created
-``data/crm.db``.
+"""A default-constructed ``RelationshipStore``'s database path is isolated
+per test.
 
-``get_crm_db_path()`` (``api/utils/db_paths.py``) resolves from
-``settings.chroma_path``, which defaults to the *relative* ``./data/chromadb``
--- resolved against the pytest process's cwd. Every xdist worker shares that
-cwd, so a plain test that constructs a default-path store (e.g.
-``RelationshipStore()``) races every other worker's default-path store over
-the same file: ``RelationshipStore._init_db()`` connects (creating a
-zero-page file) and only then issues ``CREATE TABLE IF NOT EXISTS`` -- a
-second worker connecting in that window sees an empty database and raises
+``RelationshipStore.__init__`` falls back to ``get_crm_db_path()`` when no
+``db_path`` is given, and ``_init_db()`` connects to that path (creating the
+file) before issuing ``CREATE TABLE IF NOT EXISTS``. Two processes each
+constructing a default-path store around the same moment can race that
+window: the second connection sees an empty database and raises
 ``sqlite3.OperationalError: no such table: relationships``.
 
-A deterministic red-then-green reproduction of the race itself is not
-practical (it requires two real xdist worker processes racing a narrow
-connect-then-create-table window). Instead, these tests pin the ownership
-property the fix establishes: the default CRM db path this process resolves
-to is not the literal shared, cwd-relative ``data/crm.db`` -- it is a path
-owned by this test/worker. Reverting the ``conftest.py`` fixture under test
-makes ``test_get_crm_db_path_is_isolated_from_shared_default`` fail (it
-resolves to the literal relative path); this file's own tests never
-monkeypatch ``get_crm_db_path`` themselves, so the isolation exercised here
-comes entirely from the autouse conftest fixture.
+A deterministic reproduction of that race across real parallel worker
+processes is impractical to drive from a single test. These tests instead
+pin the ownership property that prevents it: the path a default-constructed
+``RelationshipStore`` resolves to is never the path a fresh, unpatched
+``get_crm_db_path()`` produces -- the path every process that skips
+isolation would share -- and it lives under this test's own pytest-managed
+temp tree.
 """
 from pathlib import Path
 
@@ -29,36 +23,39 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
-def _unpatched_default_crm_db_path() -> Path:
-    """The crm.db path a fresh, un-monkeypatched ``Settings()`` would resolve
-    to -- i.e. the one every xdist worker shares absent this fix, whatever
-    the un-isolated default value of ``chroma_path`` itself happens to be."""
+def _shared_default_crm_db_path() -> Path:
+    """The path a default-constructed store shares with every other process
+    that also skips isolation.
+
+    Built from a fresh ``Settings`` rather than from ``get_crm_db_path()``,
+    which the isolation under test redirects -- reading it through the
+    redirected helper would compare the isolated path against itself and
+    assert nothing.
+    """
     from config.settings import Settings
 
     return Path(Settings().chroma_path).parent / "crm.db"
 
 
-def test_get_crm_db_path_is_isolated_from_shared_default(tmp_path_factory):
-    """The default CRM db path must not be the shared path every xdist
-    worker would otherwise resolve to from an un-isolated ``Settings()``."""
-    from api.utils.db_paths import get_crm_db_path
+def test_relationship_store_default_path_is_isolated(tmp_path_factory):
+    """A default-constructed ``RelationshipStore`` must not resolve to the
+    shared path every other default-constructed store would share."""
+    from api.services.relationship import RelationshipStore
 
-    resolved = Path(get_crm_db_path())
+    resolved = Path(RelationshipStore().db_path)
 
-    assert resolved != _unpatched_default_crm_db_path()
-    # It must be owned by *this test's* pytest-managed temp tree (unique per
-    # xdist worker), not merely different by coincidence.
+    assert resolved != _shared_default_crm_db_path()
     assert resolved.is_relative_to(tmp_path_factory.getbasetemp())
 
 
-def test_relationship_store_default_path_matches_get_crm_db_path():
-    """``RelationshipStore()`` (no explicit ``db_path``) resolves through
-    ``get_crm_db_path()`` -- confirming the isolation fixture actually
-    reaches the store construction path most call sites use, not just the
-    bare path-resolution function."""
-    from api.services.relationship import RelationshipStore
-    from api.utils.db_paths import get_crm_db_path
+def test_relationship_store_singleton_default_path_is_isolated(tmp_path_factory):
+    """``get_relationship_store()``'s lazily constructed singleton resolves
+    the same isolated path as a direct ``RelationshipStore()`` construction."""
+    from api.services.relationship import get_relationship_store, reset_relationship_store
 
-    store = RelationshipStore()
-    assert store.db_path == get_crm_db_path()
-    assert Path(store.db_path) != _unpatched_default_crm_db_path()
+    reset_relationship_store()
+    resolved = Path(get_relationship_store().db_path)
+    reset_relationship_store()
+
+    assert resolved != _shared_default_crm_db_path()
+    assert resolved.is_relative_to(tmp_path_factory.getbasetemp())

--- a/tests/test_crm_db_path_isolation.py
+++ b/tests/test_crm_db_path_isolation.py
@@ -1,0 +1,64 @@
+"""Regression tests for #952: xdist workers sharing one lazily-created
+``data/crm.db``.
+
+``get_crm_db_path()`` (``api/utils/db_paths.py``) resolves from
+``settings.chroma_path``, which defaults to the *relative* ``./data/chromadb``
+-- resolved against the pytest process's cwd. Every xdist worker shares that
+cwd, so a plain test that constructs a default-path store (e.g.
+``RelationshipStore()``) races every other worker's default-path store over
+the same file: ``RelationshipStore._init_db()`` connects (creating a
+zero-page file) and only then issues ``CREATE TABLE IF NOT EXISTS`` -- a
+second worker connecting in that window sees an empty database and raises
+``sqlite3.OperationalError: no such table: relationships``.
+
+A deterministic red-then-green reproduction of the race itself is not
+practical (it requires two real xdist worker processes racing a narrow
+connect-then-create-table window). Instead, these tests pin the ownership
+property the fix establishes: the default CRM db path this process resolves
+to is not the literal shared, cwd-relative ``data/crm.db`` -- it is a path
+owned by this test/worker. Reverting the ``conftest.py`` fixture under test
+makes ``test_get_crm_db_path_is_isolated_from_shared_default`` fail (it
+resolves to the literal relative path); this file's own tests never
+monkeypatch ``get_crm_db_path`` themselves, so the isolation exercised here
+comes entirely from the autouse conftest fixture.
+"""
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _unpatched_default_crm_db_path() -> Path:
+    """The crm.db path a fresh, un-monkeypatched ``Settings()`` would resolve
+    to -- i.e. the one every xdist worker shares absent this fix, whatever
+    the un-isolated default value of ``chroma_path`` itself happens to be."""
+    from config.settings import Settings
+
+    return Path(Settings().chroma_path).parent / "crm.db"
+
+
+def test_get_crm_db_path_is_isolated_from_shared_default(tmp_path_factory):
+    """The default CRM db path must not be the shared path every xdist
+    worker would otherwise resolve to from an un-isolated ``Settings()``."""
+    from api.utils.db_paths import get_crm_db_path
+
+    resolved = Path(get_crm_db_path())
+
+    assert resolved != _unpatched_default_crm_db_path()
+    # It must be owned by *this test's* pytest-managed temp tree (unique per
+    # xdist worker), not merely different by coincidence.
+    assert resolved.is_relative_to(tmp_path_factory.getbasetemp())
+
+
+def test_relationship_store_default_path_matches_get_crm_db_path():
+    """``RelationshipStore()`` (no explicit ``db_path``) resolves through
+    ``get_crm_db_path()`` -- confirming the isolation fixture actually
+    reaches the store construction path most call sites use, not just the
+    bare path-resolution function."""
+    from api.services.relationship import RelationshipStore
+    from api.utils.db_paths import get_crm_db_path
+
+    store = RelationshipStore()
+    assert store.db_path == get_crm_db_path()
+    assert Path(store.db_path) != _unpatched_default_crm_db_path()

--- a/tests/test_task_manager_default_no_repo_pollution.py
+++ b/tests/test_task_manager_default_no_repo_pollution.py
@@ -1,0 +1,39 @@
+"""Regression test for #1012: ``get_task_manager()``'s default singleton
+writes into the real checkout.
+
+``TaskManager.__init__`` unconditionally loads/creates its index file and
+rewrites ``vault/LifeOS/Tasks/Dashboard.md`` the moment it constructs -- there
+is no lazy "only touch disk when asked" path. The only call site that
+constructs one with every argument defaulted is ``get_task_manager()``
+itself, reached without an explicit override by
+``agent_system_prompt._get_existing_tags()`` while building a chat system
+prompt -- exactly the path ``test_agent_loop_error_messages.py``'s
+``run_agent_loop(...)`` calls exercise. Absent isolation, a plain local
+pytest run (not routed through ``verify_candidate.py``'s candidate-data
+symlink) creates ``data/task_index.json`` and
+``vault/LifeOS/Tasks/Dashboard.md`` in the real checkout the moment any test
+reaches this path.
+"""
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_REAL_TASK_INDEX = REPO_ROOT / "data" / "task_index.json"
+_REAL_DASHBOARD = REPO_ROOT / "vault" / "LifeOS" / "Tasks" / "Dashboard.md"
+
+
+def test_building_existing_tags_block_does_not_touch_the_real_checkout():
+    """Exercising the same call path ``run_agent_loop`` uses to build a
+    system prompt must not create task-store files in the real checkout."""
+    from api.services import agent_system_prompt
+
+    index_existed_before = _REAL_TASK_INDEX.exists()
+    dashboard_existed_before = _REAL_DASHBOARD.exists()
+
+    agent_system_prompt._get_existing_tags()
+
+    assert _REAL_TASK_INDEX.exists() == index_existed_before
+    assert _REAL_DASHBOARD.exists() == dashboard_existed_before

--- a/tests/test_task_manager_default_no_repo_pollution.py
+++ b/tests/test_task_manager_default_no_repo_pollution.py
@@ -25,9 +25,33 @@ _REAL_TASK_INDEX = REPO_ROOT / "data" / "task_index.json"
 _REAL_DASHBOARD = REPO_ROOT / "vault" / "LifeOS" / "Tasks" / "Dashboard.md"
 
 
+def test_default_task_manager_paths_are_isolated_from_the_real_checkout(tmp_path_factory):
+    """``get_task_manager()``'s default singleton must resolve its vault and
+    index paths away from the real checkout, regardless of whether
+    ``data/task_index.json``/``vault/LifeOS/Tasks/Dashboard.md`` happen to
+    already exist there. An existence check alone (see the sibling test
+    below) has no failure mode on a checkout where those files are already
+    present -- this pins the actual ownership property instead."""
+    from config.settings import Settings
+    from api.services.task_manager import get_task_manager
+
+    real_default_vault_path = Path(Settings().vault_path)
+    real_default_index_path = REPO_ROOT / "data" / "task_index.json"
+
+    manager = get_task_manager()
+
+    assert manager.vault_path != real_default_vault_path
+    assert manager.index_path != real_default_index_path
+    basetemp = tmp_path_factory.getbasetemp()
+    assert manager.vault_path.is_relative_to(basetemp)
+    assert manager.index_path.is_relative_to(basetemp)
+
+
 def test_building_existing_tags_block_does_not_touch_the_real_checkout():
     """Exercising the same call path ``run_agent_loop`` uses to build a
-    system prompt must not create task-store files in the real checkout."""
+    system prompt must not create task-store files in the real checkout.
+    Adds value on a checkout that starts clean; see the state-independent
+    test above for the property that holds regardless of ambient state."""
     from api.services import agent_system_prompt
 
     index_existed_before = _REAL_TASK_INDEX.exists()

--- a/tests/test_task_manager_default_no_repo_pollution.py
+++ b/tests/test_task_manager_default_no_repo_pollution.py
@@ -1,18 +1,11 @@
-"""Regression test for #1012: ``get_task_manager()``'s default singleton
-writes into the real checkout.
+"""``get_task_manager()``'s default singleton resolves isolated vault and
+index paths.
 
-``TaskManager.__init__`` unconditionally loads/creates its index file and
-rewrites ``vault/LifeOS/Tasks/Dashboard.md`` the moment it constructs -- there
-is no lazy "only touch disk when asked" path. The only call site that
-constructs one with every argument defaulted is ``get_task_manager()``
-itself, reached without an explicit override by
-``agent_system_prompt._get_existing_tags()`` while building a chat system
-prompt -- exactly the path ``test_agent_loop_error_messages.py``'s
-``run_agent_loop(...)`` calls exercise. Absent isolation, a plain local
-pytest run (not routed through ``verify_candidate.py``'s candidate-data
-symlink) creates ``data/task_index.json`` and
-``vault/LifeOS/Tasks/Dashboard.md`` in the real checkout the moment any test
-reaches this path.
+``TaskManager.__init__`` loads/creates its index file and rewrites
+``vault/LifeOS/Tasks/Dashboard.md`` unconditionally, and ``get_task_manager()``
+is the only call site that constructs one with every argument defaulted --
+reachable, for example, from ``agent_system_prompt._get_existing_tags()``
+while building a chat system prompt.
 """
 from pathlib import Path
 
@@ -26,22 +19,21 @@ _REAL_DASHBOARD = REPO_ROOT / "vault" / "LifeOS" / "Tasks" / "Dashboard.md"
 
 
 def test_default_task_manager_paths_are_isolated_from_the_real_checkout(tmp_path_factory):
-    """``get_task_manager()``'s default singleton must resolve its vault and
-    index paths away from the real checkout, regardless of whether
-    ``data/task_index.json``/``vault/LifeOS/Tasks/Dashboard.md`` happen to
-    already exist there. An existence check alone (see the sibling test
-    below) has no failure mode on a checkout where those files are already
-    present -- this pins the actual ownership property instead."""
+    """The default ``TaskManager()`` reached via ``get_task_manager()`` must
+    resolve its vault and index paths under this test's own pytest-managed
+    temp tree, regardless of whether ``data/task_index.json`` or
+    ``vault/LifeOS/Tasks/Dashboard.md`` happen to already exist in the real
+    checkout -- an existence check alone (see the sibling test below) has no
+    failure mode when those files are already present."""
     from config.settings import Settings
     from api.services.task_manager import get_task_manager
 
     real_default_vault_path = Path(Settings().vault_path)
-    real_default_index_path = REPO_ROOT / "data" / "task_index.json"
 
     manager = get_task_manager()
 
     assert manager.vault_path != real_default_vault_path
-    assert manager.index_path != real_default_index_path
+    assert manager.index_path != _REAL_TASK_INDEX
     basetemp = tmp_path_factory.getbasetemp()
     assert manager.vault_path.is_relative_to(basetemp)
     assert manager.index_path.is_relative_to(basetemp)
@@ -50,8 +42,9 @@ def test_default_task_manager_paths_are_isolated_from_the_real_checkout(tmp_path
 def test_building_existing_tags_block_does_not_touch_the_real_checkout():
     """Exercising the same call path ``run_agent_loop`` uses to build a
     system prompt must not create task-store files in the real checkout.
-    Adds value on a checkout that starts clean; see the state-independent
-    test above for the property that holds regardless of ambient state."""
+    This is a secondary check with a failure mode only on a checkout that
+    starts clean; the test above pins the property that holds regardless of
+    ambient state."""
     from api.services import agent_system_prompt
 
     index_existed_before = _REAL_TASK_INDEX.exists()


### PR DESCRIPTION
Two related test-isolation defects, both concurrency/resource-ownership under the repo's risk table:

- **#952**: `get_crm_db_path()` resolves a cwd-relative `data/crm.db` that every xdist worker shares. `RelationshipStore._init_db()` connects (creating the file) and only then issues `CREATE TABLE IF NOT EXISTS`; a second worker connecting in that window sees an empty database and raises `no such table: relationships`.
- **#1012**: `TaskManager.__init__` unconditionally loads/creates its index file and rewrites `vault/LifeOS/Tasks/Dashboard.md`. `get_task_manager()`'s only fully-defaulted call site is reached unpatched by `agent_system_prompt._get_existing_tags()` while building a chat system prompt, so a plain local pytest run leaks `data/task_index.json` and `vault/LifeOS/Tasks/Dashboard.md` into the real checkout.

Adds two autouse fixtures in `tests/conftest.py`, alongside the existing `_isolate_slow_crm_schema`/`_isolate_integration_persistent_stores` (which keep handling their own markers unchanged), giving plain unit tests their own owned crm.db and task-manager paths. Adds regression tests for both:

- `tests/test_crm_db_path_isolation.py` pins the ownership property for #952 (a deterministic race reproduction across real xdist workers isn't practical): the default CRM path this process resolves to is never the shared default a fresh, un-isolated `Settings()` would produce.
- `tests/test_task_manager_default_no_repo_pollution.py` is a direct regression test for #1012: it exercises the exact `agent_system_prompt._get_existing_tags()` path and asserts the real repo-root `data/task_index.json` and `vault/LifeOS/Tasks/Dashboard.md` are untouched. Confirmed failing against pre-change code (it created both files in the real checkout) before the fix.

Fixes #952
Fixes #1012

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXNMnBCw1vTtx1jYrW54Ms