### PR TITLE
fix(tests): give PersonEntityStore an owned default path under parallel runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -613,6 +613,43 @@ def _isolate_default_task_manager_paths(request, tmp_path, monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def _isolate_default_person_entity_store_path(request, tmp_path, monkeypatch):
+    """Redirect a default-constructed ``PersonEntityStore``'s database path
+    to a path owned by this test.
+
+    ``PersonEntityStore.CRM_DB_PATH`` is a ``Path(__file__)``-derived class
+    attribute, not something resolved through ``settings`` -- every xdist
+    worker that skips this fixture resolves the same repo-root file.
+    ``__init__`` falls back to it when no ``db_path`` is given, and
+    ``_init_db()`` connects to that path (creating the file) before issuing
+    ``CREATE TABLE IF NOT EXISTS`` -- a concurrent worker connecting to the
+    same file inside that window sees an empty database and raises
+    ``sqlite3.OperationalError: no such table: person_entities``. Patch the
+    class attribute directly and reset the ``_entity_store`` singleton so
+    the next default construction picks up the new path.
+    ``get_person_entity_store`` itself is left intact, so a test that
+    injects its own store by setting the ``_entity_store`` singleton still
+    has that store served to the code under test. Tests marked ``slow`` or
+    ``integration`` carry their own redirection above and are left alone
+    here.
+    """
+    if request.node.get_closest_marker("slow") is not None:
+        yield
+        return
+    if request.node.get_closest_marker("integration") is not None:
+        yield
+        return
+
+    import api.services.person_entity as person_entity_mod
+
+    monkeypatch.setattr(
+        person_entity_mod.PersonEntityStore, "CRM_DB_PATH", tmp_path / "crm.db"
+    )
+    monkeypatch.setattr(person_entity_mod, "_entity_store", None)
+    yield
+
+
 # Collection names `VectorStore` actually writes to on a real install:
 # `VectorStore`'s own class default (also what `get_vector_store()`'s
 # process-wide singleton resolves to) plus every non-vault indexer's own

--- a/tests/test_person_entity_store_isolation.py
+++ b/tests/test_person_entity_store_isolation.py
@@ -1,0 +1,60 @@
+"""A default-constructed ``PersonEntityStore``'s database path is isolated
+per test.
+
+``PersonEntityStore.CRM_DB_PATH`` is a ``Path(__file__)``-derived class
+attribute, not something resolved through ``settings``. ``__init__`` falls
+back to it when no ``db_path`` is given, and ``_init_db()`` connects to that
+path (creating the file) before issuing ``CREATE TABLE IF NOT EXISTS`` -- a
+second process connecting to the same file inside that window sees an empty
+database and raises
+``sqlite3.OperationalError: no such table: person_entities``.
+
+A deterministic reproduction of that race across real parallel worker
+processes is impractical to drive from a single test. These tests instead
+pin the ownership property that prevents it: the path a default-constructed
+``PersonEntityStore`` resolves to is never the repo-root path every process
+that skips isolation would share, and it lives under this test's own
+pytest-managed temp tree.
+"""
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _shared_default_crm_db_path() -> Path:
+    """The path a default-constructed store shares with every other process
+    that also skips isolation.
+
+    Computed from this test file's own known position in the repo tree,
+    independent of ``PersonEntityStore.CRM_DB_PATH`` -- reading the class
+    attribute here would compare the isolated path against itself and
+    assert nothing.
+    """
+    return Path(__file__).parent.parent / "data" / "crm.db"
+
+
+def test_person_entity_store_default_path_is_isolated(tmp_path_factory):
+    """A default-constructed ``PersonEntityStore`` must not resolve to the
+    shared repo-root path every other default-constructed store would
+    share."""
+    from api.services.person_entity import PersonEntityStore
+
+    resolved = Path(PersonEntityStore().db_path)
+
+    assert resolved != _shared_default_crm_db_path()
+    assert resolved.is_relative_to(tmp_path_factory.getbasetemp())
+
+
+def test_person_entity_store_singleton_default_path_is_isolated(tmp_path_factory):
+    """``get_person_entity_store()``'s lazily constructed singleton resolves
+    the same isolated path as a direct ``PersonEntityStore()`` construction."""
+    import api.services.person_entity as person_entity_mod
+
+    person_entity_mod._entity_store = None
+    resolved = Path(person_entity_mod.get_person_entity_store().db_path)
+    person_entity_mod._entity_store = None
+
+    assert resolved != _shared_default_crm_db_path()
+    assert resolved.is_relative_to(tmp_path_factory.getbasetemp())

--- a/tests/test_tone_analysis_handler.py
+++ b/tests/test_tone_analysis_handler.py
@@ -240,18 +240,13 @@ class TestCacheAndFreshness:
 
         client = _patch_llm(monkeypatch, _RecordingLLMClient())
 
-        start = time.time()
         response = app_client.post("/api/crm/relationship/tone-analysis-detailed")
-        elapsed = time.time() - start
 
         # `client.calls == []` is the load-bearing assertion for the "cache
-        # hit avoids the LLM call" acceptance criterion. The wall-clock
-        # bound below passes comfortably in practice, but it is secondary --
-        # a loaded xdist worker is a more plausible source of flake than the
-        # call-count check.
+        # hit avoids the LLM call" acceptance criterion: it observes the call
+        # list directly, so it holds on any hardware.
         assert response.status_code == 200
         assert client.calls == []
-        assert elapsed < 0.2
 
         data = response.json()
         by_month = {t["month"]: t for t in data["monthly_tones"]}
@@ -579,9 +574,7 @@ class TestCacheHitPerformance:
 
         client = _patch_llm(monkeypatch, _RecordingLLMClient())
 
-        start = time.time()
         response = app_client.post("/api/crm/relationship/tone-analysis-detailed?months=12")
-        elapsed = time.time() - start
 
         assert response.status_code == 200
         assert client.calls == []
@@ -589,7 +582,6 @@ class TestCacheHitPerformance:
         # called on a full cache hit, regardless of how large the window's
         # true row count is.
         assert patch_interactions.range_fetch_calls == []
-        assert elapsed < 0.2
 
         assert len(response.json()["monthly_tones"]) == len(counts)
 


### PR DESCRIPTION
## Summary

Two test-isolation fixes that both surfaced from the same parallel-run failure mode.

**`PersonEntityStore` default path (Fixes #1042).** `CRM_DB_PATH` is a `Path(__file__)`-derived class attribute, so every xdist worker resolves the same repo-root `data/crm.db`. `_init_db()` connects — creating the file — before issuing `CREATE TABLE IF NOT EXISTS`, so a worker connecting inside that window sees an empty database. A new autouse fixture gives unmarked tests an owned path and resets the `_entity_store` singleton; `get_person_entity_store()` itself is untouched, so a test injecting its own store still wins. `slow` and `integration` tests keep their existing redirection.

**Redundant wall-clock bounds (Fixes #1058).** Both tone-analysis cache-hit tests assert the call list directly — `client.calls == []` and `range_fetch_calls == []` — and then restate that property as a `0.2s` bound. The call-list assertions observe the skipped work itself and hold on any hardware; the bounds measure the host, and one failed a candidate run at `0.2063s`. One of the two already carried a comment calling its bound secondary and naming a loaded xdist worker as the likely flake source.

## Verification

- `test_route_handlers_concurrency.py` leaves no `data/crm.db`; on `main` it creates one.
- Both new isolation tests fail against pre-change `conftest.py` and pass with it.
- The surviving cache-hit guard still discriminates: appending a simulated fetch makes the test fail; clean, it passes.
- `tests/test_tone_analysis_handler.py` — 34 passed. Narration ratchet and Ruff pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)