### PR TITLE
fix(publisher): accept only the verification this dispatch caused

### DIFF
--- a/docs/guides/candidate-verification-ci.md
+++ b/docs/guides/candidate-verification-ci.md
@@ -112,7 +112,14 @@ the candidate, pushes it to a disposable staging ref, dispatches
 `workflow_dispatch` against it, polls for the resulting check via the
 GitHub API filtered to the dedicated App's `app_id` (never accepting a
 same-named check from any other app), and only then performs the atomic
-`main`+source publish. See `scripts/candidate_publisher.py`'s module
+`main`+source publish. Because a candidate SHA is deterministic from its
+content, re-publishing an unchanged branch rebuilds the identical candidate,
+which may already carry verdicts from an earlier dispatch; the publisher
+snapshots those check-run ids before dispatching and accepts only a check this
+invocation caused, taking the most recently started completed one rather than
+whichever the API lists first. That holds in both directions — a stale failure
+never refuses a candidate whose fresh run passed, and a stale success never
+authorizes publication of one whose own run did not. See `scripts/candidate_publisher.py`'s module
 docstring for the exact ordering guarantee (construct before verify, verify
 before publish).
 

--- a/scripts/candidate_publisher.py
+++ b/scripts/candidate_publisher.py
@@ -36,7 +36,7 @@ from urllib.parse import urlencode
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Optional, Sequence
+from typing import Callable, Iterable, Optional, Sequence
 
 Runner = Callable[..., subprocess.CompletedProcess]
 
@@ -441,12 +441,69 @@ class CheckOutcome:
     detail: str
 
 
+def _is_required_check(check: dict, check_name: str, trusted_app_id: Optional[int]) -> bool:
+    """Name-and-issuer match for the required check.
+
+    The issuer half is the property that closes the forged-context
+    vulnerability a generic Actions-app-only match cannot: a
+    candidate-controlled workflow can trivially post a check with a matching
+    *name*, but it cannot authenticate as an app whose credentials it was
+    never given.
+    """
+    if check.get("name") != check_name:
+        return False
+    if trusted_app_id is not None and (check.get("app") or {}).get("id") != trusted_app_id:
+        return False
+    return True
+
+
+def _check_recency_key(check: dict) -> tuple[str, int]:
+    """Order matching checks newest-last. `started_at` is ISO-8601 UTC, so
+    it sorts lexicographically; the check id breaks ties and stands in for a
+    missing timestamp, since GitHub check-run ids increase monotonically.
+    """
+    return (str(check.get("started_at") or ""), int(check.get("id") or 0))
+
+
+def existing_check_run_ids(
+    repository: str,
+    candidate_sha: str,
+    check_name: str,
+    *,
+    trusted_app_id: Optional[int] = None,
+    run: Runner = subprocess.run,
+) -> frozenset[int]:
+    """The required-check runs already present on a candidate SHA.
+
+    A candidate SHA is deterministic from its content, so a re-publish of an
+    unchanged branch targets a SHA that may already carry verdicts from an
+    earlier dispatch. Snapshotting their ids before dispatching lets the wait
+    below accept only a check this invocation actually caused.
+
+    A failed query raises rather than returning an empty set: "no existing
+    checks" and "could not tell" must not collapse into the same value, since
+    the empty set is precisely what would let a stale verdict through.
+    """
+    result = _run(run, ["gh", "api", f"repos/{repository}/commits/{candidate_sha}/check-runs"])
+    if result.returncode != 0:
+        raise PublisherError(
+            f"could not read existing {check_name!r} checks for {candidate_sha}: {result.stderr.strip()}"
+        )
+    payload = json.loads(result.stdout)
+    return frozenset(
+        int(check["id"])
+        for check in payload.get("check_runs", [])
+        if _is_required_check(check, check_name, trusted_app_id) and check.get("id") is not None
+    )
+
+
 def await_required_check(
     repository: str,
     candidate_sha: str,
     check_name: str,
     *,
     trusted_app_id: Optional[int] = None,
+    ignore_check_run_ids: Iterable[int] = (),
     timeout_seconds: float = 1800.0,
     poll_interval_seconds: float = 5.0,
     run: Runner = subprocess.run,
@@ -461,28 +518,34 @@ def await_required_check(
     issuer configuration before any GitHub call and always supplies a
     dedicated app id.
 
-    When ``trusted_app_id`` is given, a check with a matching name but a
-    different reporting app is not accepted — this is exactly the property
-    that closes the forged-context vulnerability a generic Actions-app-only
-    match cannot: a candidate-controlled workflow can trivially post a check
-    with a matching *name*, but it cannot authenticate as an app whose
-    credentials it was never given.
+    ``ignore_check_run_ids`` carries the verdicts that already existed on this
+    SHA before the caller dispatched its own verification (see
+    ``existing_check_run_ids``). They are never accepted, in either direction:
+    a stale failure would refuse a candidate that now passes, and a stale
+    success would authorize publication on the strength of a run that did not
+    verify this dispatch. The second is the graver of the two, so the filter
+    is applied before the conclusion is ever read.
+
+    Among the checks that remain, the most recently started completed one
+    decides the outcome — never whichever the API happened to list first.
     """
+    ignored = frozenset(ignore_check_run_ids)
     deadline = now() + timeout_seconds
     while True:
         result = _run(run, ["gh", "api", f"repos/{repository}/commits/{candidate_sha}/check-runs"])
         if result.returncode == 0:
             payload = json.loads(result.stdout)
-            for check in payload.get("check_runs", []):
-                if check.get("name") != check_name:
-                    continue
-                if trusted_app_id is not None and (check.get("app") or {}).get("id") != trusted_app_id:
-                    continue
-                if check.get("status") != "completed":
-                    break
-                conclusion = check.get("conclusion")
+            completed = [
+                check for check in payload.get("check_runs", [])
+                if _is_required_check(check, check_name, trusted_app_id)
+                and check.get("id") not in ignored
+                and check.get("status") == "completed"
+            ]
+            if completed:
+                newest = max(completed, key=_check_recency_key)
+                conclusion = newest.get("conclusion")
                 if conclusion == "success":
-                    return CheckOutcome("success", f"{check_name} succeeded at {check.get('completed_at')}")
+                    return CheckOutcome("success", f"{check_name} succeeded at {newest.get('completed_at')}")
                 return CheckOutcome("failure", f"{check_name} concluded {conclusion}")
         if now() >= deadline:
             return CheckOutcome("timeout", f"no matching completed {check_name} within {timeout_seconds}s")
@@ -713,13 +776,21 @@ def publish_pull_request(
     staging_ref = staging_ref_for(pr.number, candidate.sha)
     push_candidate_for_verification(repo, remote, candidate.sha, staging_ref, run=run)
     try:
+        # Snapshot before dispatching, so the wait below can tell this
+        # invocation's verdict from one already on the SHA. Re-publishing an
+        # unchanged branch rebuilds the identical candidate, which is a normal
+        # recovery path rather than an error.
+        preexisting_checks = existing_check_run_ids(
+            repository, candidate.sha, check_name, trusted_app_id=trusted_app_id, run=run,
+        )
         trigger_trusted_verification(
             repository, workflow_file, candidate.sha, pr_number=pr.number,
             trusted_runner_sha=expected_main_sha, ref=pr.base_ref, run=run,
         )
         check = await_required_check(
             repository, candidate.sha, check_name,
-            trusted_app_id=trusted_app_id, timeout_seconds=check_timeout_seconds,
+            trusted_app_id=trusted_app_id, ignore_check_run_ids=preexisting_checks,
+            timeout_seconds=check_timeout_seconds,
             poll_interval_seconds=check_poll_interval_seconds, run=run, sleep=sleep, now=now,
         )
         if check.state != "success":

--- a/tests/test_candidate_publisher.py
+++ b/tests/test_candidate_publisher.py
@@ -406,6 +406,122 @@ def test_await_required_check_ignores_a_matching_name_from_the_wrong_app():
     assert sleeps == [1]
 
 
+def _check_run(run_id: int, conclusion: str, *, started_at: str, app_id: int = 42,
+               name: str = "candidate-verification") -> dict:
+    return {
+        "id": run_id, "name": name, "status": "completed", "conclusion": conclusion,
+        "started_at": started_at, "completed_at": started_at, "app": {"id": app_id},
+    }
+
+
+def test_await_required_check_ignores_a_verdict_that_predates_this_dispatch():
+    """A candidate SHA is deterministic from its content, so re-publishing an
+    unchanged branch lands on a SHA that may already carry an earlier verdict.
+    A stale failure must not refuse a candidate whose fresh run passed."""
+    payload = {"check_runs": [
+        _check_run(1, "failure", started_at="2026-01-01T00:00:00Z"),
+        _check_run(2, "success", started_at="2026-01-01T01:00:00Z"),
+    ]}
+
+    def run(args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+    outcome = await_required_check(
+        "nbramia/LifeOS", "deadbeef", "candidate-verification", trusted_app_id=42,
+        ignore_check_run_ids={1},
+        timeout_seconds=100, poll_interval_seconds=1, run=run,
+        sleep=lambda s: None, now=iter([0, 1]).__next__,
+    )
+    assert outcome.state == "success"
+
+
+def test_await_required_check_never_publishes_on_a_stale_success():
+    """The graver direction: a success left over from an earlier dispatch must
+    not authorize publication of a candidate whose own run failed."""
+    payload = {"check_runs": [
+        _check_run(7, "success", started_at="2026-01-01T00:00:00Z"),
+        _check_run(8, "failure", started_at="2026-01-01T01:00:00Z"),
+    ]}
+
+    def run(args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+    outcome = await_required_check(
+        "nbramia/LifeOS", "deadbeef", "candidate-verification", trusted_app_id=42,
+        ignore_check_run_ids={7},
+        timeout_seconds=100, poll_interval_seconds=1, run=run,
+        sleep=lambda s: None, now=iter([0, 1]).__next__,
+    )
+    assert outcome.state == "failure"
+
+
+def test_await_required_check_waits_rather_than_reading_an_ignored_verdict():
+    """With only the ignored verdict present, the wait keeps polling — it does
+    not fall back to the stale answer, and it does not report success."""
+    calls = {"n": 0}
+    stale_only = {"check_runs": [_check_run(1, "success", started_at="2026-01-01T00:00:00Z")]}
+
+    def run(args, **kwargs):
+        calls["n"] += 1
+        return SimpleNamespace(returncode=0, stdout=json.dumps(stale_only), stderr="")
+
+    clock = iter([0, 50, 150])
+    outcome = await_required_check(
+        "nbramia/LifeOS", "deadbeef", "candidate-verification", trusted_app_id=42,
+        ignore_check_run_ids={1},
+        timeout_seconds=100, poll_interval_seconds=1, run=run,
+        sleep=lambda s: None, now=lambda: next(clock),
+    )
+    assert outcome.state == "timeout"
+    assert calls["n"] >= 2
+
+
+def test_await_required_check_reads_the_newest_completed_check_not_the_first_listed():
+    """Ordering in the API response must not decide the verdict."""
+    payload = {"check_runs": [
+        _check_run(3, "failure", started_at="2026-01-01T00:00:00Z"),
+        _check_run(4, "success", started_at="2026-01-01T02:00:00Z"),
+    ]}
+
+    def run(args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+    outcome = await_required_check(
+        "nbramia/LifeOS", "deadbeef", "candidate-verification", trusted_app_id=42,
+        timeout_seconds=100, poll_interval_seconds=1, run=run,
+        sleep=lambda s: None, now=iter([0, 1]).__next__,
+    )
+    assert outcome.state == "success"
+
+
+def test_existing_check_run_ids_snapshots_only_the_trusted_issuer():
+    payload = {"check_runs": [
+        _check_run(1, "failure", started_at="2026-01-01T00:00:00Z"),
+        _check_run(2, "success", started_at="2026-01-01T00:00:00Z", app_id=999999),
+        _check_run(3, "success", started_at="2026-01-01T00:00:00Z", name="something-else"),
+    ]}
+
+    def run(args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+    assert publisher.existing_check_run_ids(
+        "nbramia/LifeOS", "deadbeef", "candidate-verification", trusted_app_id=42, run=run,
+    ) == frozenset({1})
+
+
+def test_existing_check_run_ids_raises_rather_than_reporting_none_on_a_failed_query():
+    """"No existing checks" and "could not tell" must not collapse into the
+    same value — the empty set is exactly what would let a stale verdict
+    through."""
+    def run(args, **kwargs):
+        return SimpleNamespace(returncode=1, stdout="", stderr="boom")
+
+    with pytest.raises(publisher.PublisherError, match="could not read existing"):
+        publisher.existing_check_run_ids(
+            "nbramia/LifeOS", "deadbeef", "candidate-verification", trusted_app_id=42, run=run,
+        )
+
+
 def test_await_required_check_times_out_when_nothing_matches():
     def run(args, **kwargs):
         return SimpleNamespace(returncode=0, stdout=json.dumps({"check_runs": []}), stderr="")
@@ -726,6 +842,10 @@ def test_open_shared_head_ref_is_rechecked_before_atomic_publish(monkeypatch, tm
 
     def fake_run(args, **kwargs):
         nonlocal list_calls
+        if args[:2] == ["gh", "api"] and str(args[-1]).endswith("/check-runs"):
+            # The pre-dispatch snapshot of verdicts already on this candidate;
+            # counted separately from the head-exclusivity listings below.
+            return SimpleNamespace(returncode=0, stdout=json.dumps({"check_runs": []}), stderr="")
         if args[:2] == ["gh", "api"]:
             list_calls += 1
             rows = [{


### PR DESCRIPTION
## Summary

Closes #1061.

A candidate SHA is deterministic from its content, so re-publishing an unchanged branch targets a SHA that may already carry verdicts from an earlier dispatch. `await_required_check` returned the **first** name-and-issuer match the API listed, so which verdict decided the publish depended on response ordering rather than on which run the publisher was actually waiting for.

Observed on #1059: the first gate run failed on an unrelated flaky test (#1060); re-running the publisher dispatched a fresh run, returned the previous failure within seconds, and exited. That fresh run then completed successfully.

- The publisher snapshots the required-check run ids on the candidate **before** dispatching, and ignores them while waiting.
- Among what remains, the most recently started completed check decides the outcome.
- A failed snapshot query raises rather than returning an empty set — "no existing checks" and "could not tell" must not collapse into the same value, since the empty set is precisely what would let a stale verdict through.

This matters in both directions. A stale **failure** refuses a candidate that would now pass; a stale **success** would authorize publication on the strength of a run that did not verify this dispatch. The second is the graver one, so the filter is applied before any conclusion is read.

The trusted-app-id filter is untouched — run identity is a separate property from issuer identity, and both are required.

## Validation

- 36 publisher tests pass (6 new).
- Each new test mutation-checked: dropping the ignore-set, taking the first listed check instead of the newest, and returning an empty set on a failed query each fail their test.
- Ruff clean.

## Note

One existing test (`test_open_shared_head_ref_is_rechecked_before_atomic_publish`) stubbed *every* `gh api` call as the open-PR listing and counted them. Its stub now routes `/check-runs` separately; the assertion it actually makes — two head-exclusivity checks, no publish — is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)