### PR TITLE
test: make each test module establish its own database prerequisite

### DIFF
--- a/docs/guides/candidate-verification-ci.md
+++ b/docs/guides/candidate-verification-ci.md
@@ -71,23 +71,20 @@ of a partitioned run:
   --lane-log-dir /path/to/lane-logs
 ```
 
-### What still blocks running the gate in parts
+### What running the gate in parts still waits on
 
-The hosted gate runs one execution job, not a matrix, because the `fast-unit`
-lane is not yet safe to partition at all. At least one module —
-`tests/test_briefings_service.py` — takes `require_db`'s conditional skip for
-five of its seven tests when it runs without whichever other module first
-creates the runtime `interactions` table, which it does even when that module
-is the only one selected. A whole-lane run happens to win that ordering; a
-four-part run of the same candidate does not, and the part owning that module
-correctly fails with five skips against the whole lane's one.
+The hosted gate runs one execution job, not a matrix. Partitioning a lane is
+safe only where every module in it establishes its own prerequisites. A
+cross-module prerequisite — a module whose tests pass only because some other
+module created runtime state first — is one no partition of whole modules can
+satisfy, and it shows up as a conditional skip that a part takes and a whole
+lane does not. A module that reads the runtime `interactions` database creates
+that table through `require_db`, so it reports the same outcomes selected alone
+as it does beside the whole lane.
 
-That is a cross-module prerequisite, which no partition of whole modules can
-satisfy: such a module has to establish its own store. Until every module in
-the lane is self-sufficient, enabling a matrix would fail the gate for every
-candidate. Prove coverage equivalence — an unpartitioned run and a partitioned
-run of the same candidate reporting the same skip count — before changing the
-topology.
+Confirm that property for a lane before changing its topology: run an
+unpartitioned verification of one candidate and a partitioned verification of
+the same candidate, and require the total skip count to be identical.
 
 Note also that a workflow change cannot verify itself: `pull_request_target`
 and `workflow_dispatch` both resolve the workflow definition from the base

--- a/docs/specs/standards/testing-standards.md
+++ b/docs/specs/standards/testing-standards.md
@@ -230,6 +230,16 @@ Shared fixtures are in `tests/conftest.py`. Key fixtures:
 | `mock_settings` | function | Patched `config.settings.settings` with temp paths |
 | `server_available` | session | Checks if API server is running |
 | `reset_singletons_after_test` | function (autouse) | Resets service singletons to prevent test pollution |
+| `require_db` | function | Establishes the `interactions` schema, then skips when the database is locked |
+| `require_populated_db` | function | Adds `require_db`'s gate, then skips when the runtime databases hold no records |
+
+A module establishes every prerequisite it can establish for itself, so its
+outcomes are the same whether it runs alone or beside the whole lane. A
+conditional skip is reserved for a precondition the module genuinely cannot
+create: a running server holding the database lock, or the absence of a
+developer's own indexed records. Depending on a prerequisite that a different
+module happens to create makes the module's outcomes a function of which other
+modules the run selected, which no partition of the suite can reproduce.
 
 Test-specific fixtures use `tmp_path` for isolated file system state:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,6 +328,89 @@ def server_available(candidate_base_url):
     return bool(candidate_base_url)
 
 
+def establish_interaction_schema() -> None:
+    """Create the ``interactions`` table the ``db_available`` probe reads.
+
+    ``get_interaction_db_path()`` resolves inside the candidate's own data
+    directory, which holds no schema until something constructs the default
+    ``InteractionStore``. A module that needs the table establishes it here
+    so its outcomes do not depend on which other modules the run selected;
+    ``CREATE TABLE IF NOT EXISTS`` makes the call a no-op against a database
+    that already has it.
+
+    Every failure is swallowed on purpose. The genuine preconditions this
+    cannot satisfy -- a running server holding the write lock, an
+    unresolvable path -- belong to ``db_available``'s probe and must reach
+    ``require_db``'s skip rather than error the fixture that called this.
+    """
+    try:
+        from api.services.interaction_store import InteractionStore, get_interaction_db_path
+
+        InteractionStore(db_path=get_interaction_db_path(), strict=False)
+    except Exception:
+        pass
+
+
+def interaction_db_readable() -> bool:
+    """Report whether the ``interactions`` table can be read right now."""
+    import sqlite3
+    try:
+        from api.services.interaction_store import get_interaction_db_path
+        db_path = get_interaction_db_path()
+        conn = sqlite3.connect(db_path, timeout=1.0)
+        # Try to execute a simple query to check for lock
+        conn.execute("SELECT 1 FROM interactions LIMIT 1")
+        conn.close()
+        return True
+    except sqlite3.OperationalError:
+        return False
+    except Exception:
+        return False
+
+
+def runtime_databases_populated() -> bool:
+    """Report whether the runtime databases hold records to verify.
+
+    Tests that check the correctness of a developer's own indexed data need
+    records, not merely a schema. Each database is opened read-only so a
+    probe never creates or migrates one.
+    """
+    import sqlite3
+    try:
+        from api.services.interaction_store import get_interaction_db_path
+        from api.services.person_entity import PersonEntityStore
+
+        probes = (
+            (get_interaction_db_path(), "interactions"),
+            (str(PersonEntityStore.CRM_DB_PATH), "person_entities"),
+        )
+    except Exception:
+        return False
+    for db_path, table in probes:
+        try:
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
+            try:
+                if conn.execute(f"SELECT 1 FROM {table} LIMIT 1").fetchone() is None:
+                    return False
+            finally:
+                conn.close()
+        except Exception:
+            return False
+    return True
+
+
+@pytest.fixture(scope="module")
+def interaction_schema():
+    """Establish this module's own ``interactions``-table prerequisite.
+
+    Module-scoped so it is set up before the function-scoped probe that
+    reads the table. ``_isolate_integration_persistent_stores`` leaves the
+    default store path alone for every ``require_db`` user, so the path this
+    resolves once per module is the one each of that module's tests sees.
+    """
+    establish_interaction_schema()
+
+
 @pytest.fixture
 def db_available():
     """
@@ -348,26 +431,21 @@ def db_available():
     requested one, so a function-scoped probe here observes the same
     redirected path the test body itself will use.
     """
-    import sqlite3
-    try:
-        from api.services.interaction_store import get_interaction_db_path
-        db_path = get_interaction_db_path()
-        conn = sqlite3.connect(db_path, timeout=1.0)
-        # Try to execute a simple query to check for lock
-        conn.execute("SELECT 1 FROM interactions LIMIT 1")
-        conn.close()
-        return True
-    except sqlite3.OperationalError:
-        return False
-    except Exception:
-        return False
+    return interaction_db_readable()
 
 
 @pytest.fixture(autouse=False)
-def require_db(db_available):
+def require_db(interaction_schema, db_available):
     """Skip test if database is not available (e.g., locked by running server)."""
     if not db_available:
         pytest.skip("Database is locked (server may be running). Stop server to run these tests.")
+
+
+@pytest.fixture
+def require_populated_db(require_db):
+    """Skip test if the runtime databases hold no records to verify."""
+    if not runtime_databases_populated():
+        pytest.skip("Runtime databases hold no records. These tests verify an indexed install.")
 
 
 @pytest.fixture(scope="session")

--- a/tests/narration_baseline.json
+++ b/tests/narration_baseline.json
@@ -3407,10 +3407,6 @@
     "#609: PUT .../facts/{id} for a missing fact is a 404, never a",
     "#682)."
   ],
-  "tests/test_crm_data_integrity.py": [
-    "# (#682: `require_db` only skips a *locked* db, not an empty one, so this",
-    "#682: `require_db` only skips a *locked* db, not an empty one, so this"
-  ],
   "tests/test_data_path_anchoring.py": [
     "Regression tests for #645: seven data-store defaults resolved against the",
     "cwd exactly as before. Credentials path, so covered explicitly per #645."
@@ -3980,10 +3976,8 @@
     "say-so (#584): it parks at `ask` and waits for the operator to choose."
   ],
   "tests/test_p91_data_integrity.py": [
-    "# (#682: `require_db` only skips a *locked* db, not an empty one, so this",
     "# which matched any extracted name sharing that letter (#551) \u2014 were",
-    "#551) \u2014 were",
-    "#682: `require_db` only skips a *locked* db, not an empty one, so this"
+    "#551) \u2014 were"
   ],
   "tests/test_pending_question_ui_browser.py": [
     "# #311: whether the spawned session is still running. The client",

--- a/tests/test_crm_data_integrity.py
+++ b/tests/test_crm_data_integrity.py
@@ -4,8 +4,9 @@ CRM Data Integrity Tests - P9.1
 These tests verify that data flows correctly from sources to CRM display.
 They use real production data and should pass when the CRM is working correctly.
 
-NOTE: These tests require direct database access and will be skipped if
-the server is running (database locked). Stop the server to run these tests.
+NOTE: These tests read a developer's own indexed records directly, so they are
+skipped when the runtime databases are empty and when a running server holds
+the database lock. Stop the server to run these tests.
 
 IMPORTANT: These tests are designed for the developer's production environment.
 When setting up LifeOS for the first time, you'll need to configure TEST_CONTACT_EMAIL
@@ -17,10 +18,12 @@ from api.services.person_entity import get_person_entity_store
 from api.services.interaction_store import get_interaction_store
 
 
-# All classes in this file require database access to real production data
-# (#682: `require_db` only skips a *locked* db, not an empty one, so this
-# also needs `integration` to actually leave the unit/push gate).
-pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("require_db")]
+# All classes in this file verify the correctness of a developer's own indexed
+# data, so they need records rather than a schema: `require_populated_db`
+# establishes the schema, skips a locked database, and skips an empty one.
+# `integration` keeps them out of the unit lane and the push gate, which run
+# against a candidate that has no such records.
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("require_populated_db")]
 
 # Test contact configuration - set these environment variables for data integrity tests
 # These should be a person you communicate with frequently

--- a/tests/test_crm_ui_requirements.py
+++ b/tests/test_crm_ui_requirements.py
@@ -146,12 +146,13 @@ class TestZeroInteractionFilter:
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures("require_db")
+@pytest.mark.usefixtures("require_populated_db")
 class TestStatsMatchDatabase:
     """Tests that PersonEntity stats match the interaction database.
 
-    NOTE: These tests require direct database access and will be skipped if
-    the server is running (database locked). Stop the server to run these tests.
+    NOTE: These tests compare a developer's own indexed records, so they are
+    skipped when the runtime databases are empty or when a running server
+    holds the database lock. Stop the server to run these tests.
     """
 
     def test_top_person_stats_accurate(self):

--- a/tests/test_module_db_prerequisite.py
+++ b/tests/test_module_db_prerequisite.py
@@ -1,0 +1,153 @@
+"""Tests for the database prerequisite a test module establishes for itself.
+
+``require_db`` gates tests that read the runtime interactions database. Its
+probe must report unavailable for the preconditions a test module cannot
+satisfy -- a running server holding the write lock, an unresolvable path --
+and available once the module has created the table it reads.
+"""
+import inspect
+import sqlite3
+
+import pytest
+
+from config.settings import settings
+from tests.conftest import (
+    establish_interaction_schema,
+    interaction_db_readable,
+    runtime_databases_populated,
+)
+
+
+@pytest.fixture
+def candidate_data_dir(tmp_path, monkeypatch):
+    """Point both default runtime database paths at an empty directory."""
+    from api.services.person_entity import PersonEntityStore
+
+    monkeypatch.setattr(settings, "chroma_path", tmp_path / "chromadb")
+    monkeypatch.setattr(PersonEntityStore, "CRM_DB_PATH", tmp_path / "crm.db")
+    return tmp_path
+
+
+@pytest.mark.unit
+class TestInteractionSchemaPrerequisite:
+    """The schema a module needs is established by the module itself."""
+
+    def test_probe_reports_unavailable_before_the_schema_exists(self, candidate_data_dir):
+        assert interaction_db_readable() is False
+
+    def test_probe_reports_available_once_the_module_establishes_it(self, candidate_data_dir):
+        establish_interaction_schema()
+
+        assert interaction_db_readable() is True
+        assert (candidate_data_dir / "interactions.db").exists()
+
+    def test_establishing_an_existing_schema_keeps_its_rows(self, candidate_data_dir):
+        establish_interaction_schema()
+        db_path = str(candidate_data_dir / "interactions.db")
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO interactions (id, person_id, timestamp, source_type, title)"
+                " VALUES ('i-1', 'p-1', '2026-01-01T00:00:00+00:00', 'vault', 'Synthetic note')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        establish_interaction_schema()
+
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("SELECT COUNT(*) FROM interactions").fetchone()[0] == 1
+        finally:
+            conn.close()
+
+    def test_establishing_the_schema_never_raises_on_an_unusable_path(self, tmp_path, monkeypatch):
+        # A file where the data directory must be: the path cannot resolve, so
+        # the probe stays the one place that decides to skip.
+        blocked = tmp_path / "blocked"
+        blocked.write_text("not a directory", encoding="utf-8")
+        monkeypatch.setattr(settings, "chroma_path", blocked / "chromadb")
+
+        establish_interaction_schema()
+
+        assert interaction_db_readable() is False
+
+
+@pytest.mark.unit
+class TestRequireDbRealPrecondition:
+    """The probe still reports unavailable for a genuinely locked database."""
+
+    def test_probe_reports_unavailable_while_a_writer_holds_the_lock(self, candidate_data_dir):
+        establish_interaction_schema()
+        db_path = str(candidate_data_dir / "interactions.db")
+        writer = sqlite3.connect(db_path)
+        try:
+            # Rollback-journal mode makes an exclusive write transaction block
+            # readers, which is how a running server's lock presents.
+            writer.execute("PRAGMA journal_mode=DELETE")
+            writer.execute("BEGIN EXCLUSIVE")
+            writer.execute(
+                "INSERT INTO interactions (id, person_id, timestamp, source_type, title)"
+                " VALUES ('i-2', 'p-2', '2026-01-01T00:00:00+00:00', 'vault', 'Synthetic note')"
+            )
+
+            assert interaction_db_readable() is False
+        finally:
+            writer.rollback()
+            writer.close()
+
+        assert interaction_db_readable() is True
+
+
+@pytest.mark.unit
+class TestPopulatedDatabasePrecondition:
+    """Records, not a schema, are what the data-integrity checks require."""
+
+    def test_an_empty_schema_is_not_populated(self, candidate_data_dir):
+        establish_interaction_schema()
+
+        assert runtime_databases_populated() is False
+
+    def test_a_missing_database_is_not_populated(self, candidate_data_dir):
+        assert runtime_databases_populated() is False
+
+    def test_records_in_both_databases_are_populated(self, candidate_data_dir):
+        from api.services.person_entity import PersonEntity, PersonEntityStore
+
+        crm_path = candidate_data_dir / "crm.db"
+        PersonEntityStore(str(crm_path)).add(
+            PersonEntity(id="p-3", canonical_name="Jordan Sample")
+        )
+
+        establish_interaction_schema()
+        conn = sqlite3.connect(str(candidate_data_dir / "interactions.db"))
+        try:
+            conn.execute(
+                "INSERT INTO interactions (id, person_id, timestamp, source_type, title)"
+                " VALUES ('i-3', 'p-3', '2026-01-01T00:00:00+00:00', 'vault', 'Synthetic note')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        assert runtime_databases_populated() is True
+
+    def test_the_probe_does_not_create_a_database_it_reads(self, candidate_data_dir):
+        assert runtime_databases_populated() is False
+        assert not (candidate_data_dir / "crm.db").exists()
+        assert not (candidate_data_dir / "interactions.db").exists()
+
+
+@pytest.mark.unit
+class TestFixtureComposition:
+    """The gates compose so both preconditions apply to the same test."""
+
+    def test_the_populated_gate_keeps_the_lock_gate_in_its_closure(self):
+        # `_isolate_integration_persistent_stores` recognizes a test that reads
+        # the developer's own databases by finding `require_db` in its fixture
+        # closure, and leaves the default store paths alone for it.
+        from tests import conftest
+
+        assert "require_db" in inspect.signature(conftest.require_populated_db).parameters
+        assert "interaction_schema" in inspect.signature(conftest.require_db).parameters

--- a/tests/test_p91_data_integrity.py
+++ b/tests/test_p91_data_integrity.py
@@ -6,8 +6,9 @@ Each test class corresponds to a requirement in docs/CRM-P9.1-Requirements.md
 
 Tests must pass before P9.1 can be considered complete.
 
-NOTE: These tests require direct database access and will be skipped if
-the server is running (database locked). Stop the server to run these tests.
+NOTE: These tests read a developer's own indexed records directly, so they are
+skipped when the runtime databases are empty and when a running server holds
+the database lock. Stop the server to run these tests.
 """
 import math
 import os
@@ -20,10 +21,12 @@ from api.services.person_entity import get_person_entity_store
 from api.services.interaction_store import get_interaction_db_path
 
 
-# All classes in this file require database access to real production data
-# (#682: `require_db` only skips a *locked* db, not an empty one, so this
-# also needs `integration` to actually leave the unit/push gate).
-pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("require_db")]
+# All classes in this file verify the correctness of a developer's own indexed
+# data, so they need records rather than a schema: `require_populated_db`
+# establishes the schema, skips a locked database, and skips an empty one.
+# `integration` keeps them out of the unit lane and the push gate, which run
+# against a candidate that has no such records.
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("require_populated_db")]
 
 
 class TestR1CleanDatabase:


### PR DESCRIPTION
## TL;DR
A test file that needs a database table creates that table itself instead of
waiting for some unrelated file in the same run to create it as a side effect.
Selecting one file therefore reports the same results as running the whole
suite, which is what lets the merge gate be split into parts. Tests that need a
database holding real records, not just an empty one, state that requirement
directly, so they skip for that reason rather than by accident.

Closes #1068

## Design
One gate covered two different preconditions: that the table exists, and that
no running server holds the database lock. Only the second is a genuine skip
reason, because a test file can create its own table and creating it is
idempotent. The gate creates the table before probing, so the probe reports the
lock condition alone.

Separating the two exposes a third precondition that three files actually rely
on: a developer's own indexed records. Those files check the correctness of
real data, so an empty schema is not enough for them, and synthesizing records
is not an option in this repository. They declare that precondition directly,
which makes them skip for the same reason regardless of which other files ran
alongside them.

## Implementation Notes
`tests/conftest.py` holds the change. `require_db` takes a module-scoped
`interaction_schema` dependency that constructs the default `InteractionStore`;
`db_available`'s probe body sits in a module-level `interaction_db_readable`
so tests can exercise it directly. `require_populated_db` layers a records
check on `require_db`, and keeps `require_db` in the fixture closure that
`_isolate_integration_persistent_stores` reads.

`tests/test_p91_data_integrity.py`, `tests/test_crm_data_integrity.py`, and
`TestStatsMatchDatabase` in `tests/test_crm_ui_requirements.py` use
`require_populated_db`. `tests/test_briefings_service.py` needs no edit,
because its `require_db` declaration carries the schema with it.
`tests/test_module_db_prerequisite.py` covers the helpers directly.

## Test evidence

### Automated tests

`tests/test_module_db_prerequisite.py` — 11 passed.

Every `require_db` and `require_populated_db` module, selected alone in an
isolated data directory:

| Module | Alone, before | Alone, after | Same four modules in one run, after |
| --- | --- | --- | --- |
| `tests/test_briefings_service.py` | 2 passed, 7 skipped | 9 passed | 9 passed |
| `tests/test_p91_data_integrity.py` | 17 skipped | 17 skipped | 17 skipped |
| `tests/test_crm_data_integrity.py` | 13 skipped | 13 skipped | 13 skipped |
| `tests/test_crm_ui_requirements.py` | 10 passed, 2 skipped | 10 passed, 2 skipped | 10 passed, 2 skipped |

The four modules run together report `19 passed, 32 skipped`, which is exactly
the sum of their individual runs.

### Manual verification

**1. The `fast-unit` lane, unpartitioned and in four module-scope parts, over
one candidate (`3265a66a885f5736a273e25f`).**

```
$ scripts/verify_candidate.py local --source . --lanes fast-unit --workers 2 \
    --lane-log-dir <dir>
{"candidate_id": "3265a66a885f5736a273e25f", "lane_selected_counts": {"fast-unit": 8332},
 "lane_totals": {"fast-unit": 8332}, "result": "success", "reused": false}

$ scripts/verify_candidate.py local --source . --lanes fast-unit --workers 2 \
    --part-index N --part-count 4 --lane-log-dir <dir>     # N = 0..3
part 0: selected 2274 of 8332, result success, reused false
part 1: selected 2055 of 8332, result success, reused false
part 2: selected 2104 of 8332, result success, reused false
part 3: selected 1899 of 8332, result success, reused false
```

Skip counts taken from each run's `fast-unit.json` lane-execution receipt:

| Run | Selected | Skipped |
| --- | --- | --- |
| Unpartitioned | 8332 | 1 |
| Part 0 | 2274 | 0 |
| Part 1 | 2055 | 0 |
| Part 2 | 2104 | 1 |
| Part 3 | 1899 | 0 |
| Four parts, total | 8332 | 1 |

The one skip in each column is
`tests/test_fixtures_no_personal_data.py::test_no_fixture_contains_a_real_sensitive_value`,
the privacy audit's recorded not-applicable case. No other test in either
topology reports anything but `passed`.

**2. The lock skip still fires.** A writer holds an exclusive transaction on the
worktree's `interactions` database while the module runs:

```
$ python hold_lock.py data/interactions.db 60 &   # BEGIN EXCLUSIVE, rollback journal
locked
$ python -m pytest tests/test_briefings_service.py -q -rs
tests/test_briefings_service.py ..sssssss
SKIPPED [1] tests/test_briefings_service.py:144: Database is locked (server may be running). Stop server to run these tests.
... (7 skips)
2 passed, 7 skipped in 13.65s
```

**3. The records gate is not a permanent disable.** With one synthetic person
and one synthetic interaction seeded into the runtime databases, the three
data-integrity modules execute rather than skip:

```
$ python -m pytest tests/test_p91_data_integrity.py tests/test_crm_data_integrity.py \
    tests/test_crm_ui_requirements.py -q
8 failed, 20 passed, 14 skipped in 5.77s
```

The failures are the assertions that need a developer's real corpus rather than
one synthetic row; the point is that the tests run.

## Review focus
- Whether `require_populated_db`'s precondition — a row in `interactions` and a
  row in `person_entities` — is the right one for the three data-integrity
  modules, in `tests/conftest.py`.
- Whether `interaction_schema` belongs on `require_db` in `tests/conftest.py`
  rather than declared separately by each module that needs it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
