### PR TITLE
perf: run a verified candidate as four concurrent parts

### DIFF
--- a/.github/workflows/candidate-verification.yml
+++ b/.github/workflows/candidate-verification.yml
@@ -53,12 +53,25 @@ jobs:
   execute-candidate:
     name: candidate-execution
     runs-on: ubuntu-latest
-    # Both retained lanes run in this one job, at the runner's full width
-    # with the capacity headroom the step below establishes. The ceiling
-    # exists to fail a genuinely stuck job, so it sits above the slowest
-    # healthy run observed with enough margin for dependency and Chromium
-    # setup, rather than near the middle of the range.
-    timeout-minutes: 45
+    strategy:
+      # A failing part must never cancel its siblings: each part's own
+      # result feeds the same aggregate below, so cancelling early would
+      # hide which other parts would also have failed without changing
+      # the published conclusion.
+      fail-fast: false
+      matrix:
+        # Whole module scopes are assigned across these parts by recorded
+        # duration. `strategy.job-total` below derives the part count from
+        # this list rather than restating it, so the two cannot disagree
+        # and leave a part's tests unrun while every other part reports
+        # success.
+        part: [0, 1, 2, 3]
+    # Each part runs its own share of the retained lanes at the runner's
+    # full width, with the capacity headroom the step below establishes.
+    # The ceiling exists to fail a genuinely stuck part, so it sits above
+    # the slowest healthy part observed with enough margin for dependency
+    # and Chromium setup, rather than near the middle of the range.
+    timeout-minutes: 25
     permissions:
       contents: read
     env:
@@ -158,6 +171,8 @@ jobs:
             --workers "$WORKERS" \
             --capacity-max-run-workers "$WORKERS" \
             --lane-log-dir "$RUNNER_TEMP/lifeos-lane-logs" \
+            --part-index "${{ matrix.part }}" \
+            --part-count "${{ strategy.job-total }}" \
             --parallel-browser-free
 
       # The step above prints only its summary JSON; pytest's own output goes
@@ -170,7 +185,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: lane-logs-${{ env.CANDIDATE_SHA }}
+          name: lane-logs-${{ env.CANDIDATE_SHA }}-part${{ matrix.part }}
           path: ${{ runner.temp }}/lifeos-lane-logs
           if-no-files-found: warn
           retention-days: 14

--- a/tests/test_candidate_ci_boundary.py
+++ b/tests/test_candidate_ci_boundary.py
@@ -67,6 +67,28 @@ def test_candidate_workflow_separates_untrusted_execution_from_status_publisher(
 
 
 @pytest.mark.unit
+def test_partitioned_execution_derives_its_part_count_from_the_matrix():
+    """Every part's tests run, and one failing part cannot hide the others.
+
+    The part count is read from the matrix rather than restated beside it:
+    a separately declared count that drifts below the matrix length leaves
+    a part's tests unselected while every part that did run reports
+    success, which is exactly the coverage loss the lane partition exists
+    to avoid. Deriving it makes the two impossible to disagree.
+    """
+    workflow = (ROOT / ".github/workflows/candidate-verification.yml").read_text()
+    assert '--part-index "${{ matrix.part }}"' in workflow
+    assert '--part-count "${{ strategy.job-total }}"' in workflow
+    # A literal count beside the matrix is the drift this guards against.
+    assert "PART_COUNT" not in workflow
+    # A failing part must not cancel its siblings, so the aggregate reports
+    # every part that would have failed rather than only the first.
+    assert "fail-fast: false" in workflow
+    # Each part uploads its own lane log; a shared name collides.
+    assert "lane-logs-${{ env.CANDIDATE_SHA }}-part${{ matrix.part }}" in workflow
+
+
+@pytest.mark.unit
 def test_candidate_workflow_pins_actions_and_proves_cpu_wheel_identity():
     workflow = (ROOT / ".github/workflows/candidate-verification.yml").read_text()
     pinned_actions = {


### PR DESCRIPTION
Closes #1030.

Enables the partition that #1069 built, now that #1068 has made the lane's coverage partition-stable.

## Equivalence, measured on the tree this runs against

| run | selected | passed | skipped | wall |
|---|---|---|---|---|
| unpartitioned | 8332 / 8332 | 8331 | 1 | 16m36s |
| part 0 | 2274 | 2274 | 0 | 4m50s |
| part 1 | 2055 | 2055 | 0 | 4m04s |
| part 2 | 2104 | 2103 | 1 | 4m08s |
| part 3 | 1899 | 1899 | 0 | 4m19s |
| **parts summed** | **8332** | **8331** | **1** | **4m50s** |

Selected counts sum exactly to the lane total, no part overlaps, and the total skip count is identical — the single skip is the privacy audit's recorded not-applicable case, in the part owning that module. Part 1 is the part that previously failed with five extra skips; it now reports none.

## The part count is derived, not restated

`--part-count` reads `${{ strategy.job-total }}` rather than a separate constant. A count declared beside the matrix can drift below the matrix length, which would leave a part's tests unselected while every part that did run reports success — precisely the silent coverage loss this partition exists to prevent. Deriving it makes the two impossible to disagree, and `tests/test_candidate_ci_boundary.py` pins that (mutation-checked: restating the count as a literal fails the test).

`fail-fast: false` so a failing part never cancels its siblings — every part's result feeds the same aggregate, and cancelling would hide which others would also have failed. Each part uploads its own lane log, since a shared artifact name collides.

The per-part ceiling is 25 minutes against a slowest observed part of 4m50s plus dependency and Chromium setup.

## Landing

This change cannot verify itself: both triggers resolve the workflow from the base branch, so this PR's own gate run executes the existing single-job topology. The first real exercise is the run after it merges. On that run, watch that all four parts are present and green, that the four `lane_selected_counts` sum to `lane_totals`, that only the part owning the privacy audit reports a skip, and that a failed or cancelled part publishes `failure`.

Unchanged: the verifier's completeness rule, the partition unit, the trust boundary, the check name, the issuing App, and the publisher's ordering. Every part keeps its provenance assertions and `contents: read`, and declares no `environment:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)