### PR TITLE
fix(config): anchor data-store defaults to the repo root

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -38,6 +38,13 @@ def _telegram_bots_source() -> "Path | None":
 _PRIMARY_PERSONA_FILE = Path("config/personas/primary.md")
 _BOT_NAME_RE = re.compile(r"^[a-z0-9_-]+$")
 
+# Anchor path defaults to the repo root rather than the process's working
+# directory (#1038): nineteen call sites derive a data-store path from
+# `Path(settings.chroma_path).parent`, so an unanchored default resolved
+# incorrectly for any caller whose cwd isn't the repo root. `settings.py`
+# lives at `config/settings.py`, so its grandparent is the repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
 
 @dataclass(frozen=True)
 class PersonaDefinition:
@@ -210,11 +217,11 @@ class Settings(BaseSettings):
 
     # Paths (use LIFEOS_ prefix)
     vault_path: Path = Field(
-        default=Path("./vault"),
+        default=_REPO_ROOT / "vault",
         alias="LIFEOS_VAULT_PATH"
     )
     chroma_path: Path = Field(
-        default=Path("./data/chromadb"),
+        default=_REPO_ROOT / "data" / "chromadb",
         alias="LIFEOS_CHROMA_PATH"
     )
     chroma_url: str = Field(

--- a/config/settings.py
+++ b/config/settings.py
@@ -38,11 +38,11 @@ def _telegram_bots_source() -> "Path | None":
 _PRIMARY_PERSONA_FILE = Path("config/personas/primary.md")
 _BOT_NAME_RE = re.compile(r"^[a-z0-9_-]+$")
 
-# Anchor path defaults to the repo root rather than the process's working
-# directory (#1038): nineteen call sites derive a data-store path from
-# `Path(settings.chroma_path).parent`, so an unanchored default resolved
-# incorrectly for any caller whose cwd isn't the repo root. `settings.py`
-# lives at `config/settings.py`, so its grandparent is the repo root.
+# Anchors path defaults to the repo root rather than the process's working
+# directory, so the call sites that derive a data-store path from
+# `Path(settings.chroma_path).parent` resolve correctly regardless of the
+# caller's cwd. `settings.py` lives at `config/settings.py`, so its
+# grandparent is the repo root.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 

--- a/tests/test_data_path_anchoring.py
+++ b/tests/test_data_path_anchoring.py
@@ -13,13 +13,14 @@ these modules. That also sidesteps this suite's autouse isolation fixtures
 (e.g. ``_isolate_telegram_state_file``), which would otherwise mask the
 in-process class attribute under a fixture-chosen tmp path.
 
-#1038 covers the same bug class for ``config.settings.Settings``'s
-``vault_path``/``chroma_path`` defaults: nineteen call sites derive a
-data-store path from ``Path(settings.chroma_path).parent`` at call time, so
-anchoring the *default* (rather than each derived helper) fixes all of them
-at once. ``get_crm_db_path()``, ``get_conversation_db_path()``, and
+``config.settings.Settings``'s ``vault_path``/``chroma_path`` defaults anchor
+to the repo root the same way, so the nineteen call sites that derive a
+data-store path from ``Path(settings.chroma_path).parent`` at call time
+resolve correctly from any working directory — anchoring the *default*
+(rather than each derived helper) fixes all of them at once.
+``get_crm_db_path()``, ``get_conversation_db_path()``, and
 ``get_bm25_db_path()`` below are a representative sample of those derived
-helpers, exercised the same foreign-cwd way as the #645 cases above.
+helpers, exercised the same foreign-cwd way as the cases above.
 """
 import os
 import subprocess

--- a/tests/test_data_path_anchoring.py
+++ b/tests/test_data_path_anchoring.py
@@ -31,6 +31,23 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
+def _env_without_data_path_overrides() -> dict:
+    """A copy of the current environment with `LIFEOS_CHROMA_PATH` and
+    `LIFEOS_VAULT_PATH` removed.
+
+    These tests are about the *default* `settings.chroma_path`/`vault_path`
+    resolve to, so the subprocess must not inherit an operator (or test
+    runner) override of either — `scripts/verify_candidate.py` sets both to
+    a runtime-scoped path on every lane run, which would otherwise make
+    every case here resolve against that runtime root instead of the repo
+    root and fail for the wrong reason.
+    """
+    env = os.environ.copy()
+    env.pop("LIFEOS_CHROMA_PATH", None)
+    env.pop("LIFEOS_VAULT_PATH", None)
+    return env
+
+
 def _resolve_in_foreign_cwd(foreign_cwd: Path, import_stmt: str, expr: str) -> str:
     """Run `expr` in a fresh subprocess whose cwd is `foreign_cwd` and whose
     sys.path is seeded with the repo root, and return its printed result."""
@@ -41,6 +58,7 @@ def _resolve_in_foreign_cwd(foreign_cwd: Path, import_stmt: str, expr: str) -> s
         capture_output=True,
         text=True,
         timeout=30,
+        env=_env_without_data_path_overrides(),
     )
     assert result.returncode == 0, result.stderr
     return result.stdout.strip()
@@ -233,6 +251,7 @@ def test_usage_store_db_path_resolves_to_repo_root_from_foreign_cwd(tmp_path):
         capture_output=True,
         text=True,
         timeout=30,
+        env=_env_without_data_path_overrides(),
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == str(REPO_ROOT / "data" / "usage.db")
@@ -251,7 +270,7 @@ def _run_get_crm_db_path(foreign_cwd: Path, chroma_path_env: str) -> str:
         capture_output=True,
         text=True,
         timeout=30,
-        env={**os.environ, "LIFEOS_CHROMA_PATH": chroma_path_env},
+        env={**_env_without_data_path_overrides(), "LIFEOS_CHROMA_PATH": chroma_path_env},
     )
     assert result.returncode == 0, result.stderr
     return result.stdout.strip()

--- a/tests/test_data_path_anchoring.py
+++ b/tests/test_data_path_anchoring.py
@@ -12,7 +12,16 @@ imported, mirroring how a non-repo-root caller (e.g. a stdio MCP child) sees
 these modules. That also sidesteps this suite's autouse isolation fixtures
 (e.g. ``_isolate_telegram_state_file``), which would otherwise mask the
 in-process class attribute under a fixture-chosen tmp path.
+
+#1038 covers the same bug class for ``config.settings.Settings``'s
+``vault_path``/``chroma_path`` defaults: nineteen call sites derive a
+data-store path from ``Path(settings.chroma_path).parent`` at call time, so
+anchoring the *default* (rather than each derived helper) fixes all of them
+at once. ``get_crm_db_path()``, ``get_conversation_db_path()``, and
+``get_bm25_db_path()`` below are a representative sample of those derived
+helpers, exercised the same foreign-cwd way as the #645 cases above.
 """
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -71,6 +80,21 @@ def _resolve_in_foreign_cwd(foreign_cwd: Path, import_stmt: str, expr: str) -> s
             "DEFAULT_DB_PATH",
             "data/cc_wezterm.db",
         ),
+        (
+            "from api.utils.db_paths import get_crm_db_path",
+            "get_crm_db_path()",
+            "data/crm.db",
+        ),
+        (
+            "from api.services.conversation_store import get_conversation_db_path",
+            "get_conversation_db_path()",
+            "data/conversations.db",
+        ),
+        (
+            "from api.services.bm25_index import get_bm25_db_path",
+            "get_bm25_db_path()",
+            "data/bm25_index.db",
+        ),
     ],
     ids=[
         "slack_integration.SLACK_TOKEN_PATH",
@@ -79,6 +103,9 @@ def _resolve_in_foreign_cwd(foreign_cwd: Path, import_stmt: str, expr: str) -> s
         "telegram.TelegramBotListener._STATE_FILE",
         "person_stats' PersonEntityStore.CRM_DB_PATH",
         "cc_wezterm_store.DEFAULT_DB_PATH",
+        "db_paths.get_crm_db_path()",
+        "conversation_store.get_conversation_db_path()",
+        "bm25_index.get_bm25_db_path()",
     ],
 )
 def test_default_resolves_to_repo_root_from_foreign_cwd(
@@ -179,3 +206,89 @@ def test_scheduler_store_explicit_relative_index_path_still_resolves_against_cwd
     )
     assert store.index_path == Path("data/explicit_sched.json")
     assert (tmp_path / "data" / "explicit_sched.json").parent.exists()
+
+
+@pytest.mark.unit
+def test_usage_store_db_path_resolves_to_repo_root_from_foreign_cwd(tmp_path):
+    """`UsageStore.__init__` computes `db_path` from `settings.chroma_path`
+    and, as a side effect, creates the sqlite file with a real schema — so
+    avoid instantiating against the real default in-process (that would
+    touch this repo's actual data/usage.db). As with the slack indexer case
+    above, patch `_init_db` to a no-op inside the subprocess before
+    constructing, so only the path computation is observed."""
+    foreign_cwd = tmp_path / "not-the-repo"
+    foreign_cwd.mkdir()
+
+    code = (
+        f"import sys; sys.path.insert(0, {str(REPO_ROOT)!r})\n"
+        "from unittest.mock import patch\n"
+        "from api.services.usage_store import UsageStore\n"
+        "with patch.object(UsageStore, '_init_db', lambda self: None):\n"
+        "    store = UsageStore()\n"
+        "print(store.db_path)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(foreign_cwd),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(REPO_ROOT / "data" / "usage.db")
+    assert not (foreign_cwd / "data").exists()
+
+
+def _run_get_crm_db_path(foreign_cwd: Path, chroma_path_env: str) -> str:
+    code = (
+        f"import sys; sys.path.insert(0, {str(REPO_ROOT)!r})\n"
+        "from api.utils.db_paths import get_crm_db_path\n"
+        "print(get_crm_db_path())\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(foreign_cwd),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, "LIFEOS_CHROMA_PATH": chroma_path_env},
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+@pytest.mark.unit
+def test_explicit_relative_chroma_path_still_resolves_against_cwd_from_foreign_cwd(
+    tmp_path,
+):
+    """An operator-set, deliberately relative `LIFEOS_CHROMA_PATH` must still
+    resolve against cwd exactly as before — anchoring only the *default*
+    must not change resolution for a caller that configures its own path.
+    `get_crm_db_path()` derives from `Path(settings.chroma_path).parent`, so
+    a relative override of `data/explicit_chroma` yields a `crm.db` sibling
+    under `data/`. The returned string stays relative (unchanged from
+    pre-anchoring behavior), but the directory it creates as a side effect
+    is resolved against the foreign cwd, not the repo root."""
+    foreign_cwd = tmp_path / "not-the-repo"
+    foreign_cwd.mkdir()
+
+    resolved = _run_get_crm_db_path(foreign_cwd, "data/explicit_chroma")
+
+    assert resolved == "data/crm.db"
+    assert (foreign_cwd / "data").is_dir()
+    assert not (REPO_ROOT / "data" / "explicit_chroma").exists()
+
+
+@pytest.mark.unit
+def test_explicit_absolute_chroma_path_with_space_is_preserved(tmp_path):
+    """A real-world absolute override may contain a space (e.g. a vault
+    path under a directory named with a date/year). Anchoring the default
+    must not corrupt an explicit override reached through string handling
+    that assumes no whitespace."""
+    foreign_cwd = tmp_path / "not-the-repo"
+    foreign_cwd.mkdir()
+    chroma_dir = tmp_path / "My Chroma 2099" / "chromadb"
+
+    resolved = _run_get_crm_db_path(foreign_cwd, str(chroma_dir))
+
+    assert resolved == str(tmp_path / "My Chroma 2099" / "crm.db")


### PR DESCRIPTION
## Summary

`config/settings.py`'s `vault_path` and `chroma_path` defaults were cwd-relative (`Path("./vault")`, `Path("./data/chromadb")`). Nineteen call sites derive a data-store path from `Path(settings.chroma_path).parent`, so any caller whose working directory isn't the repo root resolved data files (crm.db, conversations.db, usage.db, bm25_index.db, etc.) against the wrong directory.

Anchors both defaults to the repo root via `_REPO_ROOT = Path(__file__).resolve().parent.parent`, computed once at import time from `settings.py`'s own location. All nineteen derived stores inherit the fix from this one change since they read `settings.chroma_path` at call time rather than caching a module-level constant. An operator-set `LIFEOS_VAULT_PATH`/`LIFEOS_CHROMA_PATH` still wins unchanged, including a deliberately relative one — only the default changes.

`tests/test_data_path_anchoring.py` is extended with foreign-cwd coverage for `get_crm_db_path()`, `get_conversation_db_path()`, `get_bm25_db_path()`, and `UsageStore`'s default `db_path`, plus explicit-override cases (relative override still resolves against cwd; an absolute override containing a space is preserved byte-for-byte).

Fixes #1038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXNMnBCw1vTtx1jYrW54Ms