### PR TITLE
test: remove the host-speed and background-process assumptions two unit tests carry

### DIFF
--- a/tests/test_agent_worker_executor_lifecycle.py
+++ b/tests/test_agent_worker_executor_lifecycle.py
@@ -371,14 +371,27 @@ def test_hermes_blocked_fake_stream_honors_absolute_deadline(tmp_path, monkeypat
 
     class Client:
         closed = False
+        # Stamped by the factory below and by close(), bracketing exactly the
+        # interval the absolute deadline governs.
+        opened_at: float | None = None
+        closed_at: float | None = None
 
         def stream(self, *_args, **_kwargs):
             return Stream()
 
         def close(self):
+            if self.closed_at is None:
+                self.closed_at = time.monotonic()
             self.closed = True
 
     client = Client()
+
+    def open_client():
+        # The executor derives its deadline from the wall budget and then
+        # immediately asks for a client, so this is the deadline's own origin.
+        client.opened_at = time.monotonic()
+        return client
+
     sessions = SessionStore(db_path=tmp_path / "sessions.db")
     session = sessions.create(
         "hermes-deadline", routing="hermes", budget={"wall_seconds": 0.03},
@@ -386,19 +399,21 @@ def test_hermes_blocked_fake_stream_honors_absolute_deadline(tmp_path, monkeypat
     executor = HermesExecutor(
         session_store=sessions,
         transcript_store=TranscriptStore(transcripts_dir=tmp_path / "transcripts"),
-        http_client_factory=lambda: client,
+        http_client_factory=open_client,
     )
-    started = time.monotonic()
     outcome = executor.execute(session, {"description": "synthetic blocked turn"})
-    elapsed = time.monotonic() - started
-    # The bound separates the two deadlines this test tells apart: the
-    # session's 0.03s wall budget and the 3600s read-idle timeout the
-    # blocked reader would otherwise sit on. Any figure between them
-    # proves the executor stopped on the budget, so this one is set far
-    # enough above 0.03 to absorb scheduler delay on a loaded parallel
-    # run -- a bound a few hundred milliseconds wide measures the host,
-    # not the executor.
-    assert elapsed < 10, f"executor took {elapsed:.2f}s; budget was 0.03s"
+    # Enforcement is a real timed wait, so "stopped on the 0.03s wall budget
+    # rather than the 3600s read-idle timeout" is a claim about elapsed time.
+    # What keeps it off the host's speed is which interval is measured: from
+    # the deadline's own origin to the moment the blocked reader was stopped,
+    # excluding the conversation-store, envelope, and transcript work that
+    # surrounds it and that a contended host stretches without touching the
+    # deadline at all. Anything between the two candidate bounds proves which
+    # one the executor used; this one leaves the budget two orders of
+    # magnitude of scheduler slack and stays three below the timeout.
+    assert client.closed_at is not None, "the executor never stopped the blocked reader"
+    governed = client.closed_at - client.opened_at
+    assert governed < 2, f"stopping the blocked reader took {governed:.2f}s; budget was 0.03s"
     assert outcome.status == STATUS_FAILED
     assert "absolute turn deadline" in outcome.reason
     assert outcome.termination_evidence["absolute_deadline"] is True

--- a/tests/test_remote_test_runner.py
+++ b/tests/test_remote_test_runner.py
@@ -18,6 +18,22 @@ REPO = Path(__file__).resolve().parent.parent
 BOUNDED_EXEC = REPO / "scripts" / "_bounded_exec.py"
 
 
+def _no_background_git_maintenance(repo: Path) -> None:
+    """Keep every git command in a throwaway repo fully synchronous.
+
+    A writing command such as `git commit` starts auto maintenance, which
+    detaches and keeps operating on the repository after the command that
+    started it has exited — its own lock file lives directly in
+    `.git/objects`, and the gc task it may run rewrites that directory. A
+    test that removes or rebuilds `.git` the instant a commit returns is
+    then racing a process it never started, so these repositories opt out
+    for their whole lifetime instead.
+    """
+    subprocess.run(["git", "config", "maintenance.auto", "false"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "gc.auto", "0"], cwd=repo, check=True)
+
+
+
 def _synthetic_remote_checkout(
     tmp_path: Path, *, failing: bool = False, initial_branch: str | None = None,
 ) -> Path:
@@ -42,6 +58,7 @@ def _synthetic_remote_checkout(
     if initial_branch is not None:
         init_args.append(f"--initial-branch={initial_branch}")
     subprocess.run(init_args, cwd=checkout, check=True)
+    _no_background_git_maintenance(checkout)
     subprocess.run(["git", "config", "user.name", "Synthetic Remote"], cwd=checkout, check=True)
     subprocess.run(["git", "config", "user.email", "remote@example.invalid"], cwd=checkout, check=True)
     subprocess.run(["git", "add", "."], cwd=checkout, check=True)
@@ -114,6 +131,7 @@ def _synthetic_main_repo(tmp_path: Path) -> Path:
         "import pytest\n@pytest.mark.unit\ndef test_remote_candidate(): assert True\n"
     )
     subprocess.run(["git", "init", "-q"], cwd=main, check=True)
+    _no_background_git_maintenance(main)
     # Identifying source-host identity: must never appear on the transferred
     # side — proves no git config/credential export, not just no .git copy.
     subprocess.run(["git", "config", "user.name", "Source Host Identity"], cwd=main, check=True)
@@ -723,6 +741,7 @@ def test_bundle_metadata_field_parsing_preserves_empty_detached_branch_field():
         repo = tmp_path / "repo"
         repo.mkdir()
         subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        _no_background_git_maintenance(repo)
         subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
         subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=repo, check=True)
         (repo / "a.txt").write_text("a\n")

--- a/tests/test_remote_test_runner.py
+++ b/tests/test_remote_test_runner.py
@@ -1001,6 +1001,7 @@ def test_pre_transfer_failures_never_touch_the_remote(tmp_path, setup, expected_
     elif setup == "no_commits":
         shutil.rmtree(checkout / ".git")
         subprocess.run(["git", "init", "-q"], cwd=checkout, check=True)
+        _no_background_git_maintenance(checkout)
 
     fake_bin = _fake_transport_bin(tmp_path)
     home = tmp_path / "home"


### PR DESCRIPTION
## TL;DR

Two unit tests failed only on the narrow, contended hosted verification
machine, for two unrelated reasons, and both now stand on something the host's
speed and scheduling cannot move. One test built a throwaway git repository and
deleted part of it the moment a commit finished, unaware that git leaves a
background process still working inside that repository; those repositories now
turn the background work off for their whole lifetime. The other test claimed a
turn stopped on its own time budget by timing the entire executor call, most of
which is unrelated bookkeeping the busy machine stretched at will; it now times
only the stretch of work the budget actually governs.

Part of #1060

## Design

The first failure is a genuine race with a real second actor, so the fix removes
that actor rather than tolerating it. A writing git command starts auto
maintenance, and on a recent git that maintenance detaches and does its work
after the command that started it has already exited. Its lock file lives
directly inside the object directory and the collection task it may run rewrites
that directory, so a throwaway repository whose `.git` is deleted immediately
after a commit is competing with a process the test never launched. Disabling
maintenance for these repositories keeps every git command they run fully
synchronous; retrying or ignoring errors from the deletion would have left the
second actor in place.

The second failure is not a race but a measurement mistake. Enforcement of the
turn budget is a real timed wait, so "stopped on the budget rather than on the
much longer read-idle timeout" is unavoidably a claim about elapsed time; what
made it fragile was measuring an interval that mostly consists of conversation
store, envelope, and transcript work the deadline has no say over. Anchoring the
measurement to the deadline's own origin, and ending it at the moment the
blocked reader is stopped, leaves a window whose expected width is the budget
itself, so the bound can sit orders of magnitude clear of both candidates
instead of being tuned against observed noise.

A third test named in the issue, the cache-hit assertion, already asserts the
invariant rather than a duration — the row-loading fetch must not be called at
all — and is unchanged here; the evidence below confirms that assertion still
fails when the behaviour regresses. The fourth, the interrupt test, is fixed on
main by the change that closed #1050.

## Implementation Notes

`tests/test_remote_test_runner.py` gains `_no_background_git_maintenance`, called
by each of the three helpers that initialize a synthetic repository. It sets
`maintenance.auto=false`, which is the switch git itself consults before
starting background maintenance, and `gc.auto=0` for git versions that reach
collection by the older route.

`tests/test_agent_worker_executor_lifecycle.py`'s
`test_hermes_blocked_fake_stream_honors_absolute_deadline` stamps the synthetic
client when the executor asks for it and when the executor closes it, and
asserts on the difference. The outcome assertions — failed status, absolute
deadline reason, and termination evidence — are unchanged.

## Test evidence

### Automated tests

`tests/test_remote_test_runner.py`, `tests/test_agent_worker_executor_lifecycle.py`,
and `tests/test_tone_analysis_handler.py` together, in the contended shape the
hosted lane uses (four workers pinned to four CPUs, `--dist loadscope`):
78 passed. `tests/test_no_change_narration.py` passes and Ruff is clean on both
changed files.

### Manual verification

**1. Git's background maintenance outlives the command that started it.** A
repository built the way these helpers build one, with the collection threshold
lowered so the task actually runs:

```
objects/17 count before commit: 4
TRACE: trace: run_command: git maintenance run --auto --quiet
TRACE: trace: run_command: git gc --auto --quiet
immediately after commit, .git/objects listing: ['00', '01', ... ]
packs: []
2s later, packs: ['pack-667ea673....idx', 'pack-667ea673....pack', 'pack-667ea673....rev']
gc.log: True
live git processes: []
```

`git commit` has returned, its process tree is gone, and the object directory is
still being rewritten. With `maintenance.auto=false` set on the same repository,
the same script produces no maintenance invocation at all:

```
objects/17 count before commit: 4
packs: []
2s later, packs: []
gc.log: False
```

**2. The failure reproduces, and the fix removes it.** Standing in for the
hosted machine's git, a shim spawns the same detached lock-file work after
`git commit` and honours the same two config keys real git checks. Against the
pre-change test it reproduces the hosted failure exactly — same test, same
parametrization, same directory:

```
tests/test_remote_test_runner.py:971: shutil.rmtree(checkout / ".git")
E  OSError: [Errno 39] Directory not empty:
   '.../test_pre_transfer_failures_nev2/checkout/.git/objects'
```

Repeating that test 20 times against the pre-change code: 18 passed, 2 failed.
Repeating it 30 times against the change, with the identical adversary present:
30 passed, 0 failed — the adversary is never spawned, because the repository
opts out.

**3. The deadline measurement no longer tracks the host.** Both candidate
measurements taken over the same runs, with a three-second stall injected into
the transcript work that surrounds the deadline:

```
iterations=4
whole execute() call : min=6.029s max=6.043s
deadline-governed    : min=0.010s max=0.013s
```

The whole call scales with work the deadline does not govern; the governed
interval does not move. Every outcome assertion holds in both columns. Under
sixteen CPU burners pinned to four CPUs, without any injected stall, the
governed interval stays between 0.010s and 0.013s against a 0.03s budget.

**4. The cache-hit invariant is still load-bearing.** With production changed to
load rows on a cache hit, `TestCacheHitPerformance` fails on the call-count
assertion (`Left contains one more item: 1`); with production restored it
passes. No timing assertion remains in that test.

## Review focus

- Whether `maintenance.auto=false` plus `gc.auto=0` is the right pair of keys to
  disable background git work for a throwaway repository, and whether applying
  it to all three repository builders in `tests/test_remote_test_runner.py`
  rather than only the one that flaked is the correct scope.
- The two-second bound in `tests/test_agent_worker_executor_lifecycle.py`: the
  interval it covers now has an expected width of the 0.03s budget, and the
  alternative it rules out is 3600s, so any value between them decides the
  question — this one is chosen for distance from both rather than from measured
  noise.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
